### PR TITLE
Add Melodic dockerfiles

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ env:
   # ros2
   - HUB_REPO=ros2   HUB_RELEASE=ardent    HUB_OS_NAME=ubuntu HUB_OS_CODE_NAME=xenial
   # ros
+  - HUB_REPO=ros    HUB_RELEASE=melodic HUB_OS_NAME=ubuntu HUB_OS_CODE_NAME=bionic
+  - HUB_REPO=ros    HUB_RELEASE=melodic HUB_OS_NAME=debian HUB_OS_CODE_NAME=stretch
   - HUB_REPO=ros    HUB_RELEASE=lunar   HUB_OS_NAME=ubuntu HUB_OS_CODE_NAME=xenial
   - HUB_REPO=ros    HUB_RELEASE=lunar   HUB_OS_NAME=debian HUB_OS_CODE_NAME=stretch
   - HUB_REPO=ros    HUB_RELEASE=kinetic HUB_OS_NAME=ubuntu HUB_OS_CODE_NAME=xenial

--- a/ros/manifest.yaml
+++ b/ros/manifest.yaml
@@ -268,7 +268,55 @@ release_names:
                             perception:
                                 aliases:
                                     - "$release_name-perception-$os_code_name"
-
+    melodic:
+        eol: 2023-05
+        os_names:
+            ubuntu:
+                os_code_names:
+                    bionic:
+                        <<: *DEFAULT
+                        archs:
+                            - amd64
+                            - arm32v7
+                            - arm64v8
+                        tag_names:
+                            ros-core:
+                                aliases:
+                                    - "$release_name-ros-core"
+                                    - "$release_name-ros-core-$os_code_name"
+                            ros-base:
+                                aliases:
+                                    - "$release_name-ros-base"
+                                    - "$release_name-ros-base-$os_code_name"
+                                    - "$release_name"
+                            robot:
+                                aliases:
+                                    - "$release_name-robot"
+                                    - "$release_name-robot-$os_code_name"
+                            perception:
+                                aliases:
+                                    - "$release_name-perception"
+                                    - "$release_name-perception-$os_code_name"
+            debian:
+                os_code_names:
+                    stretch:
+                        <<: *DEFAULT
+                        archs:
+                            - amd64
+                            - arm64v8
+                        tag_names:
+                            ros-core:
+                                aliases:
+                                    - "$release_name-ros-core-$os_code_name"
+                            ros-base:
+                                aliases:
+                                    - "$release_name-ros-base-$os_code_name"
+                            robot:
+                                aliases:
+                                    - "$release_name-robot-$os_code_name"
+                            perception:
+                                aliases:
+                                    - "$release_name-perception-$os_code_name"
 meta:
     maintainers:
         - Tully Foote <tfoote+buildfarm@osrfoundation.org> (@tfoote)
@@ -371,6 +419,16 @@ hacks:
             ubuntu:
                 os_code_names:
                     xenial:
+                        tag_names:
+                            desktop:
+                                <<: *DEFAULT_HOOKS
+                            desktop-full:
+                                <<: *DEFAULT_HOOKS
+    melodic:
+        os_names:
+            ubuntu:
+                os_code_names:
+                    bionic:
                         tag_names:
                             desktop:
                                 <<: *DEFAULT_HOOKS

--- a/ros/melodic/debian/stretch/Makefile
+++ b/ros/melodic/debian/stretch/Makefile
@@ -1,0 +1,34 @@
+all: help
+
+help:
+	@echo ""
+	@echo "-- Help Menu"
+	@echo ""
+	@echo "   1. make build            - build all images"
+	@echo "   2. make pull             - pull all images"
+	@echo "   3. make clean            - remove all images"
+	@echo ""
+
+build:
+	@docker build --tag=ros:melodic-ros-core-stretch          ros-core/.
+	@docker build --tag=ros:melodic-ros-base-stretch          ros-base/.
+	@docker build --tag=ros:melodic-robot-stretch             robot/.
+	@docker build --tag=ros:melodic-perception-stretch        perception/.
+	# @docker build --tag=osrf/ros:melodic-desktop-stretch      desktop/.
+	# @docker build --tag=osrf/ros:melodic-desktop-full-stretch desktop-full/.
+
+pull:
+	@docker pull ros:melodic-ros-core-stretch
+	@docker pull ros:melodic-ros-base-stretch
+	@docker pull ros:melodic-robot-stretch
+	@docker pull ros:melodic-perception-stretch
+	# @docker pull osrf/ros:melodic-desktop-stretch
+	# @docker pull osrf/ros:melodic-desktop-full-stretch
+
+clean:
+	@docker rmi -f ros:melodic-ros-core-stretch
+	@docker rmi -f ros:melodic-ros-base-stretch
+	@docker rmi -f ros:melodic-robot-stretch
+	@docker rmi -f ros:melodic-perception-stretch
+	# @docker rmi -f osrf/ros:melodic-desktop-stretch
+	# @docker rmi -f osrf/ros:melodic-desktop-full-stretch

--- a/ros/melodic/debian/stretch/desktop-full/Dockerfile
+++ b/ros/melodic/debian/stretch/desktop-full/Dockerfile
@@ -1,0 +1,9 @@
+# This is an auto generated Dockerfile for ros:desktop-full
+# generated from docker_images/create_ros_image.Dockerfile.em
+FROM osrf/ros:melodic-desktop-stretch
+
+# install ros packages
+RUN apt-get update && apt-get install -y \
+    ros-melodic-desktop-full=1.4.0-0* \
+    && rm -rf /var/lib/apt/lists/*
+

--- a/ros/melodic/debian/stretch/desktop/Dockerfile
+++ b/ros/melodic/debian/stretch/desktop/Dockerfile
@@ -1,0 +1,9 @@
+# This is an auto generated Dockerfile for ros:desktop
+# generated from docker_images/create_ros_image.Dockerfile.em
+FROM ros:melodic-robot-stretch
+
+# install ros packages
+RUN apt-get update && apt-get install -y \
+    ros-melodic-desktop=1.4.0-0* \
+    && rm -rf /var/lib/apt/lists/*
+

--- a/ros/melodic/debian/stretch/images.yaml.em
+++ b/ros/melodic/debian/stretch/images.yaml.em
@@ -1,0 +1,56 @@
+%YAML 1.1
+# ROS Dockerfile database
+---
+images:
+    ros-core:
+        base_image: @(os_name):@(os_code_name)
+        maintainer_name: @(maintainer_name)
+        template_name: docker_images/create_ros_core_image.Dockerfile.em
+        entrypoint_name: docker_images/ros_entrypoint.sh
+        template_packages:
+            - docker_templates
+        packages:
+            - dirmngr
+            - gnupg2
+        ros_packages:
+            - ros-core
+    ros-base:
+        base_image: @(user_name):@(rosdistro_name)-ros-core-@(os_code_name)
+        maintainer_name: @(maintainer_name)
+        template_name: docker_images/create_ros_image.Dockerfile.em
+        template_packages:
+            - docker_templates
+        ros_packages:
+            - ros-base
+    robot:
+        base_image: @(user_name):@(rosdistro_name)-ros-base-@(os_code_name)
+        maintainer_name: @(maintainer_name)
+        template_name: docker_images/create_ros_image.Dockerfile.em
+        template_packages:
+            - docker_templates
+        ros_packages:
+            - robot
+    perception:
+        base_image: @(user_name):@(rosdistro_name)-ros-base-@(os_code_name)
+        maintainer_name: @(maintainer_name)
+        template_name: docker_images/create_ros_image.Dockerfile.em
+        template_packages:
+            - docker_templates
+        ros_packages:
+            - perception
+    desktop:
+        base_image: @(user_name):@(rosdistro_name)-robot-@(os_code_name)
+        maintainer_name: @(maintainer_name)
+        template_name: docker_images/create_ros_image.Dockerfile.em
+        template_packages:
+            - docker_templates
+        ros_packages:
+            - desktop
+    desktop-full:
+        base_image: osrf/@(user_name):@(rosdistro_name)-desktop-@(os_code_name)
+        maintainer_name: @(maintainer_name)
+        template_name: docker_images/create_ros_image.Dockerfile.em
+        template_packages:
+            - docker_templates
+        ros_packages:
+            - desktop-full

--- a/ros/melodic/debian/stretch/perception/Dockerfile
+++ b/ros/melodic/debian/stretch/perception/Dockerfile
@@ -1,0 +1,9 @@
+# This is an auto generated Dockerfile for ros:perception
+# generated from docker_images/create_ros_image.Dockerfile.em
+FROM ros:melodic-ros-base-stretch
+
+# install ros packages
+RUN apt-get update && apt-get install -y \
+    ros-melodic-perception=1.4.0-0* \
+    && rm -rf /var/lib/apt/lists/*
+

--- a/ros/melodic/debian/stretch/platform.yaml
+++ b/ros/melodic/debian/stretch/platform.yaml
@@ -1,0 +1,13 @@
+%YAML 1.1
+# ROS Dockerfile database
+---
+platform:
+    os_name: debian
+    os_code_name: stretch
+    rosdistro_name: melodic
+    user_name: ros
+    maintainer_name:
+    arch: amd64
+    type: distribution
+    version:
+    release: ros

--- a/ros/melodic/debian/stretch/robot/Dockerfile
+++ b/ros/melodic/debian/stretch/robot/Dockerfile
@@ -1,0 +1,9 @@
+# This is an auto generated Dockerfile for ros:robot
+# generated from docker_images/create_ros_image.Dockerfile.em
+FROM ros:melodic-ros-base-stretch
+
+# install ros packages
+RUN apt-get update && apt-get install -y \
+    ros-melodic-robot=1.4.0-0* \
+    && rm -rf /var/lib/apt/lists/*
+

--- a/ros/melodic/debian/stretch/ros-base/Dockerfile
+++ b/ros/melodic/debian/stretch/ros-base/Dockerfile
@@ -1,0 +1,9 @@
+# This is an auto generated Dockerfile for ros:ros-base
+# generated from docker_images/create_ros_image.Dockerfile.em
+FROM ros:melodic-ros-core-stretch
+
+# install ros packages
+RUN apt-get update && apt-get install -y \
+    ros-melodic-ros-base=1.4.0-0* \
+    && rm -rf /var/lib/apt/lists/*
+

--- a/ros/melodic/debian/stretch/ros-core/Dockerfile
+++ b/ros/melodic/debian/stretch/ros-core/Dockerfile
@@ -2,10 +2,6 @@
 # generated from docker_images/create_ros_core_image.Dockerfile.em
 FROM debian:stretch
 
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    tzdata \
-    && rm -rf /var/lib/apt/lists/*
-
 # install packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
     dirmngr \

--- a/ros/melodic/debian/stretch/ros-core/Dockerfile
+++ b/ros/melodic/debian/stretch/ros-core/Dockerfile
@@ -1,0 +1,42 @@
+# This is an auto generated Dockerfile for ros:ros-core
+# generated from docker_images/create_ros_core_image.Dockerfile.em
+FROM debian:stretch
+
+# install packages
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    dirmngr \
+    gnupg2 \
+    && rm -rf /var/lib/apt/lists/*
+
+# setup keys
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
+
+# setup sources.list
+RUN echo "deb http://packages.ros.org/ros/ubuntu stretch main" > /etc/apt/sources.list.d/ros-latest.list
+
+# install bootstrap tools
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    python-rosdep \
+    python-rosinstall \
+    python-vcstools \
+    && rm -rf /var/lib/apt/lists/*
+
+# setup environment
+ENV LANG C.UTF-8
+ENV LC_ALL C.UTF-8
+
+# bootstrap rosdep
+RUN rosdep init \
+    && rosdep update
+
+# install ros packages
+ENV ROS_DISTRO melodic
+RUN apt-get update && apt-get install -y \
+    ros-melodic-ros-core=1.4.0-0* \
+    && rm -rf /var/lib/apt/lists/*
+
+# setup entrypoint
+COPY ./ros_entrypoint.sh /
+
+ENTRYPOINT ["/ros_entrypoint.sh"]
+CMD ["bash"]

--- a/ros/melodic/debian/stretch/ros-core/Dockerfile
+++ b/ros/melodic/debian/stretch/ros-core/Dockerfile
@@ -2,6 +2,10 @@
 # generated from docker_images/create_ros_core_image.Dockerfile.em
 FROM debian:stretch
 
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    tzdata \
+    && rm -rf /var/lib/apt/lists/*
+
 # install packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
     dirmngr \

--- a/ros/melodic/debian/stretch/ros-core/ros_entrypoint.sh
+++ b/ros/melodic/debian/stretch/ros-core/ros_entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+# setup ros environment
+source "/opt/ros/$ROS_DISTRO/setup.bash"
+exec "$@"

--- a/ros/melodic/ubuntu/bionic/Makefile
+++ b/ros/melodic/ubuntu/bionic/Makefile
@@ -1,0 +1,34 @@
+all: help
+
+help:
+	@echo ""
+	@echo "-- Help Menu"
+	@echo ""
+	@echo "   1. make build            - build all images"
+	@echo "   2. make pull             - pull all images"
+	@echo "   3. make clean            - remove all images"
+	@echo ""
+
+build:
+	@docker build --tag=ros:melodic-ros-core-bionic          ros-core/.
+	@docker build --tag=ros:melodic-ros-base-bionic          ros-base/.
+	@docker build --tag=ros:melodic-robot-bionic             robot/.
+	@docker build --tag=ros:melodic-perception-bionic        perception/.
+	# @docker build --tag=osrf/ros:melodic-desktop-bionic      desktop/.
+	# @docker build --tag=osrf/ros:melodic-desktop-full-bionic desktop-full/.
+
+pull:
+	@docker pull ros:melodic-ros-core-bionic
+	@docker pull ros:melodic-ros-base-bionic
+	@docker pull ros:melodic-robot-bionic
+	@docker pull ros:melodic-perception-bionic
+	# @docker pull osrf/ros:melodic-desktop-bionic
+	# @docker pull osrf/ros:melodic-desktop-full-bionic
+
+clean:
+	@docker rmi -f ros:melodic-ros-core-bionic
+	@docker rmi -f ros:melodic-ros-base-bionic
+	@docker rmi -f ros:melodic-robot-bionic
+	@docker rmi -f ros:melodic-perception-bionic
+	# @docker rmi -f osrf/ros:melodic-desktop-bionic
+	# @docker rmi -f osrf/ros:melodic-desktop-full-bionic

--- a/ros/melodic/ubuntu/bionic/desktop-full/Dockerfile
+++ b/ros/melodic/ubuntu/bionic/desktop-full/Dockerfile
@@ -1,0 +1,9 @@
+# This is an auto generated Dockerfile for ros:desktop-full
+# generated from docker_images/create_ros_image.Dockerfile.em
+FROM osrf/ros:melodic-desktop-bionic
+
+# install ros packages
+RUN apt-get update && apt-get install -y \
+    ros-melodic-desktop-full=1.4.0-0* \
+    && rm -rf /var/lib/apt/lists/*
+

--- a/ros/melodic/ubuntu/bionic/desktop-full/hooks/post_push
+++ b/ros/melodic/ubuntu/bionic/desktop-full/hooks/post_push
@@ -1,0 +1,14 @@
+#!/bin/bash
+# http://windsock.io/automated-docker-image-builds-with-multiple-tags/
+
+set -e
+
+# Parse image name for repo name
+tagStart=$(expr index "$IMAGE_NAME" :)
+repoName=${IMAGE_NAME:0:tagStart-1}
+
+# Tag and push image for each additional tag
+for tag in melodic-desktop-full; do
+    docker tag $IMAGE_NAME ${repoName}:${tag}
+    docker push ${repoName}:${tag}
+done

--- a/ros/melodic/ubuntu/bionic/desktop/Dockerfile
+++ b/ros/melodic/ubuntu/bionic/desktop/Dockerfile
@@ -1,0 +1,9 @@
+# This is an auto generated Dockerfile for ros:desktop
+# generated from docker_images/create_ros_image.Dockerfile.em
+FROM ros:melodic-robot-bionic
+
+# install ros packages
+RUN apt-get update && apt-get install -y \
+    ros-melodic-desktop=1.4.0-0* \
+    && rm -rf /var/lib/apt/lists/*
+

--- a/ros/melodic/ubuntu/bionic/desktop/hooks/post_push
+++ b/ros/melodic/ubuntu/bionic/desktop/hooks/post_push
@@ -1,0 +1,14 @@
+#!/bin/bash
+# http://windsock.io/automated-docker-image-builds-with-multiple-tags/
+
+set -e
+
+# Parse image name for repo name
+tagStart=$(expr index "$IMAGE_NAME" :)
+repoName=${IMAGE_NAME:0:tagStart-1}
+
+# Tag and push image for each additional tag
+for tag in melodic-desktop; do
+    docker tag $IMAGE_NAME ${repoName}:${tag}
+    docker push ${repoName}:${tag}
+done

--- a/ros/melodic/ubuntu/bionic/images.yaml.em
+++ b/ros/melodic/ubuntu/bionic/images.yaml.em
@@ -1,0 +1,56 @@
+%YAML 1.1
+# ROS Dockerfile database
+---
+images:
+    ros-core:
+        base_image: @(os_name):@(os_code_name)
+        maintainer_name: @(maintainer_name)
+        template_name: docker_images/create_ros_core_image.Dockerfile.em
+        entrypoint_name: docker_images/ros_entrypoint.sh
+        template_packages:
+            - docker_templates
+        packages:
+            - dirmngr
+            - gnupg2
+        ros_packages:
+            - ros-core
+    ros-base:
+        base_image: @(user_name):@(rosdistro_name)-ros-core-@(os_code_name)
+        maintainer_name: @(maintainer_name)
+        template_name: docker_images/create_ros_image.Dockerfile.em
+        template_packages:
+            - docker_templates
+        ros_packages:
+            - ros-base
+    robot:
+        base_image: @(user_name):@(rosdistro_name)-ros-base-@(os_code_name)
+        maintainer_name: @(maintainer_name)
+        template_name: docker_images/create_ros_image.Dockerfile.em
+        template_packages:
+            - docker_templates
+        ros_packages:
+            - robot
+    perception:
+        base_image: @(user_name):@(rosdistro_name)-ros-base-@(os_code_name)
+        maintainer_name: @(maintainer_name)
+        template_name: docker_images/create_ros_image.Dockerfile.em
+        template_packages:
+            - docker_templates
+        ros_packages:
+            - perception
+    desktop:
+        base_image: @(user_name):@(rosdistro_name)-robot-@(os_code_name)
+        maintainer_name: @(maintainer_name)
+        template_name: docker_images/create_ros_image.Dockerfile.em
+        template_packages:
+            - docker_templates
+        ros_packages:
+            - desktop
+    desktop-full:
+        base_image: osrf/@(user_name):@(rosdistro_name)-desktop-@(os_code_name)
+        maintainer_name: @(maintainer_name)
+        template_name: docker_images/create_ros_image.Dockerfile.em
+        template_packages:
+            - docker_templates
+        ros_packages:
+            - desktop-full

--- a/ros/melodic/ubuntu/bionic/perception/Dockerfile
+++ b/ros/melodic/ubuntu/bionic/perception/Dockerfile
@@ -1,0 +1,9 @@
+# This is an auto generated Dockerfile for ros:perception
+# generated from docker_images/create_ros_image.Dockerfile.em
+FROM ros:melodic-ros-base-bionic
+
+# install ros packages
+RUN apt-get update && apt-get install -y \
+    ros-melodic-perception=1.4.0-0* \
+    && rm -rf /var/lib/apt/lists/*
+

--- a/ros/melodic/ubuntu/bionic/platform.yaml
+++ b/ros/melodic/ubuntu/bionic/platform.yaml
@@ -1,0 +1,13 @@
+%YAML 1.1
+# ROS Dockerfile database
+---
+platform:
+    os_name: ubuntu
+    os_code_name: bionic
+    rosdistro_name: melodic
+    user_name: ros
+    maintainer_name:
+    arch: amd64
+    type: distribution
+    version:
+    release: ros

--- a/ros/melodic/ubuntu/bionic/robot/Dockerfile
+++ b/ros/melodic/ubuntu/bionic/robot/Dockerfile
@@ -1,0 +1,9 @@
+# This is an auto generated Dockerfile for ros:robot
+# generated from docker_images/create_ros_image.Dockerfile.em
+FROM ros:melodic-ros-base-bionic
+
+# install ros packages
+RUN apt-get update && apt-get install -y \
+    ros-melodic-robot=1.4.0-0* \
+    && rm -rf /var/lib/apt/lists/*
+

--- a/ros/melodic/ubuntu/bionic/ros-base/Dockerfile
+++ b/ros/melodic/ubuntu/bionic/ros-base/Dockerfile
@@ -1,0 +1,9 @@
+# This is an auto generated Dockerfile for ros:ros-base
+# generated from docker_images/create_ros_image.Dockerfile.em
+FROM ros:melodic-ros-core-bionic
+
+# install ros packages
+RUN apt-get update && apt-get install -y \
+    ros-melodic-ros-base=1.4.0-0* \
+    && rm -rf /var/lib/apt/lists/*
+

--- a/ros/melodic/ubuntu/bionic/ros-core/Dockerfile
+++ b/ros/melodic/ubuntu/bionic/ros-core/Dockerfile
@@ -2,9 +2,9 @@
 # generated from docker_images/create_ros_core_image.Dockerfile.em
 FROM ubuntu:bionic
 
-RUN echo 'Etc/UTC' > /etc/timezone
-RUN ln -s /usr/share/zoneinfo/Etc/UTC /etc/localtime
-RUN apt-get update && apt-get install -q -y tzdata && rm -rf /var/lib/apt/lists/*
+RUN echo 'Etc/UTC' > /etc/timezone && \
+    ln -s /usr/share/zoneinfo/Etc/UTC /etc/localtime && \
+    apt-get update && apt-get install -q -y tzdata && rm -rf /var/lib/apt/lists/*
 
 
 # install packages

--- a/ros/melodic/ubuntu/bionic/ros-core/Dockerfile
+++ b/ros/melodic/ubuntu/bionic/ros-core/Dockerfile
@@ -1,0 +1,42 @@
+# This is an auto generated Dockerfile for ros:ros-core
+# generated from docker_images/create_ros_core_image.Dockerfile.em
+FROM ubuntu:bionic
+
+# install packages
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    dirmngr \
+    gnupg2 \
+    && rm -rf /var/lib/apt/lists/*
+
+# setup keys
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
+
+# setup sources.list
+RUN echo "deb http://packages.ros.org/ros/ubuntu bionic main" > /etc/apt/sources.list.d/ros-latest.list
+
+# install bootstrap tools
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    python-rosdep \
+    python-rosinstall \
+    python-vcstools \
+    && rm -rf /var/lib/apt/lists/*
+
+# setup environment
+ENV LANG C.UTF-8
+ENV LC_ALL C.UTF-8
+
+# bootstrap rosdep
+RUN rosdep init \
+    && rosdep update
+
+# install ros packages
+ENV ROS_DISTRO melodic
+RUN apt-get update && apt-get install -y \
+    ros-melodic-ros-core=1.4.0-0* \
+    && rm -rf /var/lib/apt/lists/*
+
+# setup entrypoint
+COPY ./ros_entrypoint.sh /
+
+ENTRYPOINT ["/ros_entrypoint.sh"]
+CMD ["bash"]

--- a/ros/melodic/ubuntu/bionic/ros-core/Dockerfile
+++ b/ros/melodic/ubuntu/bionic/ros-core/Dockerfile
@@ -2,6 +2,10 @@
 # generated from docker_images/create_ros_core_image.Dockerfile.em
 FROM ubuntu:bionic
 
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    tzdata \
+    && rm -rf /var/lib/apt/lists/*
+
 # install packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
     dirmngr \

--- a/ros/melodic/ubuntu/bionic/ros-core/Dockerfile
+++ b/ros/melodic/ubuntu/bionic/ros-core/Dockerfile
@@ -2,9 +2,10 @@
 # generated from docker_images/create_ros_core_image.Dockerfile.em
 FROM ubuntu:bionic
 
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    tzdata \
-    && rm -rf /var/lib/apt/lists/*
+RUN echo 'Etc/UTC' > /etc/timezone
+RUN ln -s /usr/share/zoneinfo/Etc/UTC /etc/localtime
+RUN apt-get update && apt-get install -q -y tzdata && rm -rf /var/lib/apt/lists/*
+
 
 # install packages
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/ros/melodic/ubuntu/bionic/ros-core/ros_entrypoint.sh
+++ b/ros/melodic/ubuntu/bionic/ros-core/ros_entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+# setup ros environment
+source "/opt/ros/$ROS_DISTRO/setup.bash"
+exec "$@"

--- a/ros/ros
+++ b/ros/ros
@@ -127,3 +127,53 @@ Architectures: amd64, arm64v8
 GitCommit: 4d697291568d826da713ef8b20be58fa8e86e4f5
 Directory: ros/lunar/debian/stretch/perception
 
+
+################################################################################
+# Release: melodic
+
+########################################
+# Distro: ubuntu:bionic
+
+Tags: melodic-ros-core, melodic-ros-core-bionic
+Architectures: amd64, arm32v7, arm64v8
+GitCommit: 58e5da985c78ee1daaae8bc3f8c01ecff64170d6
+Directory: ros/melodic/ubuntu/bionic/ros-core
+
+Tags: melodic-ros-base, melodic-ros-base-bionic, melodic
+Architectures: amd64, arm32v7, arm64v8
+GitCommit: 58e5da985c78ee1daaae8bc3f8c01ecff64170d6
+Directory: ros/melodic/ubuntu/bionic/ros-base
+
+Tags: melodic-robot, melodic-robot-bionic
+Architectures: amd64, arm32v7, arm64v8
+GitCommit: 58e5da985c78ee1daaae8bc3f8c01ecff64170d6
+Directory: ros/melodic/ubuntu/bionic/robot
+
+Tags: melodic-perception, melodic-perception-bionic
+Architectures: amd64, arm32v7, arm64v8
+GitCommit: 58e5da985c78ee1daaae8bc3f8c01ecff64170d6
+Directory: ros/melodic/ubuntu/bionic/perception
+
+########################################
+# Distro: debian:stretch
+
+Tags: melodic-ros-core-stretch
+Architectures: amd64, arm64v8
+GitCommit: 58e5da985c78ee1daaae8bc3f8c01ecff64170d6
+Directory: ros/melodic/debian/stretch/ros-core
+
+Tags: melodic-ros-base-stretch
+Architectures: amd64, arm64v8
+GitCommit: 58e5da985c78ee1daaae8bc3f8c01ecff64170d6
+Directory: ros/melodic/debian/stretch/ros-base
+
+Tags: melodic-robot-stretch
+Architectures: amd64, arm64v8
+GitCommit: 58e5da985c78ee1daaae8bc3f8c01ecff64170d6
+Directory: ros/melodic/debian/stretch/robot
+
+Tags: melodic-perception-stretch
+Architectures: amd64, arm64v8
+GitCommit: 58e5da985c78ee1daaae8bc3f8c01ecff64170d6
+Directory: ros/melodic/debian/stretch/perception
+

--- a/ros/ros
+++ b/ros/ros
@@ -136,22 +136,22 @@ Directory: ros/lunar/debian/stretch/perception
 
 Tags: melodic-ros-core, melodic-ros-core-bionic
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 58e5da985c78ee1daaae8bc3f8c01ecff64170d6
+GitCommit: 0b131b18d6b55681d429b73e94da0ce18fa84811
 Directory: ros/melodic/ubuntu/bionic/ros-core
 
 Tags: melodic-ros-base, melodic-ros-base-bionic, melodic
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 58e5da985c78ee1daaae8bc3f8c01ecff64170d6
+GitCommit: 0b131b18d6b55681d429b73e94da0ce18fa84811
 Directory: ros/melodic/ubuntu/bionic/ros-base
 
 Tags: melodic-robot, melodic-robot-bionic
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 58e5da985c78ee1daaae8bc3f8c01ecff64170d6
+GitCommit: 0b131b18d6b55681d429b73e94da0ce18fa84811
 Directory: ros/melodic/ubuntu/bionic/robot
 
 Tags: melodic-perception, melodic-perception-bionic
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 58e5da985c78ee1daaae8bc3f8c01ecff64170d6
+GitCommit: 0b131b18d6b55681d429b73e94da0ce18fa84811
 Directory: ros/melodic/ubuntu/bionic/perception
 
 ########################################
@@ -159,21 +159,21 @@ Directory: ros/melodic/ubuntu/bionic/perception
 
 Tags: melodic-ros-core-stretch
 Architectures: amd64, arm64v8
-GitCommit: 58e5da985c78ee1daaae8bc3f8c01ecff64170d6
+GitCommit: 0b131b18d6b55681d429b73e94da0ce18fa84811
 Directory: ros/melodic/debian/stretch/ros-core
 
 Tags: melodic-ros-base-stretch
 Architectures: amd64, arm64v8
-GitCommit: 58e5da985c78ee1daaae8bc3f8c01ecff64170d6
+GitCommit: 0b131b18d6b55681d429b73e94da0ce18fa84811
 Directory: ros/melodic/debian/stretch/ros-base
 
 Tags: melodic-robot-stretch
 Architectures: amd64, arm64v8
-GitCommit: 58e5da985c78ee1daaae8bc3f8c01ecff64170d6
+GitCommit: 0b131b18d6b55681d429b73e94da0ce18fa84811
 Directory: ros/melodic/debian/stretch/robot
 
 Tags: melodic-perception-stretch
 Architectures: amd64, arm64v8
-GitCommit: 58e5da985c78ee1daaae8bc3f8c01ecff64170d6
+GitCommit: 0b131b18d6b55681d429b73e94da0ce18fa84811
 Directory: ros/melodic/debian/stretch/perception
 


### PR DESCRIPTION
Note: I didnt add artful as it's almost EOL, so this adds only Debian Stretch and Ubuntu Bionic.

Depending on the final state of https://github.com/osrf/docker_templates/pull/34 this PR may require changes before being merged and released. 