### PR TITLE
Updating gazebo 9 to bionic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ env:
   - HUB_REPO=ros    HUB_RELEASE=kinetic HUB_OS_NAME=ubuntu HUB_OS_CODE_NAME=xenial
   - HUB_REPO=ros    HUB_RELEASE=indigo  HUB_OS_NAME=ubuntu HUB_OS_CODE_NAME=trusty
   # gazebo
+  - HUB_REPO=gazebo HUB_RELEASE=9       HUB_OS_NAME=ubuntu HUB_OS_CODE_NAME=bionic
   - HUB_REPO=gazebo HUB_RELEASE=9       HUB_OS_NAME=ubuntu HUB_OS_CODE_NAME=xenial
   - HUB_REPO=gazebo HUB_RELEASE=8       HUB_OS_NAME=ubuntu HUB_OS_CODE_NAME=xenial
   - HUB_REPO=gazebo HUB_RELEASE=7       HUB_OS_NAME=ubuntu HUB_OS_CODE_NAME=xenial

--- a/gazebo/9/ubuntu/bionic/Makefile
+++ b/gazebo/9/ubuntu/bionic/Makefile
@@ -1,0 +1,28 @@
+all: help
+
+help:
+	@echo ""
+	@echo "-- Help Menu"
+	@echo ""
+	@echo "   1. make build            - build all images"
+	@echo "   2. make pull             - pull all images"
+	@echo "   3. make clean            - remove all images"
+	@echo ""
+
+build:
+	@docker build --tag=gazebo:gzserver9	gzserver9/.
+	@docker build --tag=gazebo:libgazebo9	libgazebo9/.
+	# @docker build --tag=gazebo:gzclient9	gzclient9/.
+	# @docker build --tag=gazebo:gzweb9			gzweb9/.
+
+pull:
+	@docker pull gazebo:libgazebo9
+	@docker pull gazebo:gzserver9
+	# @docker pull gazebo:gzclient9
+	# @docker pull gazebo:gzweb9
+
+clean:
+	@docker rmi -f gazebo:libgazebo9
+	@docker rmi -f gazebo:gzserver9
+	# @docker rmi -f gazebo:gzclient9
+	# @docker rmi -f gazebo:gzweb9

--- a/gazebo/9/ubuntu/bionic/gzclient9/Dockerfile
+++ b/gazebo/9/ubuntu/bionic/gzclient9/Dockerfile
@@ -1,0 +1,16 @@
+# This is an auto generated Dockerfile for gazebo:gzclient9
+# generated from docker_images/create_gzclient_image.Dockerfile.em
+FROM gazebo:gzserver9
+
+# install packages
+RUN apt-get update && apt-get install -q -y \
+    binutils \
+    mesa-utils \
+    module-init-tools \
+    x-window-system \
+    && rm -rf /var/lib/apt/lists/*
+
+# install gazebo packages
+RUN apt-get update && apt-get install -q -y \
+    gazebo9=9.1.1-1* \
+    && rm -rf /var/lib/apt/lists/*

--- a/gazebo/9/ubuntu/bionic/gzclient9/Dockerfile
+++ b/gazebo/9/ubuntu/bionic/gzclient9/Dockerfile
@@ -12,5 +12,5 @@ RUN apt-get update && apt-get install -q -y \
 
 # install gazebo packages
 RUN apt-get update && apt-get install -q -y \
-    gazebo9=9.1.1-1* \
+    gazebo9=9.2.0-1* \
     && rm -rf /var/lib/apt/lists/*

--- a/gazebo/9/ubuntu/bionic/gzserver9/Dockerfile
+++ b/gazebo/9/ubuntu/bionic/gzserver9/Dockerfile
@@ -1,0 +1,36 @@
+# This is an auto generated Dockerfile for gazebo:gzserver9
+# generated from docker_images/create_gzserver_image.Dockerfile.em
+FROM ubuntu:bionic
+
+RUN echo 'Etc/UTC' > /etc/timezone && \
+    ln -s /usr/share/zoneinfo/Etc/UTC /etc/localtime && \
+    apt-get update && apt-get install -q -y tzdata && rm -rf /var/lib/apt/lists/*
+
+
+# install packages
+RUN apt-get update && apt-get install -q -y \
+    dirmngr \
+    gnupg2 \
+    lsb-release \
+    && rm -rf /var/lib/apt/lists/*
+
+# setup keys
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys D2486D2DD83DB69272AFE98867170598AF249743
+
+# setup sources.list
+RUN . /etc/os-release \
+    && echo "deb http://packages.osrfoundation.org/gazebo/$ID-stable `lsb_release -sc` main" > /etc/apt/sources.list.d/gazebo-latest.list
+
+# install gazebo packages
+RUN apt-get update && apt-get install -q -y \
+    gazebo9=9.1.1-1* \
+    && rm -rf /var/lib/apt/lists/*
+
+# setup environment
+EXPOSE 11345
+
+# setup entrypoint
+COPY ./gzserver_entrypoint.sh /
+
+ENTRYPOINT ["/gzserver_entrypoint.sh"]
+CMD ["gzserver"]

--- a/gazebo/9/ubuntu/bionic/gzserver9/Dockerfile
+++ b/gazebo/9/ubuntu/bionic/gzserver9/Dockerfile
@@ -23,7 +23,7 @@ RUN . /etc/os-release \
 
 # install gazebo packages
 RUN apt-get update && apt-get install -q -y \
-    gazebo9=9.1.1-1* \
+    gazebo9=9.2.0-1* \
     && rm -rf /var/lib/apt/lists/*
 
 # setup environment

--- a/gazebo/9/ubuntu/bionic/gzserver9/gzserver_entrypoint.sh
+++ b/gazebo/9/ubuntu/bionic/gzserver9/gzserver_entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+# setup gazebo environment
+source "/usr/share/gazebo/setup.sh"
+exec "$@"

--- a/gazebo/9/ubuntu/bionic/gzweb9/Dockerfile
+++ b/gazebo/9/ubuntu/bionic/gzweb9/Dockerfile
@@ -1,0 +1,42 @@
+# This is an auto generated Dockerfile for gazebo:gzweb9
+# generated from docker_images/create_gzweb_image.Dockerfile.em
+FROM gazebo:libgazebo9
+
+# install packages
+RUN apt-get update && apt-get install -q -y \
+    build-essential \
+    cmake \
+    imagemagick \
+    libboost-all-dev \
+    libgts-dev \
+    libjansson-dev \
+    libtinyxml-dev \
+    mercurial \
+    nodejs \
+    nodejs-legacy \
+    npm \
+    pkg-config \
+    psmisc \
+    xvfb \
+    && rm -rf /var/lib/apt/lists/*
+
+# install gazebo packages
+RUN apt-get update && apt-get install -q -y \
+    libgazebo9-dev=9.1.1-1* \
+    && rm -rf /var/lib/apt/lists/*
+
+# clone gzweb
+ENV GZWEB_WS /root/gzweb
+RUN hg clone https://bitbucket.org/osrf/gzweb $GZWEB_WS
+WORKDIR $GZWEB_WS
+
+# build gzweb
+RUN hg up default \
+    && xvfb-run -s "-screen 0 1280x1024x24" ./deploy.sh -m -t
+
+# setup environment
+EXPOSE 8080
+EXPOSE 7681
+
+# run gzserver and gzweb
+CMD gzserver --verbose & npm start

--- a/gazebo/9/ubuntu/bionic/gzweb9/Dockerfile
+++ b/gazebo/9/ubuntu/bionic/gzweb9/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update && apt-get install -q -y \
 
 # install gazebo packages
 RUN apt-get update && apt-get install -q -y \
-    libgazebo9-dev=9.1.1-1* \
+    libgazebo9-dev=9.2.0-1* \
     && rm -rf /var/lib/apt/lists/*
 
 # clone gzweb

--- a/gazebo/9/ubuntu/bionic/images.yaml.em
+++ b/gazebo/9/ubuntu/bionic/images.yaml.em
@@ -1,0 +1,57 @@
+%YAML 1.1
+# Gazebo Dockerfile database
+---
+images:
+    gzserver@(gazebo_version):
+        base_image: @(os_name):@(os_code_name)
+        maintainer_name: @(maintainer_name)
+        template_name: docker_images/create_gzserver_image.Dockerfile.em
+        entrypoint_name: docker_images/gzserver_entrypoint.sh
+        template_packages:
+            - docker_templates
+        gazebo_packages:
+            - gazebo@(gazebo_version)
+    libgazebo@(gazebo_version):
+        base_image: @(user_name):gzserver@(gazebo_version)
+        maintainer_name: @(maintainer_name)
+        template_name: docker_images/create_gzclient_image.Dockerfile.em
+        template_packages:
+            - docker_templates
+        gazebo_packages:
+            - libgazebo@(gazebo_version)-dev
+    gzweb@(gazebo_version):
+        base_image: @(user_name):libgazebo@(gazebo_version)
+        maintainer_name: @(maintainer_name)
+        template_name: docker_images/create_gzweb_image.Dockerfile.em
+        template_packages:
+            - docker_templates
+        upstream_packages:
+            - build-essential
+            - cmake
+            - imagemagick
+            - libboost-all-dev
+            - libgts-dev
+            - libjansson-dev
+            - libtinyxml-dev
+            - mercurial
+            - nodejs
+            - nodejs-legacy
+            - npm
+            - pkg-config
+            - psmisc
+            - xvfb
+        gazebo_packages:
+            - libgazebo@(gazebo_version)-dev
+    gzclient@(gazebo_version):
+        base_image: @(user_name):gzserver@(gazebo_version)
+        maintainer_name: @(maintainer_name)
+        template_name: docker_images/create_gzclient_image.Dockerfile.em
+        template_packages:
+            - docker_templates
+        upstream_packages:
+            - binutils
+            - mesa-utils
+            - module-init-tools
+            - x-window-system
+        gazebo_packages:
+            - gazebo@(gazebo_version)

--- a/gazebo/9/ubuntu/bionic/libgazebo9/Dockerfile
+++ b/gazebo/9/ubuntu/bionic/libgazebo9/Dockerfile
@@ -1,0 +1,7 @@
+# This is an auto generated Dockerfile for gazebo:libgazebo9
+# generated from docker_images/create_gzclient_image.Dockerfile.em
+FROM gazebo:gzserver9
+# install gazebo packages
+RUN apt-get update && apt-get install -q -y \
+    libgazebo9-dev=9.1.1-1* \
+    && rm -rf /var/lib/apt/lists/*

--- a/gazebo/9/ubuntu/bionic/libgazebo9/Dockerfile
+++ b/gazebo/9/ubuntu/bionic/libgazebo9/Dockerfile
@@ -3,5 +3,5 @@
 FROM gazebo:gzserver9
 # install gazebo packages
 RUN apt-get update && apt-get install -q -y \
-    libgazebo9-dev=9.1.1-1* \
+    libgazebo9-dev=9.2.0-1* \
     && rm -rf /var/lib/apt/lists/*

--- a/gazebo/9/ubuntu/bionic/platform.yaml
+++ b/gazebo/9/ubuntu/bionic/platform.yaml
@@ -1,0 +1,13 @@
+%YAML 1.1
+# Gazebo Dockerfile database
+---
+platform:
+    os_name: ubuntu
+    os_code_name: bionic
+    gazebo_version: 9
+    user_name: gazebo
+    maintainer_name:
+    arch: amd64
+    type: distribution
+    version:
+    release: stable

--- a/gazebo/gazebo
+++ b/gazebo/gazebo
@@ -92,13 +92,26 @@ Directory: gazebo/8/ubuntu/xenial/libgazebo8
 ########################################
 # Distro: ubuntu:xenial
 
-Tags: gzserver9, gzserver9-xenial
+Tags: gzserver9-xenial
 Architectures: amd64
 GitCommit: 12f5819139c90d3f9709ad2bddfd75235a840153
 Directory: gazebo/9/ubuntu/xenial/gzserver9
 
-Tags: libgazebo9, libgazebo9-xenial, latest
+Tags: libgazebo9-xenial
 Architectures: amd64
 GitCommit: 12f5819139c90d3f9709ad2bddfd75235a840153
 Directory: gazebo/9/ubuntu/xenial/libgazebo9
+
+########################################
+# Distro: ubuntu:bionic
+
+Tags: gzserver9, gzserver9-bionic
+Architectures: amd64
+GitCommit: 91c4368c1077639d16318c2f92e9d21f07ea40b9
+Directory: gazebo/9/ubuntu/bionic/gzserver9
+
+Tags: libgazebo9, libgazebo9-bionic, latest
+Architectures: amd64
+GitCommit: 91c4368c1077639d16318c2f92e9d21f07ea40b9
+Directory: gazebo/9/ubuntu/bionic/libgazebo9
 

--- a/gazebo/gazebo
+++ b/gazebo/gazebo
@@ -107,11 +107,11 @@ Directory: gazebo/9/ubuntu/xenial/libgazebo9
 
 Tags: gzserver9, gzserver9-bionic
 Architectures: amd64
-GitCommit: 91c4368c1077639d16318c2f92e9d21f07ea40b9
+GitCommit: 41c37cabe584ef4526c375a2705226743d4a91ee
 Directory: gazebo/9/ubuntu/bionic/gzserver9
 
 Tags: libgazebo9, libgazebo9-bionic, latest
 Architectures: amd64
-GitCommit: 91c4368c1077639d16318c2f92e9d21f07ea40b9
+GitCommit: 41c37cabe584ef4526c375a2705226743d4a91ee
 Directory: gazebo/9/ubuntu/bionic/libgazebo9
 

--- a/gazebo/manifest.yaml
+++ b/gazebo/manifest.yaml
@@ -116,6 +116,17 @@ release_names:
                         tag_names:
                             gzserver9:
                                 aliases:
+                                    - "gzserver9-$os_code_name"
+                            libgazebo9:
+                                aliases:
+                                    - "libgazebo9-$os_code_name"
+                    bionic:
+                        <<: *DEFAULT
+                        archs:
+                            - amd64
+                        tag_names:
+                            gzserver9:
+                                aliases:
                                     - "gzserver9"
                                     - "gzserver9-$os_code_name"
                             libgazebo9:


### PR DESCRIPTION
Correct me if mistaken: with Gazebo 9 support period (EOL 2023-01-25) matching that of Ubuntu Bionic, it would make sense to make the latest gazebo 9 tags eventually target Bionic. I have left the Xenial tags in place, and can be deprecated in due time with the EOL 16.04.