### PR TITLE
update image.yaml.em for all images

### DIFF
--- a/gazebo/4/ubuntu/trusty/images.yaml.em
+++ b/gazebo/4/ubuntu/trusty/images.yaml.em
@@ -25,7 +25,7 @@ images:
         template_name: docker_images/create_gzweb_image.Dockerfile.em
         template_packages:
             - docker_templates
-        packages:
+        upstream_packages:
             - build-essential
             - cmake
             - imagemagick
@@ -48,7 +48,7 @@ images:
         template_name: docker_images/create_gzclient_image.Dockerfile.em
         template_packages:
             - docker_templates
-        packages:
+        upstream_packages:
             - binutils
             - mesa-utils
             - module-init-tools

--- a/gazebo/5/ubuntu/trusty/images.yaml.em
+++ b/gazebo/5/ubuntu/trusty/images.yaml.em
@@ -25,7 +25,7 @@ images:
         template_name: docker_images/create_gzweb_image.Dockerfile.em
         template_packages:
             - docker_templates
-        packages:
+        upstream_packages:
             - build-essential
             - cmake
             - imagemagick
@@ -48,7 +48,7 @@ images:
         template_name: docker_images/create_gzclient_image.Dockerfile.em
         template_packages:
             - docker_templates
-        packages:
+        upstream_packages:
             - binutils
             - mesa-utils
             - module-init-tools

--- a/gazebo/6/ubuntu/trusty/images.yaml.em
+++ b/gazebo/6/ubuntu/trusty/images.yaml.em
@@ -25,7 +25,7 @@ images:
         template_name: docker_images/create_gzweb_image.Dockerfile.em
         template_packages:
             - docker_templates
-        packages:
+        upstream_packages:
             - build-essential
             - cmake
             - imagemagick
@@ -48,7 +48,7 @@ images:
         template_name: docker_images/create_gzclient_image.Dockerfile.em
         template_packages:
             - docker_templates
-        packages:
+        upstream_packages:
             - binutils
             - mesa-utils
             - module-init-tools

--- a/gazebo/7/ubuntu/xenial/images.yaml.em
+++ b/gazebo/7/ubuntu/xenial/images.yaml.em
@@ -25,7 +25,7 @@ images:
         template_name: docker_images/create_gzweb_image.Dockerfile.em
         template_packages:
             - docker_templates
-        packages:
+        upstream_packages:
             - build-essential
             - cmake
             - imagemagick
@@ -48,7 +48,7 @@ images:
         template_name: docker_images/create_gzclient_image.Dockerfile.em
         template_packages:
             - docker_templates
-        packages:
+        upstream_packages:
             - binutils
             - mesa-utils
             - module-init-tools

--- a/gazebo/8/ubuntu/xenial/images.yaml.em
+++ b/gazebo/8/ubuntu/xenial/images.yaml.em
@@ -25,7 +25,7 @@ images:
         template_name: docker_images/create_gzweb_image.Dockerfile.em
         template_packages:
             - docker_templates
-        packages:
+        upstream_packages:
             - build-essential
             - cmake
             - imagemagick
@@ -48,7 +48,7 @@ images:
         template_name: docker_images/create_gzclient_image.Dockerfile.em
         template_packages:
             - docker_templates
-        packages:
+        upstream_packages:
             - binutils
             - mesa-utils
             - module-init-tools

--- a/gazebo/9/ubuntu/xenial/images.yaml.em
+++ b/gazebo/9/ubuntu/xenial/images.yaml.em
@@ -25,7 +25,7 @@ images:
         template_name: docker_images/create_gzweb_image.Dockerfile.em
         template_packages:
             - docker_templates
-        packages:
+        upstream_packages:
             - build-essential
             - cmake
             - imagemagick
@@ -48,7 +48,7 @@ images:
         template_name: docker_images/create_gzclient_image.Dockerfile.em
         template_packages:
             - docker_templates
-        packages:
+        upstream_packages:
             - binutils
             - mesa-utils
             - module-init-tools

--- a/ros/indigo/ubuntu/trusty/images.yaml.em
+++ b/ros/indigo/ubuntu/trusty/images.yaml.em
@@ -9,9 +9,6 @@ images:
         entrypoint_name: docker_images/ros_entrypoint.sh
         template_packages:
             - docker_templates
-        packages:
-            - dirmngr
-            - gnupg2
         ros_packages:
             - ros-core
     ros-base:

--- a/ros/jade/ubuntu/trusty/images.yaml.em
+++ b/ros/jade/ubuntu/trusty/images.yaml.em
@@ -9,9 +9,6 @@ images:
         entrypoint_name: docker_images/ros_entrypoint.sh
         template_packages:
             - docker_templates
-        packages:
-            - dirmngr
-            - gnupg2
         ros_packages:
             - ros-core
     ros-base:

--- a/ros/kinetic/debian/jessie/images.yaml.em
+++ b/ros/kinetic/debian/jessie/images.yaml.em
@@ -9,9 +9,6 @@ images:
         entrypoint_name: docker_images/ros_entrypoint.sh
         template_packages:
             - docker_templates
-        packages:
-            - dirmngr
-            - gnupg2
         ros_packages:
             - ros-core
     ros-base:

--- a/ros/kinetic/ubuntu/xenial/images.yaml.em
+++ b/ros/kinetic/ubuntu/xenial/images.yaml.em
@@ -9,9 +9,6 @@ images:
         entrypoint_name: docker_images/ros_entrypoint.sh
         template_packages:
             - docker_templates
-        packages:
-            - dirmngr
-            - gnupg2
         ros_packages:
             - ros-core
     ros-base:

--- a/ros/lunar/debian/stretch/images.yaml.em
+++ b/ros/lunar/debian/stretch/images.yaml.em
@@ -9,9 +9,6 @@ images:
         entrypoint_name: docker_images/ros_entrypoint.sh
         template_packages:
             - docker_templates
-        packages:
-            - dirmngr
-            - gnupg2
         ros_packages:
             - ros-core
     ros-base:

--- a/ros/lunar/ubuntu/xenial/images.yaml.em
+++ b/ros/lunar/ubuntu/xenial/images.yaml.em
@@ -9,9 +9,6 @@ images:
         entrypoint_name: docker_images/ros_entrypoint.sh
         template_packages:
             - docker_templates
-        packages:
-            - dirmngr
-            - gnupg2
         ros_packages:
             - ros-core
     ros-base:

--- a/ros/lunar/ubuntu/zesty/images.yaml.em
+++ b/ros/lunar/ubuntu/zesty/images.yaml.em
@@ -9,9 +9,6 @@ images:
         entrypoint_name: docker_images/ros_entrypoint.sh
         template_packages:
             - docker_templates
-        packages:
-            - dirmngr
-            - gnupg2
         ros_packages:
             - ros-core
     ros-base:

--- a/ros/melodic/debian/stretch/images.yaml.em
+++ b/ros/melodic/debian/stretch/images.yaml.em
@@ -9,9 +9,6 @@ images:
         entrypoint_name: docker_images/ros_entrypoint.sh
         template_packages:
             - docker_templates
-        packages:
-            - dirmngr
-            - gnupg2
         ros_packages:
             - ros-core
     ros-base:

--- a/ros/melodic/ubuntu/bionic/images.yaml.em
+++ b/ros/melodic/ubuntu/bionic/images.yaml.em
@@ -9,9 +9,6 @@ images:
         entrypoint_name: docker_images/ros_entrypoint.sh
         template_packages:
             - docker_templates
-        packages:
-            - dirmngr
-            - gnupg2
         ros_packages:
             - ros-core
     ros-base:

--- a/ros2/.config/images.yaml.em
+++ b/ros2/.config/images.yaml.em
@@ -9,8 +9,6 @@ images:
         entrypoint_name: docker_images/ros2_entrypoint.sh
         template_packages:
             - docker_templates
-        upstream_packages:
-            - python3-pip
         ros2_packages:
             - rclcpp
             - rclpy
@@ -20,8 +18,6 @@ images:
         template_name: docker_images/create_ros2_image.Dockerfile.em
         template_packages:
             - docker_templates
-        upstream_packages:
-            - python3-pip
         pip3_install:
             - argcomplete
         ros2_packages:

--- a/ros2/ardent/ubuntu/xenial/images.yaml.em
+++ b/ros2/ardent/ubuntu/xenial/images.yaml.em
@@ -9,8 +9,6 @@ images:
         entrypoint_name: docker_images/ros2_entrypoint.sh
         template_packages:
             - docker_templates
-        packages:
-            - python3-pip
         ros2_packages:
             - rclcpp
             - rclpy
@@ -20,8 +18,6 @@ images:
         template_name: docker_images/create_ros2_image.Dockerfile.em
         template_packages:
             - docker_templates
-        packages:
-            - python3-pip
         pip3_install:
             - argcomplete
         ros2_packages:

--- a/ros2/source/images.yaml.em
+++ b/ros2/source/images.yaml.em
@@ -43,7 +43,6 @@ images:
             - python3-mock
             - python3-nose
             - python3-pep8
-            - python3-pip
             - python3-pyparsing
             - python3-setuptools
             - python3-yaml


### PR DESCRIPTION
Follow-up of https://github.com/osrf/docker_images/pull/136

Autogenerated PRs don't regenerate images.yaml.em, this updates them all to use the new `upstream_packages` variable name.

This also removes python3-pip from being passed explicitly so that it's installed only when necessary: https://github.com/osrf/docker_templates/pull/38