### PR TITLE
Changing ROS package version lookup

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,12 +1,12 @@
 FROM python:3
-MAINTAINER Dirk Thomas dthomas+buildfarm@osrfoundation.org
 
 WORKDIR /tmp/
 
 RUN pip3 install \
         empy \
-        rosdistro && \
-    git clone \
+        pyyaml
+
+RUN git clone \
         -b docker_images \
         https://github.com/ruffsl/ros_buildfarm.git && \
     git clone \

--- a/ros/indigo/platform.yaml
+++ b/ros/indigo/platform.yaml
@@ -9,4 +9,5 @@ platform:
     maintainer_name:
     arch: amd64
     type: distribution
-    version: 1
+    version:
+    release: ros

--- a/ros/jade/platform.yaml
+++ b/ros/jade/platform.yaml
@@ -9,4 +9,5 @@ platform:
     maintainer_name:
     arch: amd64
     type: distribution
-    version: 1
+    version:
+    release: ros

--- a/ros/kinetic/platform.yaml
+++ b/ros/kinetic/platform.yaml
@@ -9,4 +9,5 @@ platform:
     maintainer_name:
     arch: amd64
     type: distribution
-    version: 1
+    version:
+    release: ros

--- a/ros/lunar/platform.yaml
+++ b/ros/lunar/platform.yaml
@@ -9,4 +9,5 @@ platform:
     maintainer_name:
     arch: amd64
     type: distribution
-    version: 1
+    version:
+    release: ros


### PR DESCRIPTION
Now scrapping version info for ros package using online package index instead of rosdistro lookups.
Version info lookup can also be bypassed by setting `version` field in platform.yaml to something other than empty.