### PR TITLE
Add apt and pip3 packages to ros2/images.yaml.em to fix ROS 2 Dockerfile

### DIFF
--- a/ros2/images.yaml.em
+++ b/ros2/images.yaml.em
@@ -42,7 +42,8 @@ images:
             - libboost-system-dev
             - libboost-thread-dev
         pip3_install:
-            - setuptools
+            - flake8
+            - flake8-import-order
         ws: /root/ros2_ws/src
         ament_args:
             - build

--- a/ros2/images.yaml.em
+++ b/ros2/images.yaml.em
@@ -23,6 +23,8 @@ images:
             - python3-pip
             - python3-setuptools
             - python3-vcstool
+            - libtinyxml-dev
+            - libeigen3-dev
             - wget
             - clang-format
             - pydocstyle
@@ -31,6 +33,8 @@ images:
             - python3-mock
             - python3-pep8
             - uncrustify
+            - libasio-dev
+            - libtinyxml2-dev
             - libboost-chrono-dev
             - libboost-date-time-dev
             - libboost-program-options-dev

--- a/ros2/images.yaml.em
+++ b/ros2/images.yaml.em
@@ -51,6 +51,7 @@ images:
         ws: /root/ros2_ws/src
         ament_args:
             - build
+            - --build-tests
             - --symlink-install
         vcs:
             ros2:

--- a/ros2/images.yaml.em
+++ b/ros2/images.yaml.em
@@ -47,7 +47,6 @@ images:
         ws: /root/ros2_ws/src
         ament_args:
             - build
-            - --build-tests
             - --symlink-install
         vcs:
             ros2:

--- a/ros2/images.yaml.em
+++ b/ros2/images.yaml.em
@@ -15,14 +15,17 @@ images:
             - cppcheck
             - git
             - libopencv-dev
-            - libopensplice64
-            - locales
+            - libpoco-dev
+            - libpocofoundation9v5
+            - libpocofoundation9v5-dbg
             - python-empy
+            - python3-dev
             - python3-empy
             - python3-nose
             - python3-pip
             - python3-setuptools
             - python3-vcstool
+            - python3-yaml
             - libtinyxml-dev
             - libeigen3-dev
             - wget
@@ -42,6 +45,7 @@ images:
             - libboost-system-dev
             - libboost-thread-dev
         pip3_install:
+            - argcomplete
             - flake8
             - flake8-import-order
         ws: /root/ros2_ws/src

--- a/ros2/ros2/Dockerfile
+++ b/ros2/ros2/Dockerfile
@@ -1,6 +1,6 @@
 # This is an auto generated Dockerfile for ros2:ros2
 # generated from templates/docker_images/create_ros2_image.Dockerfile.em
-# generated on 2017-05-16 19:00:01 +0000
+# generated on 2017-06-17 03:12:52 +0000
 FROM ubuntu:xenial
 LABEL maintainer "Tully Foote tfoote+buildfarm@osrfoundation.org"
 
@@ -34,6 +34,8 @@ RUN apt-get update && apt-get install -q -y \
     python3-pip \
     python3-setuptools \
     python3-vcstool \
+    libtinyxml-dev \
+    libeigen3-dev \
     wget \
     clang-format \
     pydocstyle \
@@ -42,6 +44,8 @@ RUN apt-get update && apt-get install -q -y \
     python3-mock \
     python3-pep8 \
     uncrustify \
+    libasio-dev \
+    libtinyxml2-dev \
     libboost-chrono-dev \
     libboost-date-time-dev \
     libboost-program-options-dev \
@@ -51,7 +55,9 @@ RUN apt-get update && apt-get install -q -y \
     && rm -rf /var/lib/apt/lists/*
 
 # setup environment
-RUN locale-gen en_US.UTF-8
+RUN apt-get update && apt-get install -y \
+    locales \
+    && locale-gen en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LC_ALL en_US.UTF-8
 

--- a/ros2/ros2/Dockerfile
+++ b/ros2/ros2/Dockerfile
@@ -1,6 +1,6 @@
 # This is an auto generated Dockerfile for ros2:ros2
 # generated from templates/docker_images/create_ros2_image.Dockerfile.em
-# generated on 2017-06-17 05:44:04 +0000
+# generated on 2017-06-29 22:35:15 +0000
 FROM ubuntu:xenial
 LABEL maintainer "Tully Foote tfoote+buildfarm@osrfoundation.org"
 
@@ -77,7 +77,6 @@ RUN wget https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos \
 WORKDIR /root/ros2_ws/src/..
 RUN src/ament/ament_tools/scripts/ament.py \
     build \
-    --build-tests \
     --symlink-install
 
 # setup entrypoint

--- a/ros2/ros2/Dockerfile
+++ b/ros2/ros2/Dockerfile
@@ -1,6 +1,6 @@
 # This is an auto generated Dockerfile for ros2:ros2
 # generated from templates/docker_images/create_ros2_image.Dockerfile.em
-# generated on 2017-06-29 22:35:15 +0000
+# generated on 2017-07-01 08:45:37 +0000
 FROM ubuntu:xenial
 LABEL maintainer "Tully Foote tfoote+buildfarm@osrfoundation.org"
 
@@ -26,14 +26,17 @@ RUN apt-get update && apt-get install -q -y \
     cppcheck \
     git \
     libopencv-dev \
-    libopensplice64 \
-    locales \
+    libpoco-dev \
+    libpocofoundation9v5 \
+    libpocofoundation9v5-dbg \
     python-empy \
+    python3-dev \
     python3-empy \
     python3-nose \
     python3-pip \
     python3-setuptools \
     python3-vcstool \
+    python3-yaml \
     libtinyxml-dev \
     libeigen3-dev \
     wget \
@@ -63,6 +66,7 @@ ENV LC_ALL en_US.UTF-8
 
 # install python packages
 RUN pip3 install -U \
+    argcomplete \
     flake8 \
     flake8-import-order
 

--- a/ros2/ros2/Dockerfile
+++ b/ros2/ros2/Dockerfile
@@ -1,6 +1,6 @@
 # This is an auto generated Dockerfile for ros2:ros2
 # generated from templates/docker_images/create_ros2_image.Dockerfile.em
-# generated on 2017-06-17 03:12:52 +0000
+# generated on 2017-06-17 05:44:04 +0000
 FROM ubuntu:xenial
 LABEL maintainer "Tully Foote tfoote+buildfarm@osrfoundation.org"
 
@@ -63,7 +63,8 @@ ENV LC_ALL en_US.UTF-8
 
 # install python packages
 RUN pip3 install -U \
-    setuptools
+    flake8 \
+    flake8-import-order
 
 # clone source
 ENV WS /root/ros2_ws/src

--- a/ros2/ros2/Dockerfile
+++ b/ros2/ros2/Dockerfile
@@ -1,6 +1,6 @@
 # This is an auto generated Dockerfile for ros2:ros2
 # generated from templates/docker_images/create_ros2_image.Dockerfile.em
-# generated on 2017-07-01 08:45:37 +0000
+# generated on 2017-07-01 09:00:05 +0000
 FROM ubuntu:xenial
 LABEL maintainer "Tully Foote tfoote+buildfarm@osrfoundation.org"
 
@@ -81,6 +81,7 @@ RUN wget https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos \
 WORKDIR /root/ros2_ws/src/..
 RUN src/ament/ament_tools/scripts/ament.py \
     build \
+    --build-tests \
     --symlink-install
 
 # setup entrypoint


### PR DESCRIPTION
I found the build failure of ROS 2 docker image.
The error message is shown below.

~~~
CMake Error: The following variables are used in this project, but they are set to NOTFOUND.
Please set them or make sure they are set and tested correctly in the CMake files:
ASIO_INCLUDE_DIR (ADVANCED)
   used as include directory in directory /root/ros2_ws/src/eProsima/Fast-RTPS/src/cpp
   used as include directory in directory /root/ros2_ws/src/eProsima/Fast-RTPS/src/cpp
   used as include directory in directory /root/ros2_ws/src/eProsima/Fast-RTPS/src/cpp
   used as include directory in directory /root/ros2_ws/src/eProsima/Fast-RTPS/src/cpp
   used as include directory in directory /root/ros2_ws/src/eProsima/Fast-RTPS/src/cpp
   used as include directory in directory /root/ros2_ws/src/eProsima/Fast-RTPS/src/cpp
   used as include directory in directory /root/ros2_ws/src/eProsima/Fast-RTPS/src/cpp
   used as include directory in directory /root/ros2_ws/src/eProsima/Fast-RTPS/src/cpp
   used as include directory in directory /root/ros2_ws/src/eProsima/Fast-RTPS/src/cpp
TINYXML2_INCLUDE_DIR (ADVANCED)
   used as include directory in directory /root/ros2_ws/src/eProsima/Fast-RTPS/src/cpp
   used as include directory in directory /root/ros2_ws/src/eProsima/Fast-RTPS/src/cpp
   used as include directory in directory /root/ros2_ws/src/eProsima/Fast-RTPS/src/cpp
   used as include directory in directory /root/ros2_ws/src/eProsima/Fast-RTPS/src/cpp
   used as include directory in directory /root/ros2_ws/src/eProsima/Fast-RTPS/src/cpp
   used as include directory in directory /root/ros2_ws/src/eProsima/Fast-RTPS/src/cpp
   used as include directory in directory /root/ros2_ws/src/eProsima/Fast-RTPS/src/cpp
   used as include directory in directory /root/ros2_ws/src/eProsima/Fast-RTPS/src/cpp
   used as include directory in directory /root/ros2_ws/src/eProsima/Fast-RTPS/src/cpp
~~~

Compared to [Linux Development Setup](https://github.com/ros2/ros2/wiki/Linux-Development-Setup) commands, current ROS 2 Dockerfile doesn't install apt packages: `libtinyxml-dev libeigen3-dev libasio-dev libtinyxml2-dev` and pip3 packages `flake8 flake8-import-order`. 

So this PR adds the packages to ros2/images.yaml.em.