### PR TITLE
[wip] add Indigo Saucy docker image.

### DIFF
--- a/ros/indigo/indigo-saucy-ros-core/Dockerfile
+++ b/ros/indigo/indigo-saucy-ros-core/Dockerfile
@@ -1,0 +1,46 @@
+# This is NOT an auto generated Dockerfile. Instead, copy and modify osrf/docker_images/ros/indigo/indigo-ros-core/Dockerfile.
+
+FROM ubuntu:saucy
+MAINTAINER Tully Foote tfoote+buildfarm@osrfoundation.org
+
+# setup environment
+RUN locale-gen en_US.UTF-8
+ENV LANG en_US.UTF-8
+
+# setup keys
+RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
+
+# setup sources.list
+RUN echo "deb http://packages.ros.org/ros/ubuntu saucy main" > /etc/apt/sources.list.d/ros-latest.list
+
+### BEGIN Ubuntu old-release hack ###
+# Because apt-get update for Saucy fails due to missing folder in http://archive.ubuntu.com/ubuntu, disable /etc/apt/sources.list
+RUN mv /etc/apt/sources.list /etc/apt/sources.list.bk && touch /etc/apt/sources.list
+ENV SAUCY_DEB_REPOS="deb http://old-releases.ubuntu.com/ubuntu/ saucy main restricted \ndeb-src http://old-releases.ubuntu.com/ubuntu/ saucy main restricted \ndeb http://old-releases.ubuntu.com/ubuntu/ saucy-updates main restricted \ndeb-src http://old-releases.ubuntu.com/ubuntu/ saucy-updates main restricted \ndeb http://old-releases.ubuntu.com/ubuntu/ saucy universe \ndeb-src http://old-releases.ubuntu.com/ubuntu/ saucy universe \ndeb http://old-releases.ubuntu.com/ubuntu/ saucy-updates universe \ndeb-src http://old-releases.ubuntu.com/ubuntu/ saucy-updates universe \ndeb http://old-releases.ubuntu.com/ubuntu/ saucy-security main restricted \ndeb-src http://old-releases.ubuntu.com/ubuntu/ saucy-security main restricted \ndeb http://old-releases.ubuntu.com/ubuntu/ saucy-security universe \ndeb-src http://old-releases.ubuntu.com/ubuntu/ saucy-security universe"
+RUN echo "$SAUCY_DEB_REPOS" > /etc/apt/sources.list
+RUN ls -l /etc/apt/sources.list; more /etc/apt/sources.list
+### END Ubuntu old-release hack ###
+
+# install bootstrap tools
+RUN apt-get update
+RUN apt-get install --no-install-recommends -y \
+    python-rosdep \
+    python-rosinstall \
+    python-vcstools \
+    && rm -rf /var/lib/apt/lists/*
+
+# bootstrap rosdep
+RUN rosdep init \
+    && rosdep update
+
+# install ros packages
+ENV ROS_DISTRO indigo
+RUN apt-get update && apt-get install -y \
+    ros-indigo-ros-core \
+    && rm -rf /var/lib/apt/lists/*
+
+# setup entrypoint
+COPY ./ros_entrypoint.sh /
+
+ENTRYPOINT ["/ros_entrypoint.sh"]
+CMD ["bash"]

--- a/ros/indigo/indigo-saucy-ros-core/ros_entrypoint.sh
+++ b/ros/indigo/indigo-saucy-ros-core/ros_entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+# setup ros environment
+source "/opt/ros/$ROS_DISTRO/setup.bash"
+exec "$@"


### PR DESCRIPTION
<s>**DO NOT MERGE.**</s>

I tried to create Ubuntu `Saucy` image because some Saucy specific issues have risen (e.g. https://github.com/ros-planning/moveit/pull/389). But due to missing Saucy folders in http://archive.ubuntu.com/ubuntu/ I had to give up. The following is the full output on commandline using this PR.

<s>Closing because I won't work on this.</s>

Also, looks like other `Dockerfile` were auto-generated by `create_dockerfiles.py`, which results in the following error on my computer.
```
$ ./create_dockerfiles.py 
Traceback (most recent call last):
  File "./create_dockerfiles.py", line 5, in <module>
    import yaml
ImportError: No module named 'yaml'
$ lsb_release  -a
No LSB modules are available.
Distributor ID: Ubuntu
Description:    Ubuntu 14.04.5 LTS
Release:        14.04
Codename:       trusty
$ python3 --version
Python 3.4.3
```

```
$ docker build -t ros-indigo-saucy-core .
Sending build context to Docker daemon  5.12 kB
Step 1 : FROM ubuntu:saucy
 ---> 7f020f7bf345
Step 2 : MAINTAINER Tully Foote tfoote+buildfarm@osrfoundation.org
 ---> Using cache
 ---> f190cddb9ee6
Step 3 : RUN locale-gen en_US.UTF-8
 ---> Using cache
 ---> 3e44b9e82252
Step 4 : ENV LANG en_US.UTF-8
 ---> Using cache
 ---> 44c69487e03d
Step 5 : RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
 ---> Using cache
 ---> cb555bcafac5
Step 6 : RUN echo "deb http://packages.ros.org/ros/ubuntu saucy main" > /etc/apt/sources.list.d/ros-latest.list
 ---> Using cache
 ---> 1841004ad5c8
Step 7 : RUN mv /etc/apt/sources.list /etc/apt/sources.list.bk
 ---> Running in 58e9d0aa976e
 ---> 291cd97a3f21
Removing intermediate container 58e9d0aa976e
Step 8 : RUN apt-get update
 ---> Running in c41eda7bd404
Get:1 http://packages.ros.org saucy InRelease [4,009 B]
Get:2 http://packages.ros.org saucy/main amd64 Packages [523 kB]
Fetched 527 kB in 0s (1,043 kB/s)
Reading package lists...
 ---> 2d2c82c1b514
Removing intermediate container c41eda7bd404
Step 9 : RUN apt-get install --no-install-recommends -y     python-rosdep     python-rosinstall     python-vcstools     && rm -rf /var/lib/apt/lists/*
 ---> Running in 7d8ea1b631b7
Reading package lists...
Building dependency tree...
Reading state information...
Some packages could not be installed. This may mean that you have
requested an impossible situation or if you are using the unstable
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:

The following packages have unmet dependencies:
 python-rosdep : Depends: python (>= 2.7) but it is not installable
                 Depends: python (< 2.8) but it is not installable
                 Depends: python (>= 2.7.1-0ubuntu2) but it is not installable
                 Depends: python-catkin-pkg but it is not going to be installed
                 Depends: python-rospkg (>= 1.0.37) but it is not going to be installed
                 Depends: python-rosdistro (>= 0.4.0) but it is not going to be installed
                 Depends: python-yaml but it is not installable
                 Depends: ca-certificates but it is not installable
 python-rosinstall : Depends: python (>= 2.7) but it is not installable
                     Depends: python (< 2.8) but it is not installable
                     Depends: python (>= 2.7.1-0ubuntu2) but it is not installable
                     Depends: python-yaml but it is not installable
                     Depends: python-rosdistro (>= 0.3.0) but it is not going to be installed
                     Depends: python-catkin-pkg but it is not going to be installed
                     Depends: python-wstool (>= 0.1.12) but it is not going to be installed
                     Depends: subversion but it is not installable
                     Depends: mercurial but it is not installable
                     Depends: git-core but it is not installable
                     Depends: bzr but it is not installable
 python-vcstools : Depends: python (>= 2.7) but it is not installable
                   Depends: python (< 2.8) but it is not installable
                   Depends: python-yaml but it is not installable
                   Depends: python-dateutil but it is not installable
                   Depends: subversion but it is not installable
                   Depends: mercurial but it is not installable
                   Depends: git-core but it is not installable
                   Depends: bzr but it is not installable
E: Unable to correct problems, you have held broken packages.
The command '/bin/sh -c apt-get install --no-install-recommends -y     python-rosdep     python-rosinstall     python-vcstools     && rm -rf /var/lib/apt/lists/*' returned a non-zero code: 100
```