### PR TITLE
EOL old gazebo (4,5,6)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,5 @@ env:
   - HUB_REPO=gazebo HUB_RELEASE=9       HUB_OS_NAME=ubuntu HUB_OS_CODE_NAME=xenial
   - HUB_REPO=gazebo HUB_RELEASE=8       HUB_OS_NAME=ubuntu HUB_OS_CODE_NAME=xenial
   - HUB_REPO=gazebo HUB_RELEASE=7       HUB_OS_NAME=ubuntu HUB_OS_CODE_NAME=xenial
-  - HUB_REPO=gazebo HUB_RELEASE=6       HUB_OS_NAME=ubuntu HUB_OS_CODE_NAME=trusty
-  - HUB_REPO=gazebo HUB_RELEASE=5       HUB_OS_NAME=ubuntu HUB_OS_CODE_NAME=trusty
-  - HUB_REPO=gazebo HUB_RELEASE=4       HUB_OS_NAME=ubuntu HUB_OS_CODE_NAME=trusty
 
 script: .travis/travis.py

--- a/gazebo/gazebo
+++ b/gazebo/gazebo
@@ -2,57 +2,6 @@ Maintainers: Tully Foote <tfoote+buildfarm@osrfoundation.org> (@tfoote)
 GitRepo: https://github.com/osrf/docker_images.git
 
 ################################################################################
-# Release: 4
-
-########################################
-# Distro: ubuntu:trusty
-
-Tags: gzserver4, gzserver4-trusty
-Architectures: amd64
-GitCommit: c5ca5054c6921645802f21e888b79f464863eb1a
-Directory: gazebo/4/ubuntu/trusty/gzserver4
-
-Tags: libgazebo4, libgazebo4-trusty
-Architectures: amd64
-GitCommit: c5ca5054c6921645802f21e888b79f464863eb1a
-Directory: gazebo/4/ubuntu/trusty/libgazebo4
-
-
-################################################################################
-# Release: 5
-
-########################################
-# Distro: ubuntu:trusty
-
-Tags: gzserver5, gzserver5-trusty
-Architectures: amd64
-GitCommit: c5ca5054c6921645802f21e888b79f464863eb1a
-Directory: gazebo/5/ubuntu/trusty/gzserver5
-
-Tags: libgazebo5, libgazebo5-trusty
-Architectures: amd64
-GitCommit: c5ca5054c6921645802f21e888b79f464863eb1a
-Directory: gazebo/5/ubuntu/trusty/libgazebo5
-
-
-################################################################################
-# Release: 6
-
-########################################
-# Distro: ubuntu:trusty
-
-Tags: gzserver6, gzserver6-trusty
-Architectures: amd64
-GitCommit: c5ca5054c6921645802f21e888b79f464863eb1a
-Directory: gazebo/6/ubuntu/trusty/gzserver6
-
-Tags: libgazebo6, libgazebo6-trusty
-Architectures: amd64
-GitCommit: c5ca5054c6921645802f21e888b79f464863eb1a
-Directory: gazebo/6/ubuntu/trusty/libgazebo6
-
-
-################################################################################
 # Release: 7
 
 ########################################

--- a/gazebo/manifest.yaml
+++ b/gazebo/manifest.yaml
@@ -14,60 +14,61 @@ defaults:
             platform: .config/platform.yaml.em
 
 release_names:
-    '4':
-        eol: 2016-01-25
-        os_names:
-            ubuntu:
-                os_code_names:
-                    trusty:
-                        <<: *DEFAULT
-                        archs:
-                            - amd64
-                        tag_names:
-                            gzserver4:
-                                aliases:
-                                    - "gzserver4"
-                                    - "gzserver4-$os_code_name"
-                            libgazebo4:
-                                aliases:
-                                    - "libgazebo4"
-                                    - "libgazebo4-$os_code_name"
-    '5':
-        eol: 2017-01-25
-        os_names:
-            ubuntu:
-                os_code_names:
-                    trusty:
-                        <<: *DEFAULT
-                        archs:
-                            - amd64
-                        tag_names:
-                            gzserver5:
-                                aliases:
-                                    - "gzserver5"
-                                    - "gzserver5-$os_code_name"
-                            libgazebo5:
-                                aliases:
-                                    - "libgazebo5"
-                                    - "libgazebo5-$os_code_name"
-    '6':
-        eol: 2017-01-25
-        os_names:
-            ubuntu:
-                os_code_names:
-                    trusty:
-                        <<: *DEFAULT
-                        archs:
-                            - amd64
-                        tag_names:
-                            gzserver6:
-                                aliases:
-                                    - "gzserver6"
-                                    - "gzserver6-$os_code_name"
-                            libgazebo6:
-                                aliases:
-                                    - "libgazebo6"
-                                    - "libgazebo6-$os_code_name"
+    # EOL
+    # '4':
+    #     eol: 2016-01-25
+    #     os_names:
+    #         ubuntu:
+    #             os_code_names:
+    #                 trusty:
+    #                     <<: *DEFAULT
+    #                     archs:
+    #                         - amd64
+    #                     tag_names:
+    #                         gzserver4:
+    #                             aliases:
+    #                                 - "gzserver4"
+    #                                 - "gzserver4-$os_code_name"
+    #                         libgazebo4:
+    #                             aliases:
+    #                                 - "libgazebo4"
+    #                                 - "libgazebo4-$os_code_name"
+    # '5':
+    #     eol: 2017-01-25
+    #     os_names:
+    #         ubuntu:
+    #             os_code_names:
+    #                 trusty:
+    #                     <<: *DEFAULT
+    #                     archs:
+    #                         - amd64
+    #                     tag_names:
+    #                         gzserver5:
+    #                             aliases:
+    #                                 - "gzserver5"
+    #                                 - "gzserver5-$os_code_name"
+    #                         libgazebo5:
+    #                             aliases:
+    #                                 - "libgazebo5"
+    #                                 - "libgazebo5-$os_code_name"
+    # '6':
+    #     eol: 2017-01-25
+    #     os_names:
+    #         ubuntu:
+    #             os_code_names:
+    #                 trusty:
+    #                     <<: *DEFAULT
+    #                     archs:
+    #                         - amd64
+    #                     tag_names:
+    #                         gzserver6:
+    #                             aliases:
+    #                                 - "gzserver6"
+    #                                 - "gzserver6-$os_code_name"
+    #                         libgazebo6:
+    #                             aliases:
+    #                                 - "libgazebo6"
+    #                                 - "libgazebo6-$os_code_name"
     '7':
         eol: 2021-01-25
         os_names:


### PR DESCRIPTION
Implement proposal of https://github.com/osrf/docker_images/issues/118#issuecomment-422948300 to stop building images for gazebo 4, 5 and 6.

In the future maybe we could find a way to leverage the eol tag in manifest to disable them as soon as they pass the listed EOL date.