### PR TITLE
Version bump for Jade

### DIFF
--- a/ros/jade/ubuntu/trusty/desktop-full/Dockerfile
+++ b/ros/jade/ubuntu/trusty/desktop-full/Dockerfile
@@ -4,6 +4,6 @@ FROM osrf/ros:jade-desktop-trusty
 
 # install ros packages
 RUN apt-get update && apt-get install -y \
-    ros-jade-desktop-full=1.2.0-0* \
+    ros-jade-desktop-full=1.2.1-0* \
     && rm -rf /var/lib/apt/lists/*
 

--- a/ros/jade/ubuntu/trusty/desktop/Dockerfile
+++ b/ros/jade/ubuntu/trusty/desktop/Dockerfile
@@ -4,6 +4,6 @@ FROM ros:jade-robot-trusty
 
 # install ros packages
 RUN apt-get update && apt-get install -y \
-    ros-jade-desktop=1.2.0-0* \
+    ros-jade-desktop=1.2.1-0* \
     && rm -rf /var/lib/apt/lists/*
 

--- a/ros/jade/ubuntu/trusty/perception/Dockerfile
+++ b/ros/jade/ubuntu/trusty/perception/Dockerfile
@@ -4,6 +4,6 @@ FROM ros:jade-ros-base-trusty
 
 # install ros packages
 RUN apt-get update && apt-get install -y \
-    ros-jade-perception=1.2.0-0* \
+    ros-jade-perception=1.2.1-0* \
     && rm -rf /var/lib/apt/lists/*
 

--- a/ros/jade/ubuntu/trusty/robot/Dockerfile
+++ b/ros/jade/ubuntu/trusty/robot/Dockerfile
@@ -4,6 +4,6 @@ FROM ros:jade-ros-base-trusty
 
 # install ros packages
 RUN apt-get update && apt-get install -y \
-    ros-jade-robot=1.2.0-0* \
+    ros-jade-robot=1.2.1-0* \
     && rm -rf /var/lib/apt/lists/*
 

--- a/ros/jade/ubuntu/trusty/ros-base/Dockerfile
+++ b/ros/jade/ubuntu/trusty/ros-base/Dockerfile
@@ -4,6 +4,6 @@ FROM ros:jade-ros-core-trusty
 
 # install ros packages
 RUN apt-get update && apt-get install -y \
-    ros-jade-ros-base=1.2.0-0* \
+    ros-jade-ros-base=1.2.1-0* \
     && rm -rf /var/lib/apt/lists/*
 

--- a/ros/jade/ubuntu/trusty/ros-core/Dockerfile
+++ b/ros/jade/ubuntu/trusty/ros-core/Dockerfile
@@ -32,7 +32,7 @@ RUN rosdep init \
 # install ros packages
 ENV ROS_DISTRO jade
 RUN apt-get update && apt-get install -y \
-    ros-jade-ros-core=1.2.0-0* \
+    ros-jade-ros-core=1.2.1-0* \
     && rm -rf /var/lib/apt/lists/*
 
 # setup entrypoint

--- a/ros/ros
+++ b/ros/ros
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/osrf/docker_images/blob/7ba58fc107b368d6409c22161070eb93e562f240/ros/create_dockerlibrary.py
+# this file is generated via https://github.com/osrf/docker_images/blob/3e8b29c44f02c85b71a156be51c94902d4092929/ros/create_dockerlibrary.py
 
 Maintainers: Tully Foote <tfoote+buildfarm@osrfoundation.org> (@tfoote)
 GitRepo: https://github.com/osrf/docker_images.git
@@ -11,22 +11,22 @@ GitRepo: https://github.com/osrf/docker_images.git
 
 Tags: indigo-ros-core, indigo-ros-core-trusty
 Architectures: amd64, arm32v7
-GitCommit: 7ba58fc107b368d6409c22161070eb93e562f240
+GitCommit: 5399f380af0a7735405a4b6a07c6c40b867563bd
 Directory: ros/indigo/ubuntu/trusty/ros-core
 
 Tags: indigo-ros-base, indigo-ros-base-trusty, indigo
 Architectures: amd64, arm32v7
-GitCommit: 7ba58fc107b368d6409c22161070eb93e562f240
+GitCommit: 5399f380af0a7735405a4b6a07c6c40b867563bd
 Directory: ros/indigo/ubuntu/trusty/ros-base
 
 Tags: indigo-robot, indigo-robot-trusty
 Architectures: amd64, arm32v7
-GitCommit: 7ba58fc107b368d6409c22161070eb93e562f240
+GitCommit: 5399f380af0a7735405a4b6a07c6c40b867563bd
 Directory: ros/indigo/ubuntu/trusty/robot
 
 Tags: indigo-perception, indigo-perception-trusty
 Architectures: amd64, arm32v7
-GitCommit: 7ba58fc107b368d6409c22161070eb93e562f240
+GitCommit: 5399f380af0a7735405a4b6a07c6c40b867563bd
 Directory: ros/indigo/ubuntu/trusty/perception
 
 
@@ -38,22 +38,22 @@ Directory: ros/indigo/ubuntu/trusty/perception
 
 Tags: jade-ros-core, jade-ros-core-trusty
 Architectures: amd64, arm32v7
-GitCommit: 7ba58fc107b368d6409c22161070eb93e562f240
+GitCommit: dbda2abfbee89ebab4b33bdb1cfaec6dc36a3822
 Directory: ros/jade/ubuntu/trusty/ros-core
 
 Tags: jade-ros-base, jade-ros-base-trusty, jade
 Architectures: amd64, arm32v7
-GitCommit: 7ba58fc107b368d6409c22161070eb93e562f240
+GitCommit: dbda2abfbee89ebab4b33bdb1cfaec6dc36a3822
 Directory: ros/jade/ubuntu/trusty/ros-base
 
 Tags: jade-robot, jade-robot-trusty
 Architectures: amd64, arm32v7
-GitCommit: 7ba58fc107b368d6409c22161070eb93e562f240
+GitCommit: dbda2abfbee89ebab4b33bdb1cfaec6dc36a3822
 Directory: ros/jade/ubuntu/trusty/robot
 
 Tags: jade-perception, jade-perception-trusty
 Architectures: amd64, arm32v7
-GitCommit: 7ba58fc107b368d6409c22161070eb93e562f240
+GitCommit: dbda2abfbee89ebab4b33bdb1cfaec6dc36a3822
 Directory: ros/jade/ubuntu/trusty/perception
 
 
@@ -65,22 +65,22 @@ Directory: ros/jade/ubuntu/trusty/perception
 
 Tags: kinetic-ros-core, kinetic-ros-core-xenial
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 7ba58fc107b368d6409c22161070eb93e562f240
+GitCommit: 5399f380af0a7735405a4b6a07c6c40b867563bd
 Directory: ros/kinetic/ubuntu/xenial/ros-core
 
 Tags: kinetic-ros-base, kinetic-ros-base-xenial, kinetic, latest
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 7ba58fc107b368d6409c22161070eb93e562f240
+GitCommit: 5399f380af0a7735405a4b6a07c6c40b867563bd
 Directory: ros/kinetic/ubuntu/xenial/ros-base
 
 Tags: kinetic-robot, kinetic-robot-xenial
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 7ba58fc107b368d6409c22161070eb93e562f240
+GitCommit: 5399f380af0a7735405a4b6a07c6c40b867563bd
 Directory: ros/kinetic/ubuntu/xenial/robot
 
 Tags: kinetic-perception, kinetic-perception-xenial
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 7ba58fc107b368d6409c22161070eb93e562f240
+GitCommit: 5399f380af0a7735405a4b6a07c6c40b867563bd
 Directory: ros/kinetic/ubuntu/xenial/perception
 
 ########################################
@@ -88,22 +88,22 @@ Directory: ros/kinetic/ubuntu/xenial/perception
 
 Tags: kinetic-ros-core-jessie
 Architectures: amd64, arm64v8
-GitCommit: 7ba58fc107b368d6409c22161070eb93e562f240
+GitCommit: 3e8b29c44f02c85b71a156be51c94902d4092929
 Directory: ros/kinetic/debian/jessie/ros-core
 
 Tags: kinetic-ros-base-jessie
 Architectures: amd64, arm64v8
-GitCommit: 7ba58fc107b368d6409c22161070eb93e562f240
+GitCommit: 3e8b29c44f02c85b71a156be51c94902d4092929
 Directory: ros/kinetic/debian/jessie/ros-base
 
 Tags: kinetic-robot-jessie
 Architectures: amd64, arm64v8
-GitCommit: 7ba58fc107b368d6409c22161070eb93e562f240
+GitCommit: 3e8b29c44f02c85b71a156be51c94902d4092929
 Directory: ros/kinetic/debian/jessie/robot
 
 Tags: kinetic-perception-jessie
 Architectures: amd64, arm64v8
-GitCommit: 7ba58fc107b368d6409c22161070eb93e562f240
+GitCommit: 3e8b29c44f02c85b71a156be51c94902d4092929
 Directory: ros/kinetic/debian/jessie/perception
 
 
@@ -115,22 +115,22 @@ Directory: ros/kinetic/debian/jessie/perception
 
 Tags: lunar-ros-core, lunar-ros-core-xenial
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 7ba58fc107b368d6409c22161070eb93e562f240
+GitCommit: 5399f380af0a7735405a4b6a07c6c40b867563bd
 Directory: ros/lunar/ubuntu/xenial/ros-core
 
 Tags: lunar-ros-base, lunar-ros-base-xenial, lunar
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 7ba58fc107b368d6409c22161070eb93e562f240
+GitCommit: 5399f380af0a7735405a4b6a07c6c40b867563bd
 Directory: ros/lunar/ubuntu/xenial/ros-base
 
 Tags: lunar-robot, lunar-robot-xenial
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 7ba58fc107b368d6409c22161070eb93e562f240
+GitCommit: 5399f380af0a7735405a4b6a07c6c40b867563bd
 Directory: ros/lunar/ubuntu/xenial/robot
 
 Tags: lunar-perception, lunar-perception-xenial
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 7ba58fc107b368d6409c22161070eb93e562f240
+GitCommit: 5399f380af0a7735405a4b6a07c6c40b867563bd
 Directory: ros/lunar/ubuntu/xenial/perception
 
 ########################################
@@ -138,21 +138,21 @@ Directory: ros/lunar/ubuntu/xenial/perception
 
 Tags: lunar-ros-core-stretch
 Architectures: amd64, arm64v8
-GitCommit: 7ba58fc107b368d6409c22161070eb93e562f240
+GitCommit: 3e8b29c44f02c85b71a156be51c94902d4092929
 Directory: ros/lunar/debian/stretch/ros-core
 
 Tags: lunar-ros-base-stretch
 Architectures: amd64, arm64v8
-GitCommit: 7ba58fc107b368d6409c22161070eb93e562f240
+GitCommit: 3e8b29c44f02c85b71a156be51c94902d4092929
 Directory: ros/lunar/debian/stretch/ros-base
 
 Tags: lunar-robot-stretch
 Architectures: amd64, arm64v8
-GitCommit: 7ba58fc107b368d6409c22161070eb93e562f240
+GitCommit: 3e8b29c44f02c85b71a156be51c94902d4092929
 Directory: ros/lunar/debian/stretch/robot
 
 Tags: lunar-perception-stretch
 Architectures: amd64, arm64v8
-GitCommit: 7ba58fc107b368d6409c22161070eb93e562f240
+GitCommit: 3e8b29c44f02c85b71a156be51c94902d4092929
 Directory: ros/lunar/debian/stretch/perception
 


### PR DESCRIPTION
Looks like jude got its last sync. I say we let it propagate to the official docker hub tag and then think about how we should eventually remove the tag. I'm thinking for as long as its base image (ubuntu:1604) is getting update. 