### PR TITLE
Bugfix of r2b3-ros1-bridge

### DIFF
--- a/ros2/r2b3/ubuntu/xenial/r2b3-ros1-bridge/Dockerfile
+++ b/ros2/r2b3/ubuntu/xenial/r2b3-ros1-bridge/Dockerfile
@@ -7,3 +7,8 @@ RUN apt-get update && apt-get install -y \
     ros-r2b3-ros1-bridge \
     && rm -rf /var/lib/apt/lists/*
 
+# setup entrypoint
+COPY ./ros2_entrypoint.sh /
+
+ENTRYPOINT ["/ros2_entrypoint.sh"]
+CMD ["bash"]

--- a/ros2/r2b3/ubuntu/xenial/r2b3-ros1-bridge/ros2_entrypoint.sh
+++ b/ros2/r2b3/ubuntu/xenial/r2b3-ros1-bridge/ros2_entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+# setup ros1 envrionment
+source "/opt/ros/kinetic/setup.bash"
+
+# setup ros1_bridge environment
+source "/opt/ros/$ROS2_DISTRO/share/ros1_bridge/local_setup.bash"
+exec "$@"


### PR DESCRIPTION
I found `osrf/ros2:r2b3-ros1-bridge` has lack of ROS1 environment variables.
Please see the result below.

~~~
% docker run -it osrf/ros2:r2b3-ros1-bridge ros2 run ros1_bridge dynamic_bridge
/opt/ros/r2b3/lib/ros1_bridge/dynamic_bridge: error while loading shared libraries: libroscpp.so: cannot open shared object file: No such file or directory
~~~

Current `osrf/ros2:r2b3-ros1-bridge` Dockerfile sources only ROS2 environment variables. So I fixed to source `/opt/ros/kinetic/setup.bash` first and then source `/opt/ros/$ROS2_DISTRO/share/ros1_bridge/local_setup.bash` based on https://github.com/ros2/ros1_bridge/blob/master/README.md.

After the bugfix I can `docker run -it osrf/ros2:r2b3-ros1-bridge ros2 run ros1_bridge dynamic_bridge` without error.