### PR TITLE
Updating image.yaml.em to included locales package

### DIFF
--- a/ros2/images.yaml.em
+++ b/ros2/images.yaml.em
@@ -16,6 +16,7 @@ images:
             - git
             - libopencv-dev
             - libopensplice64
+            - locales
             - python-empy
             - python3-empy
             - python3-nose

--- a/ros2/ros2/Dockerfile
+++ b/ros2/ros2/Dockerfile
@@ -1,14 +1,10 @@
 # This is an auto generated Dockerfile for ros2:ros2
 # generated from templates/docker_images/create_ros2_image.Dockerfile.em
-# generated on 2016-07-15 16:28:44 +0000
+# generated on 2017-05-16 19:00:01 +0000
 FROM ubuntu:xenial
-MAINTAINER Tully Foote tfoote+buildfarm@osrfoundation.org
+LABEL maintainer "Tully Foote tfoote+buildfarm@osrfoundation.org"
 
 # ROS1 Repo Setup ##############################################################
-# setup environment
-RUN locale-gen en_US.UTF-8
-ENV LANG en_US.UTF-8
-
 # setup keys
 RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
 
@@ -31,6 +27,7 @@ RUN apt-get update && apt-get install -q -y \
     git \
     libopencv-dev \
     libopensplice64 \
+    locales \
     python-empy \
     python3-empy \
     python3-nose \
@@ -52,6 +49,11 @@ RUN apt-get update && apt-get install -q -y \
     libboost-system-dev \
     libboost-thread-dev \
     && rm -rf /var/lib/apt/lists/*
+
+# setup environment
+RUN locale-gen en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LC_ALL en_US.UTF-8
 
 # install python packages
 RUN pip3 install -U \


### PR DESCRIPTION
build still fails due to cmake errors though:
```
Process package 'fastrtps' with context:
--------------------------------------------------------------------------------
 source_space => /root/ros2_ws/src/eProsima/Fast-RTPS
  build_space => /root/ros2_ws/build/fastrtps
install_space => /root/ros2_ws/install
   make_flags => -j20, -l20
  build_tests => True
--------------------------------------------------------------------------------
+++ Building 'fastrtps'
Running cmake because arguments have changed.
==> '. /root/ros2_ws/build/fastrtps/cmake__build.sh && /usr/bin/cmake /root/ros2_ws/src/eProsima/Fast-RTPS -DCMAKE_INSTALL_PREFIX=/root/ros2_ws/install' in '/root/ros2_ws/build/fastrtps'
-- The C compiler identification is GNU 5.4.0
-- The CXX compiler identification is GNU 5.4.0
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring Fast RTPS
-- Version: 1.4.0
-- To change de version modify the file configure.ac
-- Performing Test SUPPORTS_CXX11
-- Performing Test SUPPORTS_CXX11 - Success
-- Check if the system is big endian
-- Searching 16 bit integer
-- Looking for sys/types.h
-- Looking for sys/types.h - found
-- Looking for stdint.h
-- Looking for stdint.h - found
-- Looking for stddef.h
-- Looking for stddef.h - found
-- Check size of unsigned short
-- Check size of unsigned short - done
-- Using unsigned short
-- Check if the system is big endian - little endian
-- fastcdr library found...
-- Could NOT find asio (missing:  ASIO_INCLUDE_DIR) 
-- Could NOT find tinyxml2 (missing:  TINYXML2_LIBRARY TINYXML2_INCLUDE_DIR) 
-- Looking for pthread.h
-- Looking for pthread.h - found
-- Looking for pthread_create
-- Looking for pthread_create - not found
-- Looking for pthread_create in pthreads
-- Looking for pthread_create in pthreads - not found
-- Looking for pthread_create in pthread
-- Looking for pthread_create in pthread - found
-- Found Threads: TRUE  
-- Configuring incomplete, errors occurred!
See also "/root/ros2_ws/build/fastrtps/CMakeFiles/CMakeOutput.log".
See also "/root/ros2_ws/build/fastrtps/CMakeFiles/CMakeError.log".
CMake Error: The following variables are used in this project, but they are set to NOTFOUND.
Please set them or make sure they are set and tested correctly in the CMake files:
ASIO_INCLUDE_DIR (ADVANCED)
   used as include directory in directory /root/ros2_ws/src/eProsima/Fast-RTPS/src/cpp
   used as include directory in directory /root/ros2_ws/src/eProsima/Fast-RTPS/src/cpp
   used as include directory in directory /root/ros2_ws/src/eProsima/Fast-RTPS/src/cpp
   used as include directory in directory /root/ros2_ws/src/eProsima/Fast-RTPS/src/cpp
   used as include directory in directory /root/ros2_ws/src/eProsima/Fast-RTPS/src/cpp
   used as include directory in directory /root/ros2_ws/src/eProsima/Fast-RTPS/src/cpp
   used as include directory in directory /root/ros2_ws/src/eProsima/Fast-RTPS/src/cpp
   used as include directory in directory /root/ros2_ws/src/eProsima/Fast-RTPS/src/cpp
   used as include directory in directory /root/ros2_ws/src/eProsima/Fast-RTPS/src/cpp
TINYXML2_INCLUDE_DIR (ADVANCED)
   used as include directory in directory /root/ros2_ws/src/eProsima/Fast-RTPS/src/cpp
   used as include directory in directory /root/ros2_ws/src/eProsima/Fast-RTPS/src/cpp
   used as include directory in directory /root/ros2_ws/src/eProsima/Fast-RTPS/src/cpp
   used as include directory in directory /root/ros2_ws/src/eProsima/Fast-RTPS/src/cpp
   used as include directory in directory /root/ros2_ws/src/eProsima/Fast-RTPS/src/cpp
   used as include directory in directory /root/ros2_ws/src/eProsima/Fast-RTPS/src/cpp
   used as include directory in directory /root/ros2_ws/src/eProsima/Fast-RTPS/src/cpp
   used as include directory in directory /root/ros2_ws/src/eProsima/Fast-RTPS/src/cpp
   used as include directory in directory /root/ros2_ws/src/eProsima/Fast-RTPS/src/cpp


<== Command '. /root/ros2_ws/build/fastrtps/cmake__build.sh && /usr/bin/cmake /root/ros2_ws/src/eProsima/Fast-RTPS -DCMAKE_INSTALL_PREFIX=/root/ros2_ws/install' failed in '/root/ros2_ws/build/fastrtps' with exit code '1'
<== Command '. /root/ros2_ws/build/fastrtps/cmake__build.sh && /usr/bin/cmake /root/ros2_ws/src/eProsima/Fast-RTPS -DCMAKE_INSTALL_PREFIX=/root/ros2_ws/install' failed in '/root/ros2_ws/build/fastrtps' with exit code '1'
The command '/bin/sh -c src/ament/ament_tools/scripts/ament.py     build     --build-tests     --symlink-install' returned a non-zero code: 1
```