### PR TITLE
Add full cleanup of apt-get install process (purge cached .deb)

### DIFF
--- a/gazebo/gazebo4/gzclient4/Dockerfile
+++ b/gazebo/gazebo4/gzclient4/Dockerfile
@@ -8,9 +8,9 @@ RUN apt-get update && apt-get install -q -y \
     mesa-utils \
     module-init-tools \
     x-window-system\
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # install gazebo packages
 RUN apt-get update && apt-get install -q -y \
     gazebo4=4.1.3-1* \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/gazebo/gazebo4/gzserver4/Dockerfile
+++ b/gazebo/gazebo4/gzserver4/Dockerfile
@@ -13,7 +13,7 @@ RUN . /etc/os-release \
 # install gazebo packages
 RUN apt-get update && apt-get install -q -y \
     gazebo4=4.1.3-1* \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # setup environment
 EXPOSE 11345

--- a/gazebo/gazebo4/gzweb4/Dockerfile
+++ b/gazebo/gazebo4/gzweb4/Dockerfile
@@ -18,12 +18,12 @@ RUN apt-get update && apt-get install -q -y \
     pkg-config \
     psmisc \
     xvfb\
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # install gazebo packages
 RUN apt-get update && apt-get install -q -y \
     libgazebo4-dev=4.1.3-1* \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # clone gzweb
 RUN hg clone https://bitbucket.org/osrf/gzweb ~/gzweb

--- a/gazebo/gazebo4/libgazebo4/Dockerfile
+++ b/gazebo/gazebo4/libgazebo4/Dockerfile
@@ -4,4 +4,4 @@ FROM gazebo:gzserver4
 # install gazebo packages
 RUN apt-get update && apt-get install -q -y \
     libgazebo4-dev=4.1.3-1* \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/gazebo/gazebo5/gzclient5/Dockerfile
+++ b/gazebo/gazebo5/gzclient5/Dockerfile
@@ -8,9 +8,9 @@ RUN apt-get update && apt-get install -q -y \
     mesa-utils \
     module-init-tools \
     x-window-system\
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # install gazebo packages
 RUN apt-get update && apt-get install -q -y \
     gazebo5=5.4.0-1* \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/gazebo/gazebo5/gzserver5/Dockerfile
+++ b/gazebo/gazebo5/gzserver5/Dockerfile
@@ -13,7 +13,7 @@ RUN . /etc/os-release \
 # install gazebo packages
 RUN apt-get update && apt-get install -q -y \
     gazebo5=5.4.0-1* \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # setup environment
 EXPOSE 11345

--- a/gazebo/gazebo5/gzweb5/Dockerfile
+++ b/gazebo/gazebo5/gzweb5/Dockerfile
@@ -18,12 +18,12 @@ RUN apt-get update && apt-get install -q -y \
     pkg-config \
     psmisc \
     xvfb\
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # install gazebo packages
 RUN apt-get update && apt-get install -q -y \
     libgazebo5-dev=5.4.0-1* \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # clone gzweb
 RUN hg clone https://bitbucket.org/osrf/gzweb ~/gzweb

--- a/gazebo/gazebo5/libgazebo5/Dockerfile
+++ b/gazebo/gazebo5/libgazebo5/Dockerfile
@@ -4,4 +4,4 @@ FROM gazebo:gzserver5
 # install gazebo packages
 RUN apt-get update && apt-get install -q -y \
     libgazebo5-dev=5.4.0-1* \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/gazebo/gazebo6/gzclient6/Dockerfile
+++ b/gazebo/gazebo6/gzclient6/Dockerfile
@@ -8,9 +8,9 @@ RUN apt-get update && apt-get install -q -y \
     mesa-utils \
     module-init-tools \
     x-window-system\
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # install gazebo packages
 RUN apt-get update && apt-get install -q -y \
     gazebo6=6.7.0-1* \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/gazebo/gazebo6/gzserver6/Dockerfile
+++ b/gazebo/gazebo6/gzserver6/Dockerfile
@@ -13,7 +13,7 @@ RUN . /etc/os-release \
 # install gazebo packages
 RUN apt-get update && apt-get install -q -y \
     gazebo6=6.7.0-1* \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # setup environment
 EXPOSE 11345

--- a/gazebo/gazebo6/gzweb6/Dockerfile
+++ b/gazebo/gazebo6/gzweb6/Dockerfile
@@ -18,12 +18,12 @@ RUN apt-get update && apt-get install -q -y \
     pkg-config \
     psmisc \
     xvfb\
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # install gazebo packages
 RUN apt-get update && apt-get install -q -y \
     libgazebo6-dev=6.7.0-1* \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # clone gzweb
 RUN hg clone https://bitbucket.org/osrf/gzweb ~/gzweb

--- a/gazebo/gazebo6/libgazebo6/Dockerfile
+++ b/gazebo/gazebo6/libgazebo6/Dockerfile
@@ -4,4 +4,4 @@ FROM gazebo:gzserver6
 # install gazebo packages
 RUN apt-get update && apt-get install -q -y \
     libgazebo6-dev=6.7.0-1* \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/gazebo/gazebo7/gzclient7/Dockerfile
+++ b/gazebo/gazebo7/gzclient7/Dockerfile
@@ -8,9 +8,9 @@ RUN apt-get update && apt-get install -q -y \
     mesa-utils \
     module-init-tools \
     x-window-system\
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # install gazebo packages
 RUN apt-get update && apt-get install -q -y \
     gazebo7=7.8.1-1* \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/gazebo/gazebo7/gzserver7/Dockerfile
+++ b/gazebo/gazebo7/gzserver7/Dockerfile
@@ -13,7 +13,7 @@ RUN . /etc/os-release \
 # install gazebo packages
 RUN apt-get update && apt-get install -q -y \
     gazebo7=7.8.1-1* \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # setup environment
 EXPOSE 11345

--- a/gazebo/gazebo7/gzweb7/Dockerfile
+++ b/gazebo/gazebo7/gzweb7/Dockerfile
@@ -18,12 +18,12 @@ RUN apt-get update && apt-get install -q -y \
     pkg-config \
     psmisc \
     xvfb\
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # install gazebo packages
 RUN apt-get update && apt-get install -q -y \
     libgazebo7-dev=7.8.1-1* \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # clone gzweb
 RUN hg clone https://bitbucket.org/osrf/gzweb ~/gzweb

--- a/gazebo/gazebo7/libgazebo7/Dockerfile
+++ b/gazebo/gazebo7/libgazebo7/Dockerfile
@@ -4,4 +4,4 @@ FROM gazebo:gzserver7
 # install gazebo packages
 RUN apt-get update && apt-get install -q -y \
     libgazebo7-dev=7.8.1-1* \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/gazebo/gazebo8/gzclient8/Dockerfile
+++ b/gazebo/gazebo8/gzclient8/Dockerfile
@@ -8,9 +8,9 @@ RUN apt-get update && apt-get install -q -y \
     mesa-utils \
     module-init-tools \
     x-window-system\
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # install gazebo packages
 RUN apt-get update && apt-get install -q -y \
     gazebo8=8.1.1-1* \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/gazebo/gazebo8/gzserver8/Dockerfile
+++ b/gazebo/gazebo8/gzserver8/Dockerfile
@@ -13,7 +13,7 @@ RUN . /etc/os-release \
 # install gazebo packages
 RUN apt-get update && apt-get install -q -y \
     gazebo8=8.1.1-1* \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # setup environment
 EXPOSE 11345

--- a/gazebo/gazebo8/gzweb8/Dockerfile
+++ b/gazebo/gazebo8/gzweb8/Dockerfile
@@ -18,12 +18,12 @@ RUN apt-get update && apt-get install -q -y \
     pkg-config \
     psmisc \
     xvfb\
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # install gazebo packages
 RUN apt-get update && apt-get install -q -y \
     libgazebo8-dev=8.1.1-1* \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # clone gzweb
 RUN hg clone https://bitbucket.org/osrf/gzweb ~/gzweb

--- a/gazebo/gazebo8/libgazebo8/Dockerfile
+++ b/gazebo/gazebo8/libgazebo8/Dockerfile
@@ -4,4 +4,4 @@ FROM gazebo:gzserver8
 # install gazebo packages
 RUN apt-get update && apt-get install -q -y \
     libgazebo8-dev=8.1.1-1* \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/ros/boxturtle/ubuntu/lucid/ros/Dockerfile
+++ b/ros/boxturtle/ubuntu/lucid/ros/Dockerfile
@@ -19,7 +19,7 @@ ENV LC_ALL C.UTF-8
 ENV ROS_DISTRO boxturtle
 RUN apt-get update && apt-get install -y \
     ros-boxturtle-ros \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # setup entrypoint
 COPY ./ros_eol_entrypoint.sh /ros_entrypoint.sh

--- a/ros/cturtle/ubuntu/lucid/ros/Dockerfile
+++ b/ros/cturtle/ubuntu/lucid/ros/Dockerfile
@@ -19,7 +19,7 @@ ENV LC_ALL C.UTF-8
 ENV ROS_DISTRO cturtle
 RUN apt-get update && apt-get install -y \
     ros-cturtle-ros \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # setup entrypoint
 COPY ./ros_eol_entrypoint.sh /ros_entrypoint.sh

--- a/ros/diamondback/ubuntu/lucid/ros/Dockerfile
+++ b/ros/diamondback/ubuntu/lucid/ros/Dockerfile
@@ -19,7 +19,7 @@ ENV LC_ALL C.UTF-8
 ENV ROS_DISTRO diamondback
 RUN apt-get update && apt-get install -y \
     ros-diamondback-ros \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # setup entrypoint
 COPY ./ros_eol_entrypoint.sh /ros_entrypoint.sh

--- a/ros/electric/ubuntu/lucid/ros/Dockerfile
+++ b/ros/electric/ubuntu/lucid/ros/Dockerfile
@@ -19,7 +19,7 @@ ENV LC_ALL C.UTF-8
 ENV ROS_DISTRO electric
 RUN apt-get update && apt-get install -y \
     ros-electric-ros \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # setup entrypoint
 COPY ./ros_eol_entrypoint.sh /ros_entrypoint.sh

--- a/ros/fuerte/ubuntu/precise/ros/Dockerfile
+++ b/ros/fuerte/ubuntu/precise/ros/Dockerfile
@@ -19,7 +19,7 @@ ENV LC_ALL C.UTF-8
 ENV ROS_DISTRO fuerte
 RUN apt-get update && apt-get install -y \
     ros-fuerte-ros \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # setup entrypoint
 COPY ./ros_eol_entrypoint.sh /ros_entrypoint.sh

--- a/ros/groovy/ubuntu/precise/ros/Dockerfile
+++ b/ros/groovy/ubuntu/precise/ros/Dockerfile
@@ -19,7 +19,7 @@ ENV LC_ALL C.UTF-8
 ENV ROS_DISTRO groovy
 RUN apt-get update && apt-get install -y \
     ros-groovy-ros \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # setup entrypoint
 COPY ./ros_eol_entrypoint.sh /ros_entrypoint.sh

--- a/ros/hydro/ubuntu/precise/ros/Dockerfile
+++ b/ros/hydro/ubuntu/precise/ros/Dockerfile
@@ -19,7 +19,7 @@ ENV LC_ALL C.UTF-8
 ENV ROS_DISTRO hydro
 RUN apt-get update && apt-get install -y \
     ros-hydro-ros \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # setup entrypoint
 COPY ./ros_eol_entrypoint.sh /ros_entrypoint.sh

--- a/ros/indigo/ubuntu/trusty/desktop-full/Dockerfile
+++ b/ros/indigo/ubuntu/trusty/desktop-full/Dockerfile
@@ -5,5 +5,5 @@ FROM osrf/ros:indigo-desktop-trusty
 # install ros packages
 RUN apt-get update && apt-get install -y \
     ros-indigo-desktop-full=1.1.5-0* \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 

--- a/ros/indigo/ubuntu/trusty/desktop/Dockerfile
+++ b/ros/indigo/ubuntu/trusty/desktop/Dockerfile
@@ -5,5 +5,5 @@ FROM ros:indigo-robot-trusty
 # install ros packages
 RUN apt-get update && apt-get install -y \
     ros-indigo-desktop=1.1.5-0* \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 

--- a/ros/indigo/ubuntu/trusty/perception/Dockerfile
+++ b/ros/indigo/ubuntu/trusty/perception/Dockerfile
@@ -5,5 +5,5 @@ FROM ros:indigo-ros-base-trusty
 # install ros packages
 RUN apt-get update && apt-get install -y \
     ros-indigo-perception=1.1.5-0* \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 

--- a/ros/indigo/ubuntu/trusty/robot/Dockerfile
+++ b/ros/indigo/ubuntu/trusty/robot/Dockerfile
@@ -5,5 +5,5 @@ FROM ros:indigo-ros-base-trusty
 # install ros packages
 RUN apt-get update && apt-get install -y \
     ros-indigo-robot=1.1.5-0* \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 

--- a/ros/indigo/ubuntu/trusty/ros-base/Dockerfile
+++ b/ros/indigo/ubuntu/trusty/ros-base/Dockerfile
@@ -5,5 +5,5 @@ FROM ros:indigo-ros-core-trusty
 # install ros packages
 RUN apt-get update && apt-get install -y \
     ros-indigo-ros-base=1.1.5-0* \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 

--- a/ros/indigo/ubuntu/trusty/ros-core/Dockerfile
+++ b/ros/indigo/ubuntu/trusty/ros-core/Dockerfile
@@ -6,7 +6,7 @@ FROM ubuntu:trusty
 RUN apt-get update && apt-get install -y --no-install-recommends \
     dirmngr \
     gnupg2 \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # setup keys
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
@@ -19,7 +19,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     python-rosdep \
     python-rosinstall \
     python-vcstools \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # setup environment
 ENV LANG C.UTF-8
@@ -33,7 +33,7 @@ RUN rosdep init \
 ENV ROS_DISTRO indigo
 RUN apt-get update && apt-get install -y \
     ros-indigo-ros-core=1.1.5-0* \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # setup entrypoint
 COPY ./ros_entrypoint.sh /

--- a/ros/jade/ubuntu/trusty/desktop-full/Dockerfile
+++ b/ros/jade/ubuntu/trusty/desktop-full/Dockerfile
@@ -5,5 +5,5 @@ FROM osrf/ros:jade-desktop-trusty
 # install ros packages
 RUN apt-get update && apt-get install -y \
     ros-jade-desktop-full=1.2.1-0* \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 

--- a/ros/jade/ubuntu/trusty/desktop/Dockerfile
+++ b/ros/jade/ubuntu/trusty/desktop/Dockerfile
@@ -5,5 +5,5 @@ FROM ros:jade-robot-trusty
 # install ros packages
 RUN apt-get update && apt-get install -y \
     ros-jade-desktop=1.2.1-0* \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 

--- a/ros/jade/ubuntu/trusty/perception/Dockerfile
+++ b/ros/jade/ubuntu/trusty/perception/Dockerfile
@@ -5,5 +5,5 @@ FROM ros:jade-ros-base-trusty
 # install ros packages
 RUN apt-get update && apt-get install -y \
     ros-jade-perception=1.2.1-0* \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 

--- a/ros/jade/ubuntu/trusty/robot/Dockerfile
+++ b/ros/jade/ubuntu/trusty/robot/Dockerfile
@@ -5,5 +5,5 @@ FROM ros:jade-ros-base-trusty
 # install ros packages
 RUN apt-get update && apt-get install -y \
     ros-jade-robot=1.2.1-0* \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 

--- a/ros/jade/ubuntu/trusty/ros-base/Dockerfile
+++ b/ros/jade/ubuntu/trusty/ros-base/Dockerfile
@@ -5,5 +5,5 @@ FROM ros:jade-ros-core-trusty
 # install ros packages
 RUN apt-get update && apt-get install -y \
     ros-jade-ros-base=1.2.1-0* \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 

--- a/ros/jade/ubuntu/trusty/ros-core/Dockerfile
+++ b/ros/jade/ubuntu/trusty/ros-core/Dockerfile
@@ -6,7 +6,7 @@ FROM ubuntu:trusty
 RUN apt-get update && apt-get install -y --no-install-recommends \
     dirmngr \
     gnupg2 \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # setup keys
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
@@ -19,7 +19,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     python-rosdep \
     python-rosinstall \
     python-vcstools \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # setup environment
 ENV LANG C.UTF-8
@@ -33,7 +33,7 @@ RUN rosdep init \
 ENV ROS_DISTRO jade
 RUN apt-get update && apt-get install -y \
     ros-jade-ros-core=1.2.1-0* \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # setup entrypoint
 COPY ./ros_entrypoint.sh /

--- a/ros/kinetic/debian/jessie/desktop-full/Dockerfile
+++ b/ros/kinetic/debian/jessie/desktop-full/Dockerfile
@@ -5,5 +5,5 @@ FROM osrf/ros:kinetic-desktop-jessie
 # install ros packages
 RUN apt-get update && apt-get install -y \
     ros-kinetic-desktop-full=1.3.1-0* \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 

--- a/ros/kinetic/debian/jessie/desktop/Dockerfile
+++ b/ros/kinetic/debian/jessie/desktop/Dockerfile
@@ -5,5 +5,5 @@ FROM ros:kinetic-robot-jessie
 # install ros packages
 RUN apt-get update && apt-get install -y \
     ros-kinetic-desktop=1.3.1-0* \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 

--- a/ros/kinetic/debian/jessie/perception/Dockerfile
+++ b/ros/kinetic/debian/jessie/perception/Dockerfile
@@ -5,5 +5,5 @@ FROM ros:kinetic-ros-base-jessie
 # install ros packages
 RUN apt-get update && apt-get install -y \
     ros-kinetic-perception=1.3.1-0* \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 

--- a/ros/kinetic/debian/jessie/robot/Dockerfile
+++ b/ros/kinetic/debian/jessie/robot/Dockerfile
@@ -5,5 +5,5 @@ FROM ros:kinetic-ros-base-jessie
 # install ros packages
 RUN apt-get update && apt-get install -y \
     ros-kinetic-robot=1.3.1-0* \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 

--- a/ros/kinetic/debian/jessie/ros-base/Dockerfile
+++ b/ros/kinetic/debian/jessie/ros-base/Dockerfile
@@ -5,5 +5,5 @@ FROM ros:kinetic-ros-core-jessie
 # install ros packages
 RUN apt-get update && apt-get install -y \
     ros-kinetic-ros-base=1.3.1-0* \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 

--- a/ros/kinetic/debian/jessie/ros-core/Dockerfile
+++ b/ros/kinetic/debian/jessie/ros-core/Dockerfile
@@ -6,7 +6,7 @@ FROM debian:jessie
 RUN apt-get update && apt-get install -y --no-install-recommends \
     dirmngr \
     gnupg2 \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # setup keys
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
@@ -19,7 +19,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     python-rosdep \
     python-rosinstall \
     python-vcstools \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # setup environment
 ENV LANG C.UTF-8
@@ -33,7 +33,7 @@ RUN rosdep init \
 ENV ROS_DISTRO kinetic
 RUN apt-get update && apt-get install -y \
     ros-kinetic-ros-core=1.3.1-0* \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # setup entrypoint
 COPY ./ros_entrypoint.sh /

--- a/ros/kinetic/ubuntu/xenial/desktop-full/Dockerfile
+++ b/ros/kinetic/ubuntu/xenial/desktop-full/Dockerfile
@@ -5,5 +5,5 @@ FROM osrf/ros:kinetic-desktop-xenial
 # install ros packages
 RUN apt-get update && apt-get install -y \
     ros-kinetic-desktop-full=1.3.1-0* \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 

--- a/ros/kinetic/ubuntu/xenial/desktop/Dockerfile
+++ b/ros/kinetic/ubuntu/xenial/desktop/Dockerfile
@@ -5,5 +5,5 @@ FROM ros:kinetic-robot-xenial
 # install ros packages
 RUN apt-get update && apt-get install -y \
     ros-kinetic-desktop=1.3.1-0* \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 

--- a/ros/kinetic/ubuntu/xenial/perception/Dockerfile
+++ b/ros/kinetic/ubuntu/xenial/perception/Dockerfile
@@ -5,5 +5,5 @@ FROM ros:kinetic-ros-base-xenial
 # install ros packages
 RUN apt-get update && apt-get install -y \
     ros-kinetic-perception=1.3.1-0* \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 

--- a/ros/kinetic/ubuntu/xenial/robot/Dockerfile
+++ b/ros/kinetic/ubuntu/xenial/robot/Dockerfile
@@ -5,5 +5,5 @@ FROM ros:kinetic-ros-base-xenial
 # install ros packages
 RUN apt-get update && apt-get install -y \
     ros-kinetic-robot=1.3.1-0* \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 

--- a/ros/kinetic/ubuntu/xenial/ros-base/Dockerfile
+++ b/ros/kinetic/ubuntu/xenial/ros-base/Dockerfile
@@ -5,5 +5,5 @@ FROM ros:kinetic-ros-core-xenial
 # install ros packages
 RUN apt-get update && apt-get install -y \
     ros-kinetic-ros-base=1.3.1-0* \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 

--- a/ros/kinetic/ubuntu/xenial/ros-core/Dockerfile
+++ b/ros/kinetic/ubuntu/xenial/ros-core/Dockerfile
@@ -6,7 +6,7 @@ FROM ubuntu:xenial
 RUN apt-get update && apt-get install -y --no-install-recommends \
     dirmngr \
     gnupg2 \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # setup keys
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
@@ -19,7 +19,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     python-rosdep \
     python-rosinstall \
     python-vcstools \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # setup environment
 ENV LANG C.UTF-8
@@ -33,7 +33,7 @@ RUN rosdep init \
 ENV ROS_DISTRO kinetic
 RUN apt-get update && apt-get install -y \
     ros-kinetic-ros-core=1.3.1-0* \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # setup entrypoint
 COPY ./ros_entrypoint.sh /

--- a/ros/lunar/debian/stretch/desktop-full/Dockerfile
+++ b/ros/lunar/debian/stretch/desktop-full/Dockerfile
@@ -5,5 +5,5 @@ FROM osrf/ros:lunar-desktop-stretch
 # install ros packages
 RUN apt-get update && apt-get install -y \
     ros-lunar-desktop-full=1.3.1-0* \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 

--- a/ros/lunar/debian/stretch/desktop/Dockerfile
+++ b/ros/lunar/debian/stretch/desktop/Dockerfile
@@ -5,5 +5,5 @@ FROM ros:lunar-robot-stretch
 # install ros packages
 RUN apt-get update && apt-get install -y \
     ros-lunar-desktop=1.3.1-0* \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 

--- a/ros/lunar/debian/stretch/perception/Dockerfile
+++ b/ros/lunar/debian/stretch/perception/Dockerfile
@@ -5,5 +5,5 @@ FROM ros:lunar-ros-base-stretch
 # install ros packages
 RUN apt-get update && apt-get install -y \
     ros-lunar-perception=1.3.1-0* \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 

--- a/ros/lunar/debian/stretch/robot/Dockerfile
+++ b/ros/lunar/debian/stretch/robot/Dockerfile
@@ -5,5 +5,5 @@ FROM ros:lunar-ros-base-stretch
 # install ros packages
 RUN apt-get update && apt-get install -y \
     ros-lunar-robot=1.3.1-0* \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 

--- a/ros/lunar/debian/stretch/ros-base/Dockerfile
+++ b/ros/lunar/debian/stretch/ros-base/Dockerfile
@@ -5,5 +5,5 @@ FROM ros:lunar-ros-core-stretch
 # install ros packages
 RUN apt-get update && apt-get install -y \
     ros-lunar-ros-base=1.3.1-0* \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 

--- a/ros/lunar/debian/stretch/ros-core/Dockerfile
+++ b/ros/lunar/debian/stretch/ros-core/Dockerfile
@@ -6,7 +6,7 @@ FROM debian:stretch
 RUN apt-get update && apt-get install -y --no-install-recommends \
     dirmngr \
     gnupg2 \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # setup keys
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
@@ -19,7 +19,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     python-rosdep \
     python-rosinstall \
     python-vcstools \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # setup environment
 ENV LANG C.UTF-8
@@ -33,7 +33,7 @@ RUN rosdep init \
 ENV ROS_DISTRO lunar
 RUN apt-get update && apt-get install -y \
     ros-lunar-ros-core=1.3.1-0* \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # setup entrypoint
 COPY ./ros_entrypoint.sh /

--- a/ros/lunar/ubuntu/xenial/desktop-full/Dockerfile
+++ b/ros/lunar/ubuntu/xenial/desktop-full/Dockerfile
@@ -5,5 +5,5 @@ FROM osrf/ros:lunar-desktop-xenial
 # install ros packages
 RUN apt-get update && apt-get install -y \
     ros-lunar-desktop-full=1.3.1-0* \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 

--- a/ros/lunar/ubuntu/xenial/desktop/Dockerfile
+++ b/ros/lunar/ubuntu/xenial/desktop/Dockerfile
@@ -5,5 +5,5 @@ FROM ros:lunar-robot-xenial
 # install ros packages
 RUN apt-get update && apt-get install -y \
     ros-lunar-desktop=1.3.1-0* \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 

--- a/ros/lunar/ubuntu/xenial/perception/Dockerfile
+++ b/ros/lunar/ubuntu/xenial/perception/Dockerfile
@@ -5,5 +5,5 @@ FROM ros:lunar-ros-base-xenial
 # install ros packages
 RUN apt-get update && apt-get install -y \
     ros-lunar-perception=1.3.1-0* \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 

--- a/ros/lunar/ubuntu/xenial/robot/Dockerfile
+++ b/ros/lunar/ubuntu/xenial/robot/Dockerfile
@@ -5,5 +5,5 @@ FROM ros:lunar-ros-base-xenial
 # install ros packages
 RUN apt-get update && apt-get install -y \
     ros-lunar-robot=1.3.1-0* \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 

--- a/ros/lunar/ubuntu/xenial/ros-base/Dockerfile
+++ b/ros/lunar/ubuntu/xenial/ros-base/Dockerfile
@@ -5,5 +5,5 @@ FROM ros:lunar-ros-core-xenial
 # install ros packages
 RUN apt-get update && apt-get install -y \
     ros-lunar-ros-base=1.3.1-0* \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 

--- a/ros/lunar/ubuntu/xenial/ros-core/Dockerfile
+++ b/ros/lunar/ubuntu/xenial/ros-core/Dockerfile
@@ -6,7 +6,7 @@ FROM ubuntu:xenial
 RUN apt-get update && apt-get install -y --no-install-recommends \
     dirmngr \
     gnupg2 \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # setup keys
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
@@ -19,7 +19,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     python-rosdep \
     python-rosinstall \
     python-vcstools \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # setup environment
 ENV LANG C.UTF-8
@@ -33,7 +33,7 @@ RUN rosdep init \
 ENV ROS_DISTRO lunar
 RUN apt-get update && apt-get install -y \
     ros-lunar-ros-core=1.3.1-0* \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # setup entrypoint
 COPY ./ros_entrypoint.sh /

--- a/ros2/r2b3/ubuntu/xenial/r2b3-core/Dockerfile
+++ b/ros2/r2b3/ubuntu/xenial/r2b3-core/Dockerfile
@@ -24,7 +24,7 @@ ENV ROS2_DISTRO r2b3
 # install packages
 RUN apt-get update && apt-get install -q -y \
     python3-pip \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # install python packages
 RUN pip3 install -U \
@@ -36,7 +36,7 @@ RUN apt-get update && apt-get install -y \
     ros-r2b3-demo-nodes-py \
     ros-r2b3-ros2run \
     ros-r2b3-sros2 \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # setup entrypoint
 COPY ./ros2_entrypoint.sh /

--- a/ros2/r2b3/ubuntu/xenial/r2b3-ros1-bridge/Dockerfile
+++ b/ros2/r2b3/ubuntu/xenial/r2b3-ros1-bridge/Dockerfile
@@ -5,5 +5,5 @@ FROM osrf/ros2:r2b3-core
 # install ros2 packages
 RUN apt-get update && apt-get install -y \
     ros-r2b3-ros1-bridge \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 

--- a/ros2/source/source/Dockerfile
+++ b/ros2/source/source/Dockerfile
@@ -46,7 +46,7 @@ RUN apt-get update && apt-get install -q -y \
     python3-yaml \
     uncrustify \
     wget \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # install python packages
 RUN pip3 install -U \

--- a/sros/kinetic/Dockerfile
+++ b/sros/kinetic/Dockerfile
@@ -5,7 +5,7 @@ FROM ubuntu:xenial
 RUN apt-get update && apt-get install -y --no-install-recommends \
     dirmngr \
     gnupg2 \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # setup keys
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
@@ -29,7 +29,7 @@ RUN apt-get update && \
             tree \
             wget \
             python-pip && \
-    rm -rf /var/lib/apt/lists/*
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # setup environment
 ENV LANG C.UTF-8
@@ -63,7 +63,7 @@ RUN apt-get update && \
       --rosdistro ${ROS_DISTRO} \
       --as-root=apt:false && \
     pip install --upgrade ../rospkg/ && \
-    rm -rf /var/lib/apt/lists/*
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # HACK, replacing shell with bash for later docker build commands
 RUN mv /bin/sh /bin/sh-old && \


### PR DESCRIPTION
* `rm -rf /var/lib/apt/lists/*` only removes package index to ensure a fail
if someone just do an apt-get install without an update (out of date packages)

* but a lot of space is wasted due cached .deb packages:
apt-get install will download .deb files at /var/cache/apt/archives prior to
install them. These "cached" .deb files will be preserved for a while, wasting
docker image size forever and twice (one at this layer, and another one marking
them as deleted on an upper layer when cleanup task is called through cron)

* `apt-get clean` is mandatory to avoid space wasting (docker best practises)

Note (going further): you should avoid `apt-get clean` if package reinstall is
a common step on your workflow. Examples:
  - reinstall of initial version (default settings)
  - downgrade of a package (revert changes)
  - failsafe just if package get wrong (extremely rare)

And you want to run it offline or ensure same version even if package was
dropped from repository.