### PR TITLE
add lunar Dockerfiles

### DIFF
--- a/ros/indigo/images.yaml.em
+++ b/ros/indigo/images.yaml.em
@@ -36,7 +36,7 @@ images:
         ros_packages:
             - perception
     @(rosdistro_name)-desktop:
-        base_image: @(user_name):@(rosdistro_name)-ros-base
+        base_image: @(user_name):@(rosdistro_name)-robot
         maintainer_name: @(maintainer_name)
         template_name: docker_images/create_ros_image.Dockerfile.em
         template_packages:

--- a/ros/indigo/indigo-desktop-full/Dockerfile
+++ b/ros/indigo/indigo-desktop-full/Dockerfile
@@ -5,6 +5,6 @@ FROM osrf/ros:indigo-desktop
 
 # install ros packages
 RUN apt-get update && apt-get install -y \
-    ros-indigo-desktop-full=1.1.4-0* \
+    ros-indigo-desktop-full=1.1.5-0* \
     && rm -rf /var/lib/apt/lists/*
 

--- a/ros/indigo/indigo-desktop-full/Dockerfile
+++ b/ros/indigo/indigo-desktop-full/Dockerfile
@@ -1,6 +1,6 @@
 # This is an auto generated Dockerfile for ros:indigo-desktop-full
 # generated from templates/docker_images/create_ros_image.Dockerfile.em
-# generated on 2017-01-27 02:33:52 +0000
+# generated on 2017-05-23 06:51:52 +0000
 FROM osrf/ros:indigo-desktop
 
 # install ros packages

--- a/ros/indigo/indigo-desktop/Dockerfile
+++ b/ros/indigo/indigo-desktop/Dockerfile
@@ -5,6 +5,6 @@ FROM ros:indigo-ros-base
 
 # install ros packages
 RUN apt-get update && apt-get install -y \
-    ros-indigo-desktop=1.1.4-0* \
+    ros-indigo-desktop=1.1.5-0* \
     && rm -rf /var/lib/apt/lists/*
 

--- a/ros/indigo/indigo-desktop/Dockerfile
+++ b/ros/indigo/indigo-desktop/Dockerfile
@@ -1,7 +1,7 @@
 # This is an auto generated Dockerfile for ros:indigo-desktop
 # generated from templates/docker_images/create_ros_image.Dockerfile.em
-# generated on 2017-01-27 02:33:52 +0000
-FROM ros:indigo-ros-base
+# generated on 2017-05-23 06:51:52 +0000
+FROM ros:indigo-robot
 
 # install ros packages
 RUN apt-get update && apt-get install -y \

--- a/ros/indigo/indigo-perception/Dockerfile
+++ b/ros/indigo/indigo-perception/Dockerfile
@@ -5,6 +5,6 @@ FROM ros:indigo-ros-base
 
 # install ros packages
 RUN apt-get update && apt-get install -y \
-    ros-indigo-perception=1.1.4-0* \
+    ros-indigo-perception=1.1.5-0* \
     && rm -rf /var/lib/apt/lists/*
 

--- a/ros/indigo/indigo-perception/Dockerfile
+++ b/ros/indigo/indigo-perception/Dockerfile
@@ -1,6 +1,6 @@
 # This is an auto generated Dockerfile for ros:indigo-perception
 # generated from templates/docker_images/create_ros_image.Dockerfile.em
-# generated on 2017-01-27 02:33:52 +0000
+# generated on 2017-05-23 06:51:52 +0000
 FROM ros:indigo-ros-base
 
 # install ros packages

--- a/ros/indigo/indigo-robot/Dockerfile
+++ b/ros/indigo/indigo-robot/Dockerfile
@@ -5,6 +5,6 @@ FROM ros:indigo-ros-base
 
 # install ros packages
 RUN apt-get update && apt-get install -y \
-    ros-indigo-robot=1.1.4-0* \
+    ros-indigo-robot=1.1.5-0* \
     && rm -rf /var/lib/apt/lists/*
 

--- a/ros/indigo/indigo-robot/Dockerfile
+++ b/ros/indigo/indigo-robot/Dockerfile
@@ -1,6 +1,6 @@
 # This is an auto generated Dockerfile for ros:indigo-robot
 # generated from templates/docker_images/create_ros_image.Dockerfile.em
-# generated on 2017-01-27 02:33:52 +0000
+# generated on 2017-05-23 06:51:52 +0000
 FROM ros:indigo-ros-base
 
 # install ros packages

--- a/ros/indigo/indigo-ros-base/Dockerfile
+++ b/ros/indigo/indigo-ros-base/Dockerfile
@@ -5,6 +5,6 @@ FROM ros:indigo-ros-core
 
 # install ros packages
 RUN apt-get update && apt-get install -y \
-    ros-indigo-ros-base=1.1.4-0* \
+    ros-indigo-ros-base=1.1.5-0* \
     && rm -rf /var/lib/apt/lists/*
 

--- a/ros/indigo/indigo-ros-base/Dockerfile
+++ b/ros/indigo/indigo-ros-base/Dockerfile
@@ -1,6 +1,6 @@
 # This is an auto generated Dockerfile for ros:indigo-ros-base
 # generated from templates/docker_images/create_ros_image.Dockerfile.em
-# generated on 2017-01-27 02:33:52 +0000
+# generated on 2017-05-23 06:51:52 +0000
 FROM ros:indigo-ros-core
 
 # install ros packages

--- a/ros/indigo/indigo-ros-core/Dockerfile
+++ b/ros/indigo/indigo-ros-core/Dockerfile
@@ -1,6 +1,6 @@
 # This is an auto generated Dockerfile for ros:indigo-ros-core
 # generated from templates/docker_images/create_ros_core_image.Dockerfile.em
-# generated on 2017-01-27 02:33:52 +0000
+# generated on 2017-05-23 06:51:52 +0000
 FROM ubuntu:trusty
 
 

--- a/ros/indigo/indigo-ros-core/Dockerfile
+++ b/ros/indigo/indigo-ros-core/Dockerfile
@@ -3,9 +3,6 @@
 # generated on 2017-01-27 02:33:52 +0000
 FROM ubuntu:trusty
 
-# setup environment
-RUN locale-gen en_US.UTF-8
-ENV LANG en_US.UTF-8
 
 # setup keys
 RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
@@ -15,11 +12,15 @@ RUN echo "deb http://packages.ros.org/ros/ubuntu trusty main" > /etc/apt/sources
 
 # install bootstrap tools
 RUN apt-get update && apt-get install --no-install-recommends -y \
+    locales \
     python-rosdep \
     python-rosinstall \
     python-vcstools \
     && rm -rf /var/lib/apt/lists/*
 
+# setup environment
+RUN locale-gen en_US.UTF-8
+ENV LANG en_US.UTF-8
 # bootstrap rosdep
 RUN rosdep init \
     && rosdep update
@@ -27,7 +28,7 @@ RUN rosdep init \
 # install ros packages
 ENV ROS_DISTRO indigo
 RUN apt-get update && apt-get install -y \
-    ros-indigo-ros-core=1.1.4-0* \
+    ros-indigo-ros-core=1.1.5-0* \
     && rm -rf /var/lib/apt/lists/*
 
 # setup entrypoint

--- a/ros/jade/images.yaml.em
+++ b/ros/jade/images.yaml.em
@@ -36,7 +36,7 @@ images:
         ros_packages:
             - perception
     @(rosdistro_name)-desktop:
-        base_image: @(user_name):@(rosdistro_name)-ros-base
+        base_image: @(user_name):@(rosdistro_name)-robot
         maintainer_name: @(maintainer_name)
         template_name: docker_images/create_ros_image.Dockerfile.em
         template_packages:

--- a/ros/jade/jade-desktop-full/Dockerfile
+++ b/ros/jade/jade-desktop-full/Dockerfile
@@ -1,6 +1,6 @@
 # This is an auto generated Dockerfile for ros:jade-desktop-full
 # generated from templates/docker_images/create_ros_image.Dockerfile.em
-# generated on 2017-01-27 02:33:58 +0000
+# generated on 2017-05-23 06:51:59 +0000
 FROM osrf/ros:jade-desktop
 
 # install ros packages

--- a/ros/jade/jade-desktop/Dockerfile
+++ b/ros/jade/jade-desktop/Dockerfile
@@ -1,7 +1,7 @@
 # This is an auto generated Dockerfile for ros:jade-desktop
 # generated from templates/docker_images/create_ros_image.Dockerfile.em
-# generated on 2017-01-27 02:33:58 +0000
-FROM ros:jade-ros-base
+# generated on 2017-05-23 06:51:59 +0000
+FROM ros:jade-robot
 
 # install ros packages
 RUN apt-get update && apt-get install -y \

--- a/ros/jade/jade-perception/Dockerfile
+++ b/ros/jade/jade-perception/Dockerfile
@@ -1,6 +1,6 @@
 # This is an auto generated Dockerfile for ros:jade-perception
 # generated from templates/docker_images/create_ros_image.Dockerfile.em
-# generated on 2017-01-27 02:33:58 +0000
+# generated on 2017-05-23 06:51:59 +0000
 FROM ros:jade-ros-base
 
 # install ros packages

--- a/ros/jade/jade-robot/Dockerfile
+++ b/ros/jade/jade-robot/Dockerfile
@@ -1,6 +1,6 @@
 # This is an auto generated Dockerfile for ros:jade-robot
 # generated from templates/docker_images/create_ros_image.Dockerfile.em
-# generated on 2017-01-27 02:33:58 +0000
+# generated on 2017-05-23 06:51:59 +0000
 FROM ros:jade-ros-base
 
 # install ros packages

--- a/ros/jade/jade-ros-base/Dockerfile
+++ b/ros/jade/jade-ros-base/Dockerfile
@@ -1,6 +1,6 @@
 # This is an auto generated Dockerfile for ros:jade-ros-base
 # generated from templates/docker_images/create_ros_image.Dockerfile.em
-# generated on 2017-01-27 02:33:58 +0000
+# generated on 2017-05-23 06:51:59 +0000
 FROM ros:jade-ros-core
 
 # install ros packages

--- a/ros/jade/jade-ros-core/Dockerfile
+++ b/ros/jade/jade-ros-core/Dockerfile
@@ -3,9 +3,6 @@
 # generated on 2017-01-27 02:33:58 +0000
 FROM ubuntu:trusty
 
-# setup environment
-RUN locale-gen en_US.UTF-8
-ENV LANG en_US.UTF-8
 
 # setup keys
 RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
@@ -15,11 +12,15 @@ RUN echo "deb http://packages.ros.org/ros/ubuntu trusty main" > /etc/apt/sources
 
 # install bootstrap tools
 RUN apt-get update && apt-get install --no-install-recommends -y \
+    locales \
     python-rosdep \
     python-rosinstall \
     python-vcstools \
     && rm -rf /var/lib/apt/lists/*
 
+# setup environment
+RUN locale-gen en_US.UTF-8
+ENV LANG en_US.UTF-8
 # bootstrap rosdep
 RUN rosdep init \
     && rosdep update

--- a/ros/jade/jade-ros-core/Dockerfile
+++ b/ros/jade/jade-ros-core/Dockerfile
@@ -1,6 +1,6 @@
 # This is an auto generated Dockerfile for ros:jade-ros-core
 # generated from templates/docker_images/create_ros_core_image.Dockerfile.em
-# generated on 2017-01-27 02:33:58 +0000
+# generated on 2017-05-23 06:51:59 +0000
 FROM ubuntu:trusty
 
 

--- a/ros/kinetic/images.yaml.em
+++ b/ros/kinetic/images.yaml.em
@@ -36,7 +36,7 @@ images:
         ros_packages:
             - perception
     @(rosdistro_name)-desktop:
-        base_image: @(user_name):@(rosdistro_name)-ros-base
+        base_image: @(user_name):@(rosdistro_name)-robot
         maintainer_name: @(maintainer_name)
         template_name: docker_images/create_ros_image.Dockerfile.em
         template_packages:

--- a/ros/kinetic/kinetic-desktop-full/Dockerfile
+++ b/ros/kinetic/kinetic-desktop-full/Dockerfile
@@ -1,6 +1,6 @@
 # This is an auto generated Dockerfile for ros:kinetic-desktop-full
 # generated from templates/docker_images/create_ros_image.Dockerfile.em
-# generated on 2017-01-27 02:34:03 +0000
+# generated on 2017-05-23 06:52:05 +0000
 FROM osrf/ros:kinetic-desktop
 
 # install ros packages

--- a/ros/kinetic/kinetic-desktop/Dockerfile
+++ b/ros/kinetic/kinetic-desktop/Dockerfile
@@ -1,7 +1,7 @@
 # This is an auto generated Dockerfile for ros:kinetic-desktop
 # generated from templates/docker_images/create_ros_image.Dockerfile.em
-# generated on 2017-01-27 02:34:03 +0000
-FROM ros:kinetic-ros-base
+# generated on 2017-05-23 06:52:05 +0000
+FROM ros:kinetic-robot
 
 # install ros packages
 RUN apt-get update && apt-get install -y \

--- a/ros/kinetic/kinetic-perception/Dockerfile
+++ b/ros/kinetic/kinetic-perception/Dockerfile
@@ -1,6 +1,6 @@
 # This is an auto generated Dockerfile for ros:kinetic-perception
 # generated from templates/docker_images/create_ros_image.Dockerfile.em
-# generated on 2017-01-27 02:34:03 +0000
+# generated on 2017-05-23 06:52:05 +0000
 FROM ros:kinetic-ros-base
 
 # install ros packages

--- a/ros/kinetic/kinetic-robot/Dockerfile
+++ b/ros/kinetic/kinetic-robot/Dockerfile
@@ -1,6 +1,6 @@
 # This is an auto generated Dockerfile for ros:kinetic-robot
 # generated from templates/docker_images/create_ros_image.Dockerfile.em
-# generated on 2017-01-27 02:34:03 +0000
+# generated on 2017-05-23 06:52:05 +0000
 FROM ros:kinetic-ros-base
 
 # install ros packages

--- a/ros/kinetic/kinetic-ros-base/Dockerfile
+++ b/ros/kinetic/kinetic-ros-base/Dockerfile
@@ -1,6 +1,6 @@
 # This is an auto generated Dockerfile for ros:kinetic-ros-base
 # generated from templates/docker_images/create_ros_image.Dockerfile.em
-# generated on 2017-01-27 02:34:03 +0000
+# generated on 2017-05-23 06:52:05 +0000
 FROM ros:kinetic-ros-core
 
 # install ros packages

--- a/ros/kinetic/kinetic-ros-core/Dockerfile
+++ b/ros/kinetic/kinetic-ros-core/Dockerfile
@@ -1,6 +1,6 @@
 # This is an auto generated Dockerfile for ros:kinetic-ros-core
 # generated from templates/docker_images/create_ros_core_image.Dockerfile.em
-# generated on 2017-01-27 02:34:03 +0000
+# generated on 2017-05-23 06:52:05 +0000
 FROM ubuntu:xenial
 
 

--- a/ros/kinetic/kinetic-ros-core/Dockerfile
+++ b/ros/kinetic/kinetic-ros-core/Dockerfile
@@ -3,9 +3,6 @@
 # generated on 2017-01-27 02:34:03 +0000
 FROM ubuntu:xenial
 
-# setup environment
-RUN locale-gen en_US.UTF-8
-ENV LANG en_US.UTF-8
 
 # setup keys
 RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
@@ -15,11 +12,15 @@ RUN echo "deb http://packages.ros.org/ros/ubuntu xenial main" > /etc/apt/sources
 
 # install bootstrap tools
 RUN apt-get update && apt-get install --no-install-recommends -y \
+    locales \
     python-rosdep \
     python-rosinstall \
     python-vcstools \
     && rm -rf /var/lib/apt/lists/*
 
+# setup environment
+RUN locale-gen en_US.UTF-8
+ENV LANG en_US.UTF-8
 # bootstrap rosdep
 RUN rosdep init \
     && rosdep update

--- a/ros/lunar/Makefile
+++ b/ros/lunar/Makefile
@@ -1,0 +1,34 @@
+all: help
+
+help:
+	@echo ""
+	@echo "-- Help Menu"
+	@echo ""
+	@echo "   1. make build            - build all images"
+	@echo "   2. make pull             - pull all images"
+	@echo "   3. make clean            - remove all images"
+	@echo ""
+
+build:
+	@docker build --tag=ros:lunar-ros-core          lunar-ros-core/.
+	@docker build --tag=ros:lunar-ros-base          lunar-ros-base/.
+	@docker build --tag=ros:lunar-robot             lunar-robot/.
+	@docker build --tag=ros:lunar-perception        lunar-perception/.
+	@docker build --tag=osrf/ros:lunar-desktop      lunar-desktop/.
+	@docker build --tag=osrf/ros:lunar-desktop-full lunar-desktop-full/.
+
+pull:
+	@docker pull ros:lunar-ros-core
+	@docker pull ros:lunar-ros-base
+	@docker pull ros:lunar-robot
+	@docker pull ros:lunar-perception
+	@docker pull osrf/ros:lunar-desktop
+	@docker pull osrf/ros:lunar-desktop-full
+
+clean:
+	@docker rmi -f ros:lunar-ros-core
+	@docker rmi -f ros:lunar-ros-base
+	@docker rmi -f ros:lunar-robot
+	@docker rmi -f ros:lunar-perception
+	@docker rmi -f osrf/ros:lunar-desktop
+	@docker rmi -f osrf/ros:lunar-desktop-full

--- a/ros/lunar/images.yaml.em
+++ b/ros/lunar/images.yaml.em
@@ -1,0 +1,53 @@
+%YAML 1.1
+# ROS Dockerfile database
+---
+images:
+    @(rosdistro_name)-ros-core:
+        base_image: @(os_name):@(os_code_name)
+        maintainer_name: @(maintainer_name)
+        template_name: docker_images/create_ros_core_image.Dockerfile.em
+        entrypoint_name: docker_images/ros_entrypoint.sh
+        template_packages:
+            - ros_docker_images
+        ros_packages:
+            - ros-core
+    @(rosdistro_name)-ros-base:
+        base_image: @(user_name):@(rosdistro_name)-ros-core
+        maintainer_name: @(maintainer_name)
+        template_name: docker_images/create_ros_image.Dockerfile.em
+        template_packages:
+            - ros_docker_images
+        ros_packages:
+            - ros-base
+    @(rosdistro_name)-robot:
+        base_image: @(user_name):@(rosdistro_name)-ros-base
+        maintainer_name: @(maintainer_name)
+        template_name: docker_images/create_ros_image.Dockerfile.em
+        template_packages:
+            - ros_docker_images
+        ros_packages:
+            - robot
+    @(rosdistro_name)-perception:
+        base_image: @(user_name):@(rosdistro_name)-ros-base
+        maintainer_name: @(maintainer_name)
+        template_name: docker_images/create_ros_image.Dockerfile.em
+        template_packages:
+            - ros_docker_images
+        ros_packages:
+            - perception
+    @(rosdistro_name)-desktop:
+        base_image: @(user_name):@(rosdistro_name)-ros-base
+        maintainer_name: @(maintainer_name)
+        template_name: docker_images/create_ros_image.Dockerfile.em
+        template_packages:
+            - ros_docker_images
+        ros_packages:
+            - desktop
+    @(rosdistro_name)-desktop-full:
+        base_image: osrf/@(user_name):@(rosdistro_name)-desktop
+        maintainer_name: @(maintainer_name)
+        template_name: docker_images/create_ros_image.Dockerfile.em
+        template_packages:
+            - ros_docker_images
+        ros_packages:
+            - desktop-full

--- a/ros/lunar/images.yaml.em
+++ b/ros/lunar/images.yaml.em
@@ -36,7 +36,7 @@ images:
         ros_packages:
             - perception
     @(rosdistro_name)-desktop:
-        base_image: @(user_name):@(rosdistro_name)-ros-base
+        base_image: @(user_name):@(rosdistro_name)-robot
         maintainer_name: @(maintainer_name)
         template_name: docker_images/create_ros_image.Dockerfile.em
         template_packages:

--- a/ros/lunar/lunar-desktop-full/Dockerfile
+++ b/ros/lunar/lunar-desktop-full/Dockerfile
@@ -1,6 +1,6 @@
 # This is an auto generated Dockerfile for ros:lunar-desktop-full
 # generated from templates/docker_images/create_ros_image.Dockerfile.em
-# generated on 2017-05-22 15:18:23 +0000
+# generated on 2017-05-23 06:52:09 +0000
 FROM osrf/ros:lunar-desktop
 
 # install ros packages

--- a/ros/lunar/lunar-desktop-full/Dockerfile
+++ b/ros/lunar/lunar-desktop-full/Dockerfile
@@ -1,0 +1,10 @@
+# This is an auto generated Dockerfile for ros:lunar-desktop-full
+# generated from templates/docker_images/create_ros_image.Dockerfile.em
+# generated on 2017-05-11 15:17:38 +0000
+FROM osrf/ros:lunar-desktop
+
+# install ros packages
+RUN apt-get update && apt-get install -y \
+    ros-lunar-desktop-full=1.3.1-0* \
+    && rm -rf /var/lib/apt/lists/*
+

--- a/ros/lunar/lunar-desktop-full/Dockerfile
+++ b/ros/lunar/lunar-desktop-full/Dockerfile
@@ -1,6 +1,6 @@
 # This is an auto generated Dockerfile for ros:lunar-desktop-full
 # generated from templates/docker_images/create_ros_image.Dockerfile.em
-# generated on 2017-05-11 15:17:38 +0000
+# generated on 2017-05-22 15:18:23 +0000
 FROM osrf/ros:lunar-desktop
 
 # install ros packages

--- a/ros/lunar/lunar-desktop/Dockerfile
+++ b/ros/lunar/lunar-desktop/Dockerfile
@@ -1,0 +1,10 @@
+# This is an auto generated Dockerfile for ros:lunar-desktop
+# generated from templates/docker_images/create_ros_image.Dockerfile.em
+# generated on 2017-05-11 15:17:38 +0000
+FROM ros:lunar-ros-base
+
+# install ros packages
+RUN apt-get update && apt-get install -y \
+    ros-lunar-desktop=1.3.1-0* \
+    && rm -rf /var/lib/apt/lists/*
+

--- a/ros/lunar/lunar-desktop/Dockerfile
+++ b/ros/lunar/lunar-desktop/Dockerfile
@@ -1,6 +1,6 @@
 # This is an auto generated Dockerfile for ros:lunar-desktop
 # generated from templates/docker_images/create_ros_image.Dockerfile.em
-# generated on 2017-05-11 15:17:38 +0000
+# generated on 2017-05-22 15:18:23 +0000
 FROM ros:lunar-ros-base
 
 # install ros packages

--- a/ros/lunar/lunar-desktop/Dockerfile
+++ b/ros/lunar/lunar-desktop/Dockerfile
@@ -1,7 +1,7 @@
 # This is an auto generated Dockerfile for ros:lunar-desktop
 # generated from templates/docker_images/create_ros_image.Dockerfile.em
-# generated on 2017-05-22 15:18:23 +0000
-FROM ros:lunar-ros-base
+# generated on 2017-05-23 06:52:09 +0000
+FROM ros:lunar-robot
 
 # install ros packages
 RUN apt-get update && apt-get install -y \

--- a/ros/lunar/lunar-perception/Dockerfile
+++ b/ros/lunar/lunar-perception/Dockerfile
@@ -1,6 +1,6 @@
 # This is an auto generated Dockerfile for ros:lunar-perception
 # generated from templates/docker_images/create_ros_image.Dockerfile.em
-# generated on 2017-05-11 15:17:38 +0000
+# generated on 2017-05-22 15:18:23 +0000
 FROM ros:lunar-ros-base
 
 # install ros packages

--- a/ros/lunar/lunar-perception/Dockerfile
+++ b/ros/lunar/lunar-perception/Dockerfile
@@ -1,0 +1,10 @@
+# This is an auto generated Dockerfile for ros:lunar-perception
+# generated from templates/docker_images/create_ros_image.Dockerfile.em
+# generated on 2017-05-11 15:17:38 +0000
+FROM ros:lunar-ros-base
+
+# install ros packages
+RUN apt-get update && apt-get install -y \
+    ros-lunar-perception=1.3.1-0* \
+    && rm -rf /var/lib/apt/lists/*
+

--- a/ros/lunar/lunar-perception/Dockerfile
+++ b/ros/lunar/lunar-perception/Dockerfile
@@ -1,6 +1,6 @@
 # This is an auto generated Dockerfile for ros:lunar-perception
 # generated from templates/docker_images/create_ros_image.Dockerfile.em
-# generated on 2017-05-22 15:18:23 +0000
+# generated on 2017-05-23 06:52:09 +0000
 FROM ros:lunar-ros-base
 
 # install ros packages

--- a/ros/lunar/lunar-robot/Dockerfile
+++ b/ros/lunar/lunar-robot/Dockerfile
@@ -1,0 +1,10 @@
+# This is an auto generated Dockerfile for ros:lunar-robot
+# generated from templates/docker_images/create_ros_image.Dockerfile.em
+# generated on 2017-05-11 15:17:38 +0000
+FROM ros:lunar-ros-base
+
+# install ros packages
+RUN apt-get update && apt-get install -y \
+    ros-lunar-robot=1.3.1-0* \
+    && rm -rf /var/lib/apt/lists/*
+

--- a/ros/lunar/lunar-robot/Dockerfile
+++ b/ros/lunar/lunar-robot/Dockerfile
@@ -1,6 +1,6 @@
 # This is an auto generated Dockerfile for ros:lunar-robot
 # generated from templates/docker_images/create_ros_image.Dockerfile.em
-# generated on 2017-05-11 15:17:38 +0000
+# generated on 2017-05-22 15:18:23 +0000
 FROM ros:lunar-ros-base
 
 # install ros packages

--- a/ros/lunar/lunar-robot/Dockerfile
+++ b/ros/lunar/lunar-robot/Dockerfile
@@ -1,6 +1,6 @@
 # This is an auto generated Dockerfile for ros:lunar-robot
 # generated from templates/docker_images/create_ros_image.Dockerfile.em
-# generated on 2017-05-22 15:18:23 +0000
+# generated on 2017-05-23 06:52:09 +0000
 FROM ros:lunar-ros-base
 
 # install ros packages

--- a/ros/lunar/lunar-ros-base/Dockerfile
+++ b/ros/lunar/lunar-ros-base/Dockerfile
@@ -1,6 +1,6 @@
 # This is an auto generated Dockerfile for ros:lunar-ros-base
 # generated from templates/docker_images/create_ros_image.Dockerfile.em
-# generated on 2017-05-11 15:17:38 +0000
+# generated on 2017-05-22 15:18:23 +0000
 FROM ros:lunar-ros-core
 
 # install ros packages

--- a/ros/lunar/lunar-ros-base/Dockerfile
+++ b/ros/lunar/lunar-ros-base/Dockerfile
@@ -1,6 +1,6 @@
 # This is an auto generated Dockerfile for ros:lunar-ros-base
 # generated from templates/docker_images/create_ros_image.Dockerfile.em
-# generated on 2017-05-22 15:18:23 +0000
+# generated on 2017-05-23 06:52:09 +0000
 FROM ros:lunar-ros-core
 
 # install ros packages

--- a/ros/lunar/lunar-ros-base/Dockerfile
+++ b/ros/lunar/lunar-ros-base/Dockerfile
@@ -1,0 +1,10 @@
+# This is an auto generated Dockerfile for ros:lunar-ros-base
+# generated from templates/docker_images/create_ros_image.Dockerfile.em
+# generated on 2017-05-11 15:17:38 +0000
+FROM ros:lunar-ros-core
+
+# install ros packages
+RUN apt-get update && apt-get install -y \
+    ros-lunar-ros-base=1.3.1-0* \
+    && rm -rf /var/lib/apt/lists/*
+

--- a/ros/lunar/lunar-ros-core/Dockerfile
+++ b/ros/lunar/lunar-ros-core/Dockerfile
@@ -1,0 +1,37 @@
+# This is an auto generated Dockerfile for ros:lunar-ros-core
+# generated from templates/docker_images/create_ros_core_image.Dockerfile.em
+# generated on 2017-05-11 15:17:38 +0000
+FROM ubuntu:xenial
+
+# setup environment
+RUN locale-gen en_US.UTF-8
+ENV LANG en_US.UTF-8
+
+# setup keys
+RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
+
+# setup sources.list
+RUN echo "deb http://packages.ros.org/ros/ubuntu xenial main" > /etc/apt/sources.list.d/ros-latest.list
+
+# install bootstrap tools
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    python-rosdep \
+    python-rosinstall \
+    python-vcstools \
+    && rm -rf /var/lib/apt/lists/*
+
+# bootstrap rosdep
+RUN rosdep init \
+    && rosdep update
+
+# install ros packages
+ENV ROS_DISTRO lunar
+RUN apt-get update && apt-get install -y \
+    ros-lunar-ros-core=1.3.1-0* \
+    && rm -rf /var/lib/apt/lists/*
+
+# setup entrypoint
+COPY ./ros_entrypoint.sh /
+
+ENTRYPOINT ["/ros_entrypoint.sh"]
+CMD ["bash"]

--- a/ros/lunar/lunar-ros-core/Dockerfile
+++ b/ros/lunar/lunar-ros-core/Dockerfile
@@ -1,6 +1,6 @@
 # This is an auto generated Dockerfile for ros:lunar-ros-core
 # generated from templates/docker_images/create_ros_core_image.Dockerfile.em
-# generated on 2017-05-22 15:18:23 +0000
+# generated on 2017-05-23 06:52:09 +0000
 FROM ubuntu:xenial
 
 

--- a/ros/lunar/lunar-ros-core/Dockerfile
+++ b/ros/lunar/lunar-ros-core/Dockerfile
@@ -3,11 +3,6 @@
 # generated on 2017-05-22 15:18:23 +0000
 FROM ubuntu:xenial
 
-# setup environment
-RUN apt-get update && apt-get install -y \
-    locales \
-    && locale-gen en_US.UTF-8
-ENV LANG en_US.UTF-8
 
 # setup keys
 RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
@@ -17,11 +12,15 @@ RUN echo "deb http://packages.ros.org/ros/ubuntu xenial main" > /etc/apt/sources
 
 # install bootstrap tools
 RUN apt-get update && apt-get install --no-install-recommends -y \
+    locales \
     python-rosdep \
     python-rosinstall \
     python-vcstools \
     && rm -rf /var/lib/apt/lists/*
 
+# setup environment
+RUN locale-gen en_US.UTF-8
+ENV LANG en_US.UTF-8
 # bootstrap rosdep
 RUN rosdep init \
     && rosdep update

--- a/ros/lunar/lunar-ros-core/Dockerfile
+++ b/ros/lunar/lunar-ros-core/Dockerfile
@@ -1,10 +1,12 @@
 # This is an auto generated Dockerfile for ros:lunar-ros-core
 # generated from templates/docker_images/create_ros_core_image.Dockerfile.em
-# generated on 2017-05-11 15:17:38 +0000
+# generated on 2017-05-22 15:18:23 +0000
 FROM ubuntu:xenial
 
 # setup environment
-RUN locale-gen en_US.UTF-8
+RUN apt-get update && apt-get install -y \
+    locales \
+    && locale-gen en_US.UTF-8
 ENV LANG en_US.UTF-8
 
 # setup keys

--- a/ros/lunar/lunar-ros-core/ros_entrypoint.sh
+++ b/ros/lunar/lunar-ros-core/ros_entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+# setup ros environment
+source "/opt/ros/$ROS_DISTRO/setup.bash"
+exec "$@"

--- a/ros/lunar/platform.yaml
+++ b/ros/lunar/platform.yaml
@@ -1,0 +1,12 @@
+%YAML 1.1
+# ROS Dockerfile database
+---
+platform:
+    os_name: ubuntu
+    os_code_name: xenial
+    rosdistro_name: lunar
+    user_name: ros
+    maintainer_name:
+    arch: amd64
+    type: distribution
+    version: 1


### PR DESCRIPTION
This adds the dockerfiles to create official ROS lunar images on dockerhub.

Note that the images_yaml.em Empy template is that same for all distro and thus could be shared but I prefer to do that in a follow-up PR