### PR TITLE
WIP | Adding ros2 nightly dockerfile

### DIFF
--- a/ros2/nightly/Makefile
+++ b/ros2/nightly/Makefile
@@ -1,0 +1,19 @@
+all: help
+
+help:
+	@echo ""
+	@echo "-- Help Menu"
+	@echo ""
+	@echo "   1. make build            - build all images"
+	@echo "   2. make pull             - pull all images"
+	@echo "   3. make clean            - remove all images"
+	@echo ""
+
+build:
+	@docker build --tag=ros2:nightly			nightly/.
+
+pull:
+	@docker pull ros2:nightly
+
+clean:
+	@docker rmi -f ros2:nightly

--- a/ros2/nightly/images.yaml.em
+++ b/ros2/nightly/images.yaml.em
@@ -1,0 +1,50 @@
+%YAML 1.1
+# ROS2 Dockerfile database
+---
+images:
+    nightly:
+        base_image: @(os_name):@(os_code_name)
+        maintainer_name: @(maintainer_name)
+        template_name: docker_images/create_ros2_nightly_image.Dockerfile.em
+        entrypoint_name: docker_images/ros2_nightly_entrypoint.sh
+        template_packages:
+            - docker_templates
+        upstream_packages:
+            - bash-completion
+            - git
+            - libasio-dev
+            - libtinyxml2-dev
+            - wget
+        ros2_repo_packages:
+            - python3-catkin-pkg-modules
+            - python3-rosdep
+            - python3-vcstool
+        pip3_install:
+            - argcomplete
+            - flake8
+            - flake8-blind-except
+            - flake8-builtins
+            - flake8-class-newline
+            - flake8-comprehensions
+            - flake8-deprecated
+            - flake8-docstrings
+            - flake8-import-order
+            - flake8-quotes
+            - pytest-repeat
+            - pytest-rerunfailures
+        ws: /root/ros2_ws
+        install_package_args:
+            - build
+            - --cmake-args
+                -DSECURITY=ON --no-warn-unused-cli
+            - --symlink-install
+        rosdep:
+            rosdistro_index_url: https://raw.githubusercontent.com/ros2/rosdistro/ros2/index.yaml
+            install:
+                - --from-paths src
+                - --ignore-src
+                - --rosdistro bouncy
+                - --skip-keys "console_bridge fastcdr fastrtps libopensplice67 rti-connext-dds-5.3.1 urdfdom_headers"
+        vcs:
+            ros2:
+                repos: https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos

--- a/ros2/nightly/nightly/Dockerfile
+++ b/ros2/nightly/nightly/Dockerfile
@@ -1,0 +1,85 @@
+# This is an auto generated Dockerfile for ros2:nightly
+# generated from docker_images/create_ros2_nightly_image.Dockerfile.em
+FROM ubuntu:bionic
+
+# set timezone
+RUN echo 'Etc/UTC' > /etc/timezone && \
+    ln -s /usr/share/zoneinfo/Etc/UTC /etc/localtime && \
+    apt-get update && apt-get install -q -y tzdata && rm -rf /var/lib/apt/lists/*
+
+# install packages
+RUN apt-get update && apt-get install -q -y \
+    bash-completion \
+    dirmngr \
+    git \
+    gnupg2 \
+    libasio-dev \
+    libtinyxml2-dev \
+    lsb-release \
+    python3-pip \
+    wget \
+    && rm -rf /var/lib/apt/lists/*
+
+# setup keys
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
+
+# setup sources.list
+RUN . /etc/os-release \
+    && echo "deb http://repo.ros2.org/$ID/main `lsb_release -sc` main" > /etc/apt/sources.list.d/ros2-latest.list
+
+# setup environment
+ENV LANG C.UTF-8
+ENV LC_ALL C.UTF-8
+
+# install packages from the ROS repositories
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3-catkin-pkg-modules \
+    python3-colcon-common-extensions \
+    python3-rosdep \
+    python3-vcstool \
+    && rm -rf /var/lib/apt/lists/*
+
+# install python packages
+RUN pip3 install -U \
+    argcomplete \
+    flake8 \
+    flake8-blind-except \
+    flake8-builtins \
+    flake8-class-newline \
+    flake8-comprehensions \
+    flake8-deprecated \
+    flake8-docstrings \
+    flake8-import-order \
+    flake8-quotes \
+    pytest-repeat \
+    pytest-rerunfailures
+
+# bootstrap rosdep
+ENV ROSDISTRO_INDEX_URL https://raw.githubusercontent.com/ros2/rosdistro/ros2/index.yaml
+RUN rosdep init \
+    && rosdep update
+
+# download nightly build
+ENV ROS2_INSTALL /opt/ros/nightly
+RUN mkdir -p $ROS2_INSTALL
+WORKDIR $ROS2_INSTALL
+
+ENV ROS2_BINARY_URL https://ci.ros2.org/view/packaging/job/packaging_linux/lastSuccessfulBuild/artifact/ws/ros2-package-linux-x86_64.tar.bz2
+RUN wget -q $ROS2_BINARY_URL -O - | \
+    tar -xj --strip-components=1 \
+      ros2-linux -C $ROS2_INSTALL
+
+# install dependencies
+RUN apt-get update && rosdep install -y \
+    --from-paths $ROS2_INSTALL/share \
+    --ignore-src \
+    --rosdistro bouncy \
+    --skip-keys "console_bridge fastcdr fastrtps libopensplice67 rti-connext-dds-5.3.1 urdfdom_headers" \
+    && rm -rf /var/lib/apt/lists/*
+
+# setup entrypoint
+COPY ./ros2_nightly_entrypoint.sh /ros2_entrypoint.sh
+
+WORKDIR /root
+ENTRYPOINT ["/ros2_entrypoint.sh"]
+CMD ["bash"]

--- a/ros2/nightly/nightly/ros2_nightly_entrypoint.sh
+++ b/ros2/nightly/nightly/ros2_nightly_entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+# setup ros2 environment
+source "/opt/ros/nightly/local_setup.bash"
+exec "$@"

--- a/ros2/nightly/platform.yaml
+++ b/ros2/nightly/platform.yaml
@@ -1,0 +1,12 @@
+%YAML 1.1
+# ROS2 Dockerfile database
+---
+platform:
+    os_name: ubuntu
+    os_code_name: bionic
+    rosdistro_name: melodic
+    user_name: ros2
+    maintainer_name:
+    arch: amd64
+    type: distribution
+    version: 2


### PR DESCRIPTION
This PR address https://github.com/osrf/docker_images/issues/201 and addes a new Docker Image tag, 'nightly', to the ROS2 automated repo, providing a covenant installation of ci.ros2.org nightly builds. Some remaining action items:

- [ ] Create respective docker_template file for nightly dockerfile
- [ ] Parameterized dockerfile elements into images.yaml.em
- [ ] Reduce image size (prune unneeded apt install?)
- [ ] Add webhook for new tag on Docker Hub
- [ ] Trigger webhook from ci.ros2.org nightly job

ping @mkhansen-intel 