### PR TITLE
Updating keyserver URL

### DIFF
--- a/gazebo/gazebo4/gzserver4/Dockerfile
+++ b/gazebo/gazebo4/gzserver4/Dockerfile
@@ -4,7 +4,7 @@
 FROM ubuntu:trusty
 
 # setup keys
-RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys D2486D2DD83DB69272AFE98867170598AF249743
+RUN apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-keys D2486D2DD83DB69272AFE98867170598AF249743
 
 # setup sources.list
 RUN echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-latest.list

--- a/gazebo/gazebo5/gzserver5/Dockerfile
+++ b/gazebo/gazebo5/gzserver5/Dockerfile
@@ -4,7 +4,7 @@
 FROM ubuntu:trusty
 
 # setup keys
-RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys D2486D2DD83DB69272AFE98867170598AF249743
+RUN apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-keys D2486D2DD83DB69272AFE98867170598AF249743
 
 # setup sources.list
 RUN echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-latest.list

--- a/gazebo/gazebo6/gzserver6/Dockerfile
+++ b/gazebo/gazebo6/gzserver6/Dockerfile
@@ -4,7 +4,7 @@
 FROM ubuntu:trusty
 
 # setup keys
-RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys D2486D2DD83DB69272AFE98867170598AF249743
+RUN apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-keys D2486D2DD83DB69272AFE98867170598AF249743
 
 # setup sources.list
 RUN echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-latest.list

--- a/gazebo/gazebo7/gzserver7/Dockerfile
+++ b/gazebo/gazebo7/gzserver7/Dockerfile
@@ -4,7 +4,7 @@
 FROM ubuntu:trusty
 
 # setup keys
-RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys D2486D2DD83DB69272AFE98867170598AF249743
+RUN apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-keys D2486D2DD83DB69272AFE98867170598AF249743
 
 # setup sources.list
 RUN . /etc/os-release \

--- a/gazebo/gazebo8/gzserver8/Dockerfile
+++ b/gazebo/gazebo8/gzserver8/Dockerfile
@@ -4,7 +4,7 @@
 FROM ubuntu:xenial
 
 # setup keys
-RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys D2486D2DD83DB69272AFE98867170598AF249743
+RUN apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-keys D2486D2DD83DB69272AFE98867170598AF249743
 
 # setup sources.list
 RUN . /etc/os-release \

--- a/gazebo/gazeboX/gzserverX/Dockerfile
+++ b/gazebo/gazeboX/gzserverX/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-add-repository ppa:libccd-debs \
 
 # Gazebo Setup #################################################################
 # setup keys
-RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys D2486D2DD83DB69272AFE98867170598AF249743
+RUN apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-keys D2486D2DD83DB69272AFE98867170598AF249743
 
 # setup sources.list
 RUN echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-latest.list

--- a/ros/indigo/indigo-ros-core/Dockerfile
+++ b/ros/indigo/indigo-ros-core/Dockerfile
@@ -4,7 +4,7 @@
 FROM ubuntu:trusty
 
 # setup keys
-RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
+RUN apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
 
 # setup sources.list
 RUN echo "deb http://packages.ros.org/ros/ubuntu trusty main" > /etc/apt/sources.list.d/ros-latest.list

--- a/ros/jade/jade-ros-core/Dockerfile
+++ b/ros/jade/jade-ros-core/Dockerfile
@@ -4,7 +4,7 @@
 FROM ubuntu:trusty
 
 # setup keys
-RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
+RUN apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
 
 # setup sources.list
 RUN echo "deb http://packages.ros.org/ros/ubuntu trusty main" > /etc/apt/sources.list.d/ros-latest.list

--- a/ros/kinetic/kinetic-ros-core/Dockerfile
+++ b/ros/kinetic/kinetic-ros-core/Dockerfile
@@ -4,7 +4,7 @@
 FROM ubuntu:xenial
 
 # setup keys
-RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
+RUN apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
 
 # setup sources.list
 RUN echo "deb http://packages.ros.org/ros/ubuntu xenial main" > /etc/apt/sources.list.d/ros-latest.list

--- a/ros/lunar/lunar-ros-core/Dockerfile
+++ b/ros/lunar/lunar-ros-core/Dockerfile
@@ -4,7 +4,7 @@
 FROM ubuntu:xenial
 
 # setup keys
-RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
+RUN apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
 
 # setup sources.list
 RUN echo "deb http://packages.ros.org/ros/ubuntu xenial main" > /etc/apt/sources.list.d/ros-latest.list

--- a/ros2/ros2/Dockerfile
+++ b/ros2/ros2/Dockerfile
@@ -6,14 +6,14 @@ LABEL maintainer "Tully Foote tfoote+buildfarm@osrfoundation.org"
 
 # ROS1 Repo Setup ##############################################################
 # setup keys
-RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
+RUN apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
 
 # setup sources.list
 RUN echo "deb http://packages.ros.org/ros/ubuntu xenial main" > /etc/apt/sources.list.d/ros-latest.list
 
 # OSRF Repo Setup ##############################################################
 # setup keys
-RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys D2486D2DD83DB69272AFE98867170598AF249743
+RUN apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-keys D2486D2DD83DB69272AFE98867170598AF249743
 
 # setup sources.list
 RUN echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable xenial main" > /etc/apt/sources.list.d/gazebo-latest.list

--- a/sros/kinetic/Dockerfile
+++ b/sros/kinetic/Dockerfile
@@ -7,7 +7,7 @@ RUN locale-gen en_US.UTF-8
 ENV LANG en_US.UTF-8
 
 # setup keys
-RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
+RUN apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
 
 # setup sources.list
 RUN echo "deb http://packages.ros.org/ros/ubuntu xenial main" > /etc/apt/sources.list.d/ros-latest.list


### PR DESCRIPTION
When I tried to duplicate the dockerfile commands in my container I wasn't able to add the key from the keyserver. See error from my container below:

```
root@f19b33dcdafa:/# apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
Executing: /tmp/tmp.RCcSlVBGYW/gpg.1.sh --keyserver
ha.pool.sks-keyservers.net
--recv-keys
421C365BD9FF1F717815A3895523BAEEB01FA116
gpg: requesting key B01FA116 from hkp server ha.pool.sks-keyservers.net

gpg: keyserver timed out
gpg: keyserver receive failed: keyserver error
```
Based on the ROS installation tutorial found at this URL:
http://wiki.ros.org/kinetic/Installation/Ubuntu

The recommendation is to use the url:
hkp://ha.pool.sks-keyservers.net:80

This pull request changes the keyserver url in the dockerfiles to use the tutorial URLs.

After making this change, adding the keyserver to my container was working.

