### PR TITLE
Use os specific tags in gazebo base images

### DIFF
--- a/gazebo/.config/images.yaml.em
+++ b/gazebo/.config/images.yaml.em
@@ -12,7 +12,7 @@ images:
         gazebo_packages:
             - gazebo@(gazebo_version)
     libgazebo@(gazebo_version):
-        base_image: @(user_name):gzserver@(gazebo_version)
+        base_image: @(user_name):gzserver@(gazebo_version)-@(os_code_name)
         maintainer_name: @(maintainer_name)
         template_name: docker_images/create_gzclient_image.Dockerfile.em
         template_packages:
@@ -20,7 +20,7 @@ images:
         gazebo_packages:
             - libgazebo@(gazebo_version)-dev
     gzweb@(gazebo_version):
-        base_image: @(user_name):libgazebo@(gazebo_version)
+        base_image: @(user_name):libgazebo@(gazebo_version)-@(os_code_name)
         maintainer_name: @(maintainer_name)
         template_name: docker_images/create_gzweb_image.Dockerfile.em
         template_packages:
@@ -43,7 +43,7 @@ images:
         gazebo_packages:
             - libgazebo@(gazebo_version)-dev
     gzclient@(gazebo_version):
-        base_image: @(user_name):gzserver@(gazebo_version)
+        base_image: @(user_name):gzserver@(gazebo_version)-@(os_code_name)
         maintainer_name: @(maintainer_name)
         template_name: docker_images/create_gzclient_image.Dockerfile.em
         template_packages:

--- a/gazebo/4/ubuntu/trusty/gzclient4/Dockerfile
+++ b/gazebo/4/ubuntu/trusty/gzclient4/Dockerfile
@@ -1,6 +1,6 @@
 # This is an auto generated Dockerfile for gazebo:gzclient4
 # generated from docker_images/create_gzclient_image.Dockerfile.em
-FROM gazebo:gzserver4
+FROM gazebo:gzserver4-trusty
 
 # install packages
 RUN apt-get update && apt-get install -q -y \

--- a/gazebo/4/ubuntu/trusty/gzweb4/Dockerfile
+++ b/gazebo/4/ubuntu/trusty/gzweb4/Dockerfile
@@ -1,6 +1,6 @@
 # This is an auto generated Dockerfile for gazebo:gzweb4
 # generated from docker_images/create_gzweb_image.Dockerfile.em
-FROM gazebo:libgazebo4
+FROM gazebo:libgazebo4-trusty
 
 # install packages
 RUN apt-get update && apt-get install -q -y \

--- a/gazebo/4/ubuntu/trusty/images.yaml.em
+++ b/gazebo/4/ubuntu/trusty/images.yaml.em
@@ -12,7 +12,7 @@ images:
         gazebo_packages:
             - gazebo@(gazebo_version)
     libgazebo@(gazebo_version):
-        base_image: @(user_name):gzserver@(gazebo_version)
+        base_image: @(user_name):gzserver@(gazebo_version)-@(os_code_name)
         maintainer_name: @(maintainer_name)
         template_name: docker_images/create_gzclient_image.Dockerfile.em
         template_packages:
@@ -20,7 +20,7 @@ images:
         gazebo_packages:
             - libgazebo@(gazebo_version)-dev
     gzweb@(gazebo_version):
-        base_image: @(user_name):libgazebo@(gazebo_version)
+        base_image: @(user_name):libgazebo@(gazebo_version)-@(os_code_name)
         maintainer_name: @(maintainer_name)
         template_name: docker_images/create_gzweb_image.Dockerfile.em
         template_packages:
@@ -43,7 +43,7 @@ images:
         gazebo_packages:
             - libgazebo@(gazebo_version)-dev
     gzclient@(gazebo_version):
-        base_image: @(user_name):gzserver@(gazebo_version)
+        base_image: @(user_name):gzserver@(gazebo_version)-@(os_code_name)
         maintainer_name: @(maintainer_name)
         template_name: docker_images/create_gzclient_image.Dockerfile.em
         template_packages:

--- a/gazebo/4/ubuntu/trusty/libgazebo4/Dockerfile
+++ b/gazebo/4/ubuntu/trusty/libgazebo4/Dockerfile
@@ -1,6 +1,6 @@
 # This is an auto generated Dockerfile for gazebo:libgazebo4
 # generated from docker_images/create_gzclient_image.Dockerfile.em
-FROM gazebo:gzserver4
+FROM gazebo:gzserver4-trusty
 # install gazebo packages
 RUN apt-get update && apt-get install -q -y \
     libgazebo4-dev=4.1.3-1* \

--- a/gazebo/5/ubuntu/trusty/gzclient5/Dockerfile
+++ b/gazebo/5/ubuntu/trusty/gzclient5/Dockerfile
@@ -1,6 +1,6 @@
 # This is an auto generated Dockerfile for gazebo:gzclient5
 # generated from docker_images/create_gzclient_image.Dockerfile.em
-FROM gazebo:gzserver5
+FROM gazebo:gzserver5-trusty
 
 # install packages
 RUN apt-get update && apt-get install -q -y \

--- a/gazebo/5/ubuntu/trusty/gzweb5/Dockerfile
+++ b/gazebo/5/ubuntu/trusty/gzweb5/Dockerfile
@@ -1,6 +1,6 @@
 # This is an auto generated Dockerfile for gazebo:gzweb5
 # generated from docker_images/create_gzweb_image.Dockerfile.em
-FROM gazebo:libgazebo5
+FROM gazebo:libgazebo5-trusty
 
 # install packages
 RUN apt-get update && apt-get install -q -y \

--- a/gazebo/5/ubuntu/trusty/images.yaml.em
+++ b/gazebo/5/ubuntu/trusty/images.yaml.em
@@ -12,7 +12,7 @@ images:
         gazebo_packages:
             - gazebo@(gazebo_version)
     libgazebo@(gazebo_version):
-        base_image: @(user_name):gzserver@(gazebo_version)
+        base_image: @(user_name):gzserver@(gazebo_version)-@(os_code_name)
         maintainer_name: @(maintainer_name)
         template_name: docker_images/create_gzclient_image.Dockerfile.em
         template_packages:
@@ -20,7 +20,7 @@ images:
         gazebo_packages:
             - libgazebo@(gazebo_version)-dev
     gzweb@(gazebo_version):
-        base_image: @(user_name):libgazebo@(gazebo_version)
+        base_image: @(user_name):libgazebo@(gazebo_version)-@(os_code_name)
         maintainer_name: @(maintainer_name)
         template_name: docker_images/create_gzweb_image.Dockerfile.em
         template_packages:
@@ -43,7 +43,7 @@ images:
         gazebo_packages:
             - libgazebo@(gazebo_version)-dev
     gzclient@(gazebo_version):
-        base_image: @(user_name):gzserver@(gazebo_version)
+        base_image: @(user_name):gzserver@(gazebo_version)-@(os_code_name)
         maintainer_name: @(maintainer_name)
         template_name: docker_images/create_gzclient_image.Dockerfile.em
         template_packages:

--- a/gazebo/5/ubuntu/trusty/libgazebo5/Dockerfile
+++ b/gazebo/5/ubuntu/trusty/libgazebo5/Dockerfile
@@ -1,6 +1,6 @@
 # This is an auto generated Dockerfile for gazebo:libgazebo5
 # generated from docker_images/create_gzclient_image.Dockerfile.em
-FROM gazebo:gzserver5
+FROM gazebo:gzserver5-trusty
 # install gazebo packages
 RUN apt-get update && apt-get install -q -y \
     libgazebo5-dev=5.4.0-1* \

--- a/gazebo/6/ubuntu/trusty/gzclient6/Dockerfile
+++ b/gazebo/6/ubuntu/trusty/gzclient6/Dockerfile
@@ -1,6 +1,6 @@
 # This is an auto generated Dockerfile for gazebo:gzclient6
 # generated from docker_images/create_gzclient_image.Dockerfile.em
-FROM gazebo:gzserver6
+FROM gazebo:gzserver6-trusty
 
 # install packages
 RUN apt-get update && apt-get install -q -y \

--- a/gazebo/6/ubuntu/trusty/gzweb6/Dockerfile
+++ b/gazebo/6/ubuntu/trusty/gzweb6/Dockerfile
@@ -1,6 +1,6 @@
 # This is an auto generated Dockerfile for gazebo:gzweb6
 # generated from docker_images/create_gzweb_image.Dockerfile.em
-FROM gazebo:libgazebo6
+FROM gazebo:libgazebo6-trusty
 
 # install packages
 RUN apt-get update && apt-get install -q -y \

--- a/gazebo/6/ubuntu/trusty/images.yaml.em
+++ b/gazebo/6/ubuntu/trusty/images.yaml.em
@@ -12,7 +12,7 @@ images:
         gazebo_packages:
             - gazebo@(gazebo_version)
     libgazebo@(gazebo_version):
-        base_image: @(user_name):gzserver@(gazebo_version)
+        base_image: @(user_name):gzserver@(gazebo_version)-@(os_code_name)
         maintainer_name: @(maintainer_name)
         template_name: docker_images/create_gzclient_image.Dockerfile.em
         template_packages:
@@ -20,7 +20,7 @@ images:
         gazebo_packages:
             - libgazebo@(gazebo_version)-dev
     gzweb@(gazebo_version):
-        base_image: @(user_name):libgazebo@(gazebo_version)
+        base_image: @(user_name):libgazebo@(gazebo_version)-@(os_code_name)
         maintainer_name: @(maintainer_name)
         template_name: docker_images/create_gzweb_image.Dockerfile.em
         template_packages:
@@ -43,7 +43,7 @@ images:
         gazebo_packages:
             - libgazebo@(gazebo_version)-dev
     gzclient@(gazebo_version):
-        base_image: @(user_name):gzserver@(gazebo_version)
+        base_image: @(user_name):gzserver@(gazebo_version)-@(os_code_name)
         maintainer_name: @(maintainer_name)
         template_name: docker_images/create_gzclient_image.Dockerfile.em
         template_packages:

--- a/gazebo/6/ubuntu/trusty/libgazebo6/Dockerfile
+++ b/gazebo/6/ubuntu/trusty/libgazebo6/Dockerfile
@@ -1,6 +1,6 @@
 # This is an auto generated Dockerfile for gazebo:libgazebo6
 # generated from docker_images/create_gzclient_image.Dockerfile.em
-FROM gazebo:gzserver6
+FROM gazebo:gzserver6-trusty
 # install gazebo packages
 RUN apt-get update && apt-get install -q -y \
     libgazebo6-dev=6.7.0-1* \

--- a/gazebo/7/ubuntu/xenial/gzclient7/Dockerfile
+++ b/gazebo/7/ubuntu/xenial/gzclient7/Dockerfile
@@ -1,6 +1,6 @@
 # This is an auto generated Dockerfile for gazebo:gzclient7
 # generated from docker_images/create_gzclient_image.Dockerfile.em
-FROM gazebo:gzserver7
+FROM gazebo:gzserver7-xenial
 
 # install packages
 RUN apt-get update && apt-get install -q -y \

--- a/gazebo/7/ubuntu/xenial/gzweb7/Dockerfile
+++ b/gazebo/7/ubuntu/xenial/gzweb7/Dockerfile
@@ -1,6 +1,6 @@
 # This is an auto generated Dockerfile for gazebo:gzweb7
 # generated from docker_images/create_gzweb_image.Dockerfile.em
-FROM gazebo:libgazebo7
+FROM gazebo:libgazebo7-xenial
 
 # install packages
 RUN apt-get update && apt-get install -q -y \

--- a/gazebo/7/ubuntu/xenial/images.yaml.em
+++ b/gazebo/7/ubuntu/xenial/images.yaml.em
@@ -12,7 +12,7 @@ images:
         gazebo_packages:
             - gazebo@(gazebo_version)
     libgazebo@(gazebo_version):
-        base_image: @(user_name):gzserver@(gazebo_version)
+        base_image: @(user_name):gzserver@(gazebo_version)-@(os_code_name)
         maintainer_name: @(maintainer_name)
         template_name: docker_images/create_gzclient_image.Dockerfile.em
         template_packages:
@@ -20,7 +20,7 @@ images:
         gazebo_packages:
             - libgazebo@(gazebo_version)-dev
     gzweb@(gazebo_version):
-        base_image: @(user_name):libgazebo@(gazebo_version)
+        base_image: @(user_name):libgazebo@(gazebo_version)-@(os_code_name)
         maintainer_name: @(maintainer_name)
         template_name: docker_images/create_gzweb_image.Dockerfile.em
         template_packages:
@@ -43,7 +43,7 @@ images:
         gazebo_packages:
             - libgazebo@(gazebo_version)-dev
     gzclient@(gazebo_version):
-        base_image: @(user_name):gzserver@(gazebo_version)
+        base_image: @(user_name):gzserver@(gazebo_version)-@(os_code_name)
         maintainer_name: @(maintainer_name)
         template_name: docker_images/create_gzclient_image.Dockerfile.em
         template_packages:

--- a/gazebo/7/ubuntu/xenial/libgazebo7/Dockerfile
+++ b/gazebo/7/ubuntu/xenial/libgazebo7/Dockerfile
@@ -1,6 +1,6 @@
 # This is an auto generated Dockerfile for gazebo:libgazebo7
 # generated from docker_images/create_gzclient_image.Dockerfile.em
-FROM gazebo:gzserver7
+FROM gazebo:gzserver7-xenial
 # install gazebo packages
 RUN apt-get update && apt-get install -q -y \
     libgazebo7-dev=7.14.0-1* \

--- a/gazebo/8/ubuntu/xenial/gzclient8/Dockerfile
+++ b/gazebo/8/ubuntu/xenial/gzclient8/Dockerfile
@@ -1,6 +1,6 @@
 # This is an auto generated Dockerfile for gazebo:gzclient8
 # generated from docker_images/create_gzclient_image.Dockerfile.em
-FROM gazebo:gzserver8
+FROM gazebo:gzserver8-xenial
 
 # install packages
 RUN apt-get update && apt-get install -q -y \

--- a/gazebo/8/ubuntu/xenial/gzweb8/Dockerfile
+++ b/gazebo/8/ubuntu/xenial/gzweb8/Dockerfile
@@ -1,6 +1,6 @@
 # This is an auto generated Dockerfile for gazebo:gzweb8
 # generated from docker_images/create_gzweb_image.Dockerfile.em
-FROM gazebo:libgazebo8
+FROM gazebo:libgazebo8-xenial
 
 # install packages
 RUN apt-get update && apt-get install -q -y \

--- a/gazebo/8/ubuntu/xenial/images.yaml.em
+++ b/gazebo/8/ubuntu/xenial/images.yaml.em
@@ -12,7 +12,7 @@ images:
         gazebo_packages:
             - gazebo@(gazebo_version)
     libgazebo@(gazebo_version):
-        base_image: @(user_name):gzserver@(gazebo_version)
+        base_image: @(user_name):gzserver@(gazebo_version)-@(os_code_name)
         maintainer_name: @(maintainer_name)
         template_name: docker_images/create_gzclient_image.Dockerfile.em
         template_packages:
@@ -20,7 +20,7 @@ images:
         gazebo_packages:
             - libgazebo@(gazebo_version)-dev
     gzweb@(gazebo_version):
-        base_image: @(user_name):libgazebo@(gazebo_version)
+        base_image: @(user_name):libgazebo@(gazebo_version)-@(os_code_name)
         maintainer_name: @(maintainer_name)
         template_name: docker_images/create_gzweb_image.Dockerfile.em
         template_packages:
@@ -43,7 +43,7 @@ images:
         gazebo_packages:
             - libgazebo@(gazebo_version)-dev
     gzclient@(gazebo_version):
-        base_image: @(user_name):gzserver@(gazebo_version)
+        base_image: @(user_name):gzserver@(gazebo_version)-@(os_code_name)
         maintainer_name: @(maintainer_name)
         template_name: docker_images/create_gzclient_image.Dockerfile.em
         template_packages:

--- a/gazebo/8/ubuntu/xenial/libgazebo8/Dockerfile
+++ b/gazebo/8/ubuntu/xenial/libgazebo8/Dockerfile
@@ -1,6 +1,6 @@
 # This is an auto generated Dockerfile for gazebo:libgazebo8
 # generated from docker_images/create_gzclient_image.Dockerfile.em
-FROM gazebo:gzserver8
+FROM gazebo:gzserver8-xenial
 # install gazebo packages
 RUN apt-get update && apt-get install -q -y \
     libgazebo8-dev=8.6.0-1* \

--- a/gazebo/9/ubuntu/bionic/gzclient9/Dockerfile
+++ b/gazebo/9/ubuntu/bionic/gzclient9/Dockerfile
@@ -1,6 +1,6 @@
 # This is an auto generated Dockerfile for gazebo:gzclient9
 # generated from docker_images/create_gzclient_image.Dockerfile.em
-FROM gazebo:gzserver9
+FROM gazebo:gzserver9-bionic
 
 # install packages
 RUN apt-get update && apt-get install -q -y \

--- a/gazebo/9/ubuntu/bionic/gzweb9/Dockerfile
+++ b/gazebo/9/ubuntu/bionic/gzweb9/Dockerfile
@@ -1,6 +1,6 @@
 # This is an auto generated Dockerfile for gazebo:gzweb9
 # generated from docker_images/create_gzweb_image.Dockerfile.em
-FROM gazebo:libgazebo9
+FROM gazebo:libgazebo9-bionic
 
 # install packages
 RUN apt-get update && apt-get install -q -y \

--- a/gazebo/9/ubuntu/bionic/images.yaml.em
+++ b/gazebo/9/ubuntu/bionic/images.yaml.em
@@ -12,7 +12,7 @@ images:
         gazebo_packages:
             - gazebo@(gazebo_version)
     libgazebo@(gazebo_version):
-        base_image: @(user_name):gzserver@(gazebo_version)
+        base_image: @(user_name):gzserver@(gazebo_version)-@(os_code_name)
         maintainer_name: @(maintainer_name)
         template_name: docker_images/create_gzclient_image.Dockerfile.em
         template_packages:
@@ -20,7 +20,7 @@ images:
         gazebo_packages:
             - libgazebo@(gazebo_version)-dev
     gzweb@(gazebo_version):
-        base_image: @(user_name):libgazebo@(gazebo_version)
+        base_image: @(user_name):libgazebo@(gazebo_version)-@(os_code_name)
         maintainer_name: @(maintainer_name)
         template_name: docker_images/create_gzweb_image.Dockerfile.em
         template_packages:
@@ -43,7 +43,7 @@ images:
         gazebo_packages:
             - libgazebo@(gazebo_version)-dev
     gzclient@(gazebo_version):
-        base_image: @(user_name):gzserver@(gazebo_version)
+        base_image: @(user_name):gzserver@(gazebo_version)-@(os_code_name)
         maintainer_name: @(maintainer_name)
         template_name: docker_images/create_gzclient_image.Dockerfile.em
         template_packages:

--- a/gazebo/9/ubuntu/bionic/libgazebo9/Dockerfile
+++ b/gazebo/9/ubuntu/bionic/libgazebo9/Dockerfile
@@ -1,6 +1,6 @@
 # This is an auto generated Dockerfile for gazebo:libgazebo9
 # generated from docker_images/create_gzclient_image.Dockerfile.em
-FROM gazebo:gzserver9
+FROM gazebo:gzserver9-bionic
 # install gazebo packages
 RUN apt-get update && apt-get install -q -y \
     libgazebo9-dev=9.3.1-1* \

--- a/gazebo/9/ubuntu/xenial/gzclient9/Dockerfile
+++ b/gazebo/9/ubuntu/xenial/gzclient9/Dockerfile
@@ -1,6 +1,6 @@
 # This is an auto generated Dockerfile for gazebo:gzclient9
 # generated from docker_images/create_gzclient_image.Dockerfile.em
-FROM gazebo:gzserver9
+FROM gazebo:gzserver9-xenial
 
 # install packages
 RUN apt-get update && apt-get install -q -y \

--- a/gazebo/9/ubuntu/xenial/gzweb9/Dockerfile
+++ b/gazebo/9/ubuntu/xenial/gzweb9/Dockerfile
@@ -1,6 +1,6 @@
 # This is an auto generated Dockerfile for gazebo:gzweb9
 # generated from docker_images/create_gzweb_image.Dockerfile.em
-FROM gazebo:libgazebo9
+FROM gazebo:libgazebo9-xenial
 
 # install packages
 RUN apt-get update && apt-get install -q -y \

--- a/gazebo/9/ubuntu/xenial/images.yaml.em
+++ b/gazebo/9/ubuntu/xenial/images.yaml.em
@@ -12,7 +12,7 @@ images:
         gazebo_packages:
             - gazebo@(gazebo_version)
     libgazebo@(gazebo_version):
-        base_image: @(user_name):gzserver@(gazebo_version)
+        base_image: @(user_name):gzserver@(gazebo_version)-@(os_code_name)
         maintainer_name: @(maintainer_name)
         template_name: docker_images/create_gzclient_image.Dockerfile.em
         template_packages:
@@ -20,7 +20,7 @@ images:
         gazebo_packages:
             - libgazebo@(gazebo_version)-dev
     gzweb@(gazebo_version):
-        base_image: @(user_name):libgazebo@(gazebo_version)
+        base_image: @(user_name):libgazebo@(gazebo_version)-@(os_code_name)
         maintainer_name: @(maintainer_name)
         template_name: docker_images/create_gzweb_image.Dockerfile.em
         template_packages:
@@ -43,7 +43,7 @@ images:
         gazebo_packages:
             - libgazebo@(gazebo_version)-dev
     gzclient@(gazebo_version):
-        base_image: @(user_name):gzserver@(gazebo_version)
+        base_image: @(user_name):gzserver@(gazebo_version)-@(os_code_name)
         maintainer_name: @(maintainer_name)
         template_name: docker_images/create_gzclient_image.Dockerfile.em
         template_packages:

--- a/gazebo/9/ubuntu/xenial/libgazebo9/Dockerfile
+++ b/gazebo/9/ubuntu/xenial/libgazebo9/Dockerfile
@@ -1,6 +1,6 @@
 # This is an auto generated Dockerfile for gazebo:libgazebo9
 # generated from docker_images/create_gzclient_image.Dockerfile.em
-FROM gazebo:gzserver9
+FROM gazebo:gzserver9-xenial
 # install gazebo packages
 RUN apt-get update && apt-get install -q -y \
     libgazebo9-dev=9.3.1-1* \

--- a/gazebo/gazebo
+++ b/gazebo/gazebo
@@ -9,12 +9,12 @@ GitRepo: https://github.com/osrf/docker_images.git
 
 Tags: gzserver4, gzserver4-trusty
 Architectures: amd64
-GitCommit: 1edae347ca21f301dd2396e621ed512859725924
+GitCommit: c5ca5054c6921645802f21e888b79f464863eb1a
 Directory: gazebo/4/ubuntu/trusty/gzserver4
 
 Tags: libgazebo4, libgazebo4-trusty
 Architectures: amd64
-GitCommit: 1edae347ca21f301dd2396e621ed512859725924
+GitCommit: c5ca5054c6921645802f21e888b79f464863eb1a
 Directory: gazebo/4/ubuntu/trusty/libgazebo4
 
 
@@ -26,12 +26,12 @@ Directory: gazebo/4/ubuntu/trusty/libgazebo4
 
 Tags: gzserver5, gzserver5-trusty
 Architectures: amd64
-GitCommit: a189ba5bbf7ea2bcc0529a694c5fe0f73e5ef718
+GitCommit: c5ca5054c6921645802f21e888b79f464863eb1a
 Directory: gazebo/5/ubuntu/trusty/gzserver5
 
 Tags: libgazebo5, libgazebo5-trusty
 Architectures: amd64
-GitCommit: a189ba5bbf7ea2bcc0529a694c5fe0f73e5ef718
+GitCommit: c5ca5054c6921645802f21e888b79f464863eb1a
 Directory: gazebo/5/ubuntu/trusty/libgazebo5
 
 
@@ -43,12 +43,12 @@ Directory: gazebo/5/ubuntu/trusty/libgazebo5
 
 Tags: gzserver6, gzserver6-trusty
 Architectures: amd64
-GitCommit: 17a06379348dd882822b31fade51e1eb4b4c6b8c
+GitCommit: c5ca5054c6921645802f21e888b79f464863eb1a
 Directory: gazebo/6/ubuntu/trusty/gzserver6
 
 Tags: libgazebo6, libgazebo6-trusty
 Architectures: amd64
-GitCommit: 17a06379348dd882822b31fade51e1eb4b4c6b8c
+GitCommit: c5ca5054c6921645802f21e888b79f464863eb1a
 Directory: gazebo/6/ubuntu/trusty/libgazebo6
 
 
@@ -60,12 +60,12 @@ Directory: gazebo/6/ubuntu/trusty/libgazebo6
 
 Tags: gzserver7, gzserver7-xenial
 Architectures: amd64
-GitCommit: e8f4c4d8ba96447121ca3b286c965feb0d293689
+GitCommit: c5ca5054c6921645802f21e888b79f464863eb1a
 Directory: gazebo/7/ubuntu/xenial/gzserver7
 
 Tags: libgazebo7, libgazebo7-xenial
 Architectures: amd64
-GitCommit: e8f4c4d8ba96447121ca3b286c965feb0d293689
+GitCommit: c5ca5054c6921645802f21e888b79f464863eb1a
 Directory: gazebo/7/ubuntu/xenial/libgazebo7
 
 
@@ -77,12 +77,12 @@ Directory: gazebo/7/ubuntu/xenial/libgazebo7
 
 Tags: gzserver8, gzserver8-xenial
 Architectures: amd64
-GitCommit: 84563884e54305fe02c38b5073c60fe3730fc8fa
+GitCommit: c5ca5054c6921645802f21e888b79f464863eb1a
 Directory: gazebo/8/ubuntu/xenial/gzserver8
 
 Tags: libgazebo8, libgazebo8-xenial
 Architectures: amd64
-GitCommit: 84563884e54305fe02c38b5073c60fe3730fc8fa
+GitCommit: c5ca5054c6921645802f21e888b79f464863eb1a
 Directory: gazebo/8/ubuntu/xenial/libgazebo8
 
 
@@ -94,12 +94,12 @@ Directory: gazebo/8/ubuntu/xenial/libgazebo8
 
 Tags: gzserver9-xenial
 Architectures: amd64
-GitCommit: 59f76a64533a9c352b03919172ce0783bd1e583e
+GitCommit: c5ca5054c6921645802f21e888b79f464863eb1a
 Directory: gazebo/9/ubuntu/xenial/gzserver9
 
 Tags: libgazebo9-xenial
 Architectures: amd64
-GitCommit: 59f76a64533a9c352b03919172ce0783bd1e583e
+GitCommit: c5ca5054c6921645802f21e888b79f464863eb1a
 Directory: gazebo/9/ubuntu/xenial/libgazebo9
 
 ########################################
@@ -107,11 +107,11 @@ Directory: gazebo/9/ubuntu/xenial/libgazebo9
 
 Tags: gzserver9, gzserver9-bionic
 Architectures: amd64
-GitCommit: 3ee19f3a71299da89891949d72206ca6056f3ced
+GitCommit: c5ca5054c6921645802f21e888b79f464863eb1a
 Directory: gazebo/9/ubuntu/bionic/gzserver9
 
 Tags: libgazebo9, libgazebo9-bionic, latest
 Architectures: amd64
-GitCommit: 3ee19f3a71299da89891949d72206ca6056f3ced
+GitCommit: c5ca5054c6921645802f21e888b79f464863eb1a
 Directory: gazebo/9/ubuntu/bionic/libgazebo9
 


### PR DESCRIPTION
Now that some gazebo images target multiple Ubuntu distributions, we need to add the ability of depending on the os specific tag rather than the generic short tag in the generated Dockerfiles.

Should fix and superseed https://github.com/osrf/docker_images/pull/184