### PR TITLE
Added catkin-make dependancy: build-essentials

### DIFF
--- a/ros/indigo/indigo-ros-core/Dockerfile
+++ b/ros/indigo/indigo-ros-core/Dockerfile
@@ -20,6 +20,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     python-rosdep \
     python-rosinstall \
     python-vcstools \
+    build-essential \
     && rm -rf /var/lib/apt/lists/*
 
 # bootstrap rosdep


### PR DESCRIPTION
`catkin_make` fails on a basic catkin workspace unless `build-essentials` is installed.
