### PR TITLE
EOL jessie

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ env:
   - HUB_REPO=ros    HUB_RELEASE=lunar   HUB_OS_NAME=ubuntu HUB_OS_CODE_NAME=xenial
   - HUB_REPO=ros    HUB_RELEASE=lunar   HUB_OS_NAME=debian HUB_OS_CODE_NAME=stretch
   - HUB_REPO=ros    HUB_RELEASE=kinetic HUB_OS_NAME=ubuntu HUB_OS_CODE_NAME=xenial
-  - HUB_REPO=ros    HUB_RELEASE=kinetic HUB_OS_NAME=debian HUB_OS_CODE_NAME=jessie
   - HUB_REPO=ros    HUB_RELEASE=indigo  HUB_OS_NAME=ubuntu HUB_OS_CODE_NAME=trusty
   # gazebo
   - HUB_REPO=gazebo HUB_RELEASE=9       HUB_OS_NAME=ubuntu HUB_OS_CODE_NAME=xenial

--- a/ros/manifest.yaml
+++ b/ros/manifest.yaml
@@ -188,18 +188,19 @@ release_names:
                             - amd64
                             - arm64v8
                         tag_names:
-                            ros-core:
-                                aliases:
-                                    - "$release_name-ros-core-$os_code_name"
-                            ros-base:
-                                aliases:
-                                    - "$release_name-ros-base-$os_code_name"
-                            robot:
-                                aliases:
-                                    - "$release_name-robot-$os_code_name"
-                            perception:
-                                aliases:
-                                    - "$release_name-perception-$os_code_name"
+                            # EOL
+                            # ros-core:
+                            #     aliases:
+                            #         - "$release_name-ros-core-$os_code_name"
+                            # ros-base:
+                            #     aliases:
+                            #         - "$release_name-ros-base-$os_code_name"
+                            # robot:
+                            #     aliases:
+                            #         - "$release_name-robot-$os_code_name"
+                            # perception:
+                            #     aliases:
+                            #         - "$release_name-perception-$os_code_name"
     lunar:
         eol: 2019-05
         os_names:

--- a/ros/ros
+++ b/ros/ros
@@ -9,22 +9,22 @@ GitRepo: https://github.com/osrf/docker_images.git
 
 Tags: indigo-ros-core, indigo-ros-core-trusty
 Architectures: amd64, arm32v7
-GitCommit: b61856a3f10e2b472b10a26dbca98f7803df25c3
+GitCommit: 49d22242e02e9c541a9e85b657e1785617b6f470
 Directory: ros/indigo/ubuntu/trusty/ros-core
 
 Tags: indigo-ros-base, indigo-ros-base-trusty, indigo
 Architectures: amd64, arm32v7
-GitCommit: b61856a3f10e2b472b10a26dbca98f7803df25c3
+GitCommit: 49d22242e02e9c541a9e85b657e1785617b6f470
 Directory: ros/indigo/ubuntu/trusty/ros-base
 
 Tags: indigo-robot, indigo-robot-trusty
 Architectures: amd64, arm32v7
-GitCommit: b61856a3f10e2b472b10a26dbca98f7803df25c3
+GitCommit: 49d22242e02e9c541a9e85b657e1785617b6f470
 Directory: ros/indigo/ubuntu/trusty/robot
 
 Tags: indigo-perception, indigo-perception-trusty
 Architectures: amd64, arm32v7
-GitCommit: b61856a3f10e2b472b10a26dbca98f7803df25c3
+GitCommit: 49d22242e02e9c541a9e85b657e1785617b6f470
 Directory: ros/indigo/ubuntu/trusty/perception
 
 
@@ -36,46 +36,23 @@ Directory: ros/indigo/ubuntu/trusty/perception
 
 Tags: kinetic-ros-core, kinetic-ros-core-xenial
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 806c398cb7aef71eb81138666315674da2d4b233
+GitCommit: 49d22242e02e9c541a9e85b657e1785617b6f470
 Directory: ros/kinetic/ubuntu/xenial/ros-core
 
 Tags: kinetic-ros-base, kinetic-ros-base-xenial, kinetic
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 806c398cb7aef71eb81138666315674da2d4b233
+GitCommit: 49d22242e02e9c541a9e85b657e1785617b6f470
 Directory: ros/kinetic/ubuntu/xenial/ros-base
 
 Tags: kinetic-robot, kinetic-robot-xenial
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 806c398cb7aef71eb81138666315674da2d4b233
+GitCommit: 49d22242e02e9c541a9e85b657e1785617b6f470
 Directory: ros/kinetic/ubuntu/xenial/robot
 
 Tags: kinetic-perception, kinetic-perception-xenial
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 806c398cb7aef71eb81138666315674da2d4b233
+GitCommit: 49d22242e02e9c541a9e85b657e1785617b6f470
 Directory: ros/kinetic/ubuntu/xenial/perception
-
-########################################
-# Distro: debian:jessie
-
-Tags: kinetic-ros-core-jessie
-Architectures: amd64, arm64v8
-GitCommit: 9ed28e05366468c387af9aac3c07ee4a91634a10
-Directory: ros/kinetic/debian/jessie/ros-core
-
-Tags: kinetic-ros-base-jessie
-Architectures: amd64, arm64v8
-GitCommit: 9ed28e05366468c387af9aac3c07ee4a91634a10
-Directory: ros/kinetic/debian/jessie/ros-base
-
-Tags: kinetic-robot-jessie
-Architectures: amd64, arm64v8
-GitCommit: 9ed28e05366468c387af9aac3c07ee4a91634a10
-Directory: ros/kinetic/debian/jessie/robot
-
-Tags: kinetic-perception-jessie
-Architectures: amd64, arm64v8
-GitCommit: 9ed28e05366468c387af9aac3c07ee4a91634a10
-Directory: ros/kinetic/debian/jessie/perception
 
 
 ################################################################################
@@ -86,22 +63,22 @@ Directory: ros/kinetic/debian/jessie/perception
 
 Tags: lunar-ros-core, lunar-ros-core-xenial
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: aa409b0115d9a5f090bf58ab3c0e67a4d2b2bb5a
+GitCommit: 49d22242e02e9c541a9e85b657e1785617b6f470
 Directory: ros/lunar/ubuntu/xenial/ros-core
 
 Tags: lunar-ros-base, lunar-ros-base-xenial, lunar
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: aa409b0115d9a5f090bf58ab3c0e67a4d2b2bb5a
+GitCommit: 49d22242e02e9c541a9e85b657e1785617b6f470
 Directory: ros/lunar/ubuntu/xenial/ros-base
 
 Tags: lunar-robot, lunar-robot-xenial
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: aa409b0115d9a5f090bf58ab3c0e67a4d2b2bb5a
+GitCommit: 49d22242e02e9c541a9e85b657e1785617b6f470
 Directory: ros/lunar/ubuntu/xenial/robot
 
 Tags: lunar-perception, lunar-perception-xenial
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: aa409b0115d9a5f090bf58ab3c0e67a4d2b2bb5a
+GitCommit: 49d22242e02e9c541a9e85b657e1785617b6f470
 Directory: ros/lunar/ubuntu/xenial/perception
 
 ########################################
@@ -109,22 +86,22 @@ Directory: ros/lunar/ubuntu/xenial/perception
 
 Tags: lunar-ros-core-stretch
 Architectures: amd64, arm64v8
-GitCommit: 3f160bd014297b6de3b7c4c615e5435819745bad
+GitCommit: 49d22242e02e9c541a9e85b657e1785617b6f470
 Directory: ros/lunar/debian/stretch/ros-core
 
 Tags: lunar-ros-base-stretch
 Architectures: amd64, arm64v8
-GitCommit: 3f160bd014297b6de3b7c4c615e5435819745bad
+GitCommit: 49d22242e02e9c541a9e85b657e1785617b6f470
 Directory: ros/lunar/debian/stretch/ros-base
 
 Tags: lunar-robot-stretch
 Architectures: amd64, arm64v8
-GitCommit: 3f160bd014297b6de3b7c4c615e5435819745bad
+GitCommit: 49d22242e02e9c541a9e85b657e1785617b6f470
 Directory: ros/lunar/debian/stretch/robot
 
 Tags: lunar-perception-stretch
 Architectures: amd64, arm64v8
-GitCommit: 3f160bd014297b6de3b7c4c615e5435819745bad
+GitCommit: 49d22242e02e9c541a9e85b657e1785617b6f470
 Directory: ros/lunar/debian/stretch/perception
 
 
@@ -136,22 +113,22 @@ Directory: ros/lunar/debian/stretch/perception
 
 Tags: melodic-ros-core, melodic-ros-core-bionic
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 103fa82ffb2e2432f53866b15f444299c594291b
+GitCommit: 49d22242e02e9c541a9e85b657e1785617b6f470
 Directory: ros/melodic/ubuntu/bionic/ros-core
 
 Tags: melodic-ros-base, melodic-ros-base-bionic, melodic, latest
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 103fa82ffb2e2432f53866b15f444299c594291b
+GitCommit: 49d22242e02e9c541a9e85b657e1785617b6f470
 Directory: ros/melodic/ubuntu/bionic/ros-base
 
 Tags: melodic-robot, melodic-robot-bionic
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 103fa82ffb2e2432f53866b15f444299c594291b
+GitCommit: 49d22242e02e9c541a9e85b657e1785617b6f470
 Directory: ros/melodic/ubuntu/bionic/robot
 
 Tags: melodic-perception, melodic-perception-bionic
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 103fa82ffb2e2432f53866b15f444299c594291b
+GitCommit: 49d22242e02e9c541a9e85b657e1785617b6f470
 Directory: ros/melodic/ubuntu/bionic/perception
 
 ########################################
@@ -159,21 +136,21 @@ Directory: ros/melodic/ubuntu/bionic/perception
 
 Tags: melodic-ros-core-stretch
 Architectures: amd64, arm64v8
-GitCommit: 79a8672cd146028e522bd2c5b20c1ec7e6a9bca7
+GitCommit: 49d22242e02e9c541a9e85b657e1785617b6f470
 Directory: ros/melodic/debian/stretch/ros-core
 
 Tags: melodic-ros-base-stretch
 Architectures: amd64, arm64v8
-GitCommit: 79a8672cd146028e522bd2c5b20c1ec7e6a9bca7
+GitCommit: 49d22242e02e9c541a9e85b657e1785617b6f470
 Directory: ros/melodic/debian/stretch/ros-base
 
 Tags: melodic-robot-stretch
 Architectures: amd64, arm64v8
-GitCommit: 79a8672cd146028e522bd2c5b20c1ec7e6a9bca7
+GitCommit: 49d22242e02e9c541a9e85b657e1785617b6f470
 Directory: ros/melodic/debian/stretch/robot
 
 Tags: melodic-perception-stretch
 Architectures: amd64, arm64v8
-GitCommit: 79a8672cd146028e522bd2c5b20c1ec7e6a9bca7
+GitCommit: 49d22242e02e9c541a9e85b657e1785617b6f470
 Directory: ros/melodic/debian/stretch/perception
 


### PR DESCRIPTION
Debian Jessie is now EOL and the ROS buildfarm [doesn't build packages for it anymore](https://discourse.ros.org/t/kinetic-builds-disabled-on-eol-platform-debian-jessie/5051).
Thie PR EOLs jessie images and removes them from the ros docker library.

I committed all the changes to the ros dockerlibrary so the new commit hash are now pointing to the last generated Dockerfiles after the template refactoring from https://github.com/osrf/docker_templates/pull/37