### PR TITLE
Ros2 entrypoint cleaning

### DIFF
--- a/ros2/.config/images.yaml.em
+++ b/ros2/.config/images.yaml.em
@@ -18,7 +18,6 @@ images:
         base_image: osrf/@(user_name):@(ros2distro_name)-core
         maintainer_name: @(maintainer_name)
         template_name: docker_images/create_ros2_image.Dockerfile.em
-        entrypoint_name: docker_images/ros2_entrypoint.sh
         template_packages:
             - docker_templates
         packages:
@@ -50,7 +49,6 @@ images:
         base_image: osrf/@(user_name):@(ros2distro_name)-basic
         maintainer_name: @(maintainer_name)
         template_name: docker_images/create_ros2_image.Dockerfile.em
-        entrypoint_name: docker_images/ros2_entrypoint.sh
         template_packages:
             - docker_templates
         ros2_packages:

--- a/ros2/ardent/ubuntu/xenial/ardent-basic/Dockerfile
+++ b/ros2/ardent/ubuntu/xenial/ardent-basic/Dockerfile
@@ -34,7 +34,3 @@ RUN apt-get update && apt-get install -y \
     ros-ardent-topic-monitor \
     && rm -rf /var/lib/apt/lists/*
 
-# setup entrypoint
-COPY ./ros2_entrypoint.sh /
-
-ENTRYPOINT ["/ros2_entrypoint.sh"]

--- a/ros2/ardent/ubuntu/xenial/ardent-basic/ros2_entrypoint.sh
+++ b/ros2/ardent/ubuntu/xenial/ardent-basic/ros2_entrypoint.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-set -e
-
-# setup ros2 environment
-source "/opt/ros/$ROS2_DISTRO/setup.bash"
-exec "$@"

--- a/ros2/ardent/ubuntu/xenial/ardent-full/Dockerfile
+++ b/ros2/ardent/ubuntu/xenial/ardent-full/Dockerfile
@@ -26,7 +26,3 @@ RUN apt-get update && apt-get install -y \
     ros-ardent-teleop-twist-keyboard \
     && rm -rf /var/lib/apt/lists/*
 
-# setup entrypoint
-COPY ./ros2_entrypoint.sh /
-
-ENTRYPOINT ["/ros2_entrypoint.sh"]

--- a/ros2/ardent/ubuntu/xenial/ardent-full/ros2_entrypoint.sh
+++ b/ros2/ardent/ubuntu/xenial/ardent-full/ros2_entrypoint.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-set -e
-
-# setup ros2 environment
-source "/opt/ros/$ROS2_DISTRO/setup.bash"
-exec "$@"

--- a/ros2/ardent/ubuntu/xenial/ardent-ros1-bridge/Dockerfile
+++ b/ros2/ardent/ubuntu/xenial/ardent-ros1-bridge/Dockerfile
@@ -12,3 +12,4 @@ RUN apt-get update && apt-get install -y \
 COPY ./ros1_bridge_entrypoint.sh /
 
 ENTRYPOINT ["/ros1_bridge_entrypoint.sh"]
+CMD ["bash"]

--- a/ros2/ardent/ubuntu/xenial/images.yaml.em
+++ b/ros2/ardent/ubuntu/xenial/images.yaml.em
@@ -18,7 +18,6 @@ images:
         base_image: osrf/@(user_name):@(ros2distro_name)-core
         maintainer_name: @(maintainer_name)
         template_name: docker_images/create_ros2_image.Dockerfile.em
-        entrypoint_name: docker_images/ros2_entrypoint.sh
         template_packages:
             - docker_templates
         packages:
@@ -50,7 +49,6 @@ images:
         base_image: osrf/@(user_name):@(ros2distro_name)-basic
         maintainer_name: @(maintainer_name)
         template_name: docker_images/create_ros2_image.Dockerfile.em
-        entrypoint_name: docker_images/ros2_entrypoint.sh
         template_packages:
             - docker_templates
         ros2_packages:

--- a/ros2/ardent/ubuntu/xenial/images.yaml.em
+++ b/ros2/ardent/ubuntu/xenial/images.yaml.em
@@ -52,7 +52,6 @@ images:
         template_packages:
             - docker_templates
         ros2_packages:
-            # - ament*
             - astra-camera
             - cartographer-ros
             - depthimage-to-laserscan

--- a/ros2/ros2
+++ b/ros2/ros2
@@ -9,21 +9,21 @@ GitRepo: https://github.com/osrf/docker_images.git
 
 Tags: ardent-core
 Architectures: amd64
-GitCommit: 83ba18815e9d30de2ba65224937289292ab3e402
+GitCommit: d8fa59baab89746795cb80a56153730d7902e815
 Directory: ros2/ardent/ubuntu/xenial/ardent-core
 
 Tags: ardent-basic
 Architectures: amd64
-GitCommit: 83ba18815e9d30de2ba65224937289292ab3e402
+GitCommit: d8fa59baab89746795cb80a56153730d7902e815
 Directory: ros2/ardent/ubuntu/xenial/ardent-basic
 
 Tags: ardent-full
 Architectures: amd64
-GitCommit: 83ba18815e9d30de2ba65224937289292ab3e402
+GitCommit: d8fa59baab89746795cb80a56153730d7902e815
 Directory: ros2/ardent/ubuntu/xenial/ardent-full
 
 Tags: ardent-ros1-bridge
 Architectures: amd64
-GitCommit: 83ba18815e9d30de2ba65224937289292ab3e402
+GitCommit: d8fa59baab89746795cb80a56153730d7902e815
 Directory: ros2/ardent/ubuntu/xenial/ardent-ros1-bridge
 


### PR DESCRIPTION
It seems specifying an entrypoint without a default command afterward results in the behavior where images do not necessarily inherent the base image's default command. This is a bit unitutve for users, as when no shell executable command is passed to the docker run, it does not drop into a shell session as it does only with the core image.

This also needs https://github.com/osrf/docker_templates/pull/31