### PR TITLE
Add support for arm32v7 and arm64v8 with Gazebo v9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ env:
   - HUB_REPO=ros    HUB_RELEASE=indigo  HUB_OS_NAME=ubuntu HUB_OS_CODE_NAME=trusty
   # gazebo
   - HUB_REPO=gazebo HUB_RELEASE=9       HUB_OS_NAME=ubuntu HUB_OS_CODE_NAME=bionic
+  - HUB_REPO=gazebo HUB_RELEASE=9       HUB_OS_NAME=debian HUB_OS_CODE_NAME=stretch
   - HUB_REPO=gazebo HUB_RELEASE=9       HUB_OS_NAME=ubuntu HUB_OS_CODE_NAME=xenial
   - HUB_REPO=gazebo HUB_RELEASE=8       HUB_OS_NAME=ubuntu HUB_OS_CODE_NAME=xenial
   - HUB_REPO=gazebo HUB_RELEASE=7       HUB_OS_NAME=ubuntu HUB_OS_CODE_NAME=xenial

--- a/gazebo/.config/Makefile.em
+++ b/gazebo/.config/Makefile.em
@@ -10,19 +10,19 @@ help:
 	@echo ""
 
 build:
-	@docker build --tag=gazebo:gzserver$release_name	gzserver$release_name/.
-	@docker build --tag=gazebo:libgazebo$release_name	libgazebo$release_name/.
-	# @docker build --tag=gazebo:gzclient$release_name	gzclient$release_name/.
-	# @docker build --tag=gazebo:gzweb$release_name			gzweb$release_name/.
+	@docker build --tag=gazebo:gzserver$release_name-$os_code_name	gzserver$release_name/.
+	@docker build --tag=gazebo:libgazebo$release_name-$os_code_name	libgazebo$release_name/.
+	# @docker build --tag=gazebo:gzclient$release_name-$os_code_name	gzclient$release_name/.
+	# @docker build --tag=gazebo:gzweb$release_name-$os_code_name			gzweb$release_name/.
 
 pull:
-	@docker pull gazebo:libgazebo$release_name
-	@docker pull gazebo:gzserver$release_name
-	# @docker pull gazebo:gzclient$release_name
-	# @docker pull gazebo:gzweb$release_name
+	@docker pull gazebo:libgazebo$release_name-$os_code_name
+	@docker pull gazebo:gzserver$release_name-$os_code_name
+	# @docker pull gazebo:gzclient$release_name-$os_code_name
+	# @docker pull gazebo:gzweb$release_name-$os_code_name
 
 clean:
-	@docker rmi -f gazebo:libgazebo$release_name
-	@docker rmi -f gazebo:gzserver$release_name
-	# @docker rmi -f gazebo:gzclient$release_name
-	# @docker rmi -f gazebo:gzweb$release_name
+	@docker rmi -f gazebo:libgazebo$release_name-$os_code_name
+	@docker rmi -f gazebo:gzserver$release_name-$os_code_name
+	# @docker rmi -f gazebo:gzclient$release_name-$os_code_name
+	# @docker rmi -f gazebo:gzweb$release_name-$os_code_name

--- a/gazebo/4/ubuntu/trusty/Makefile
+++ b/gazebo/4/ubuntu/trusty/Makefile
@@ -10,19 +10,19 @@ help:
 	@echo ""
 
 build:
-	@docker build --tag=gazebo:gzserver4	gzserver4/.
-	@docker build --tag=gazebo:libgazebo4	libgazebo4/.
-	# @docker build --tag=gazebo:gzclient4	gzclient4/.
-	# @docker build --tag=gazebo:gzweb4			gzweb4/.
+	@docker build --tag=gazebo:gzserver4-trusty	gzserver4/.
+	@docker build --tag=gazebo:libgazebo4-trusty	libgazebo4/.
+	# @docker build --tag=gazebo:gzclient4-trusty	gzclient4/.
+	# @docker build --tag=gazebo:gzweb4-trusty			gzweb4/.
 
 pull:
-	@docker pull gazebo:libgazebo4
-	@docker pull gazebo:gzserver4
-	# @docker pull gazebo:gzclient4
-	# @docker pull gazebo:gzweb4
+	@docker pull gazebo:libgazebo4-trusty
+	@docker pull gazebo:gzserver4-trusty
+	# @docker pull gazebo:gzclient4-trusty
+	# @docker pull gazebo:gzweb4-trusty
 
 clean:
-	@docker rmi -f gazebo:libgazebo4
-	@docker rmi -f gazebo:gzserver4
-	# @docker rmi -f gazebo:gzclient4
-	# @docker rmi -f gazebo:gzweb4
+	@docker rmi -f gazebo:libgazebo4-trusty
+	@docker rmi -f gazebo:gzserver4-trusty
+	# @docker rmi -f gazebo:gzclient4-trusty
+	# @docker rmi -f gazebo:gzweb4-trusty

--- a/gazebo/5/ubuntu/trusty/Makefile
+++ b/gazebo/5/ubuntu/trusty/Makefile
@@ -10,19 +10,19 @@ help:
 	@echo ""
 
 build:
-	@docker build --tag=gazebo:gzserver5	gzserver5/.
-	@docker build --tag=gazebo:libgazebo5	libgazebo5/.
-	# @docker build --tag=gazebo:gzclient5	gzclient5/.
-	# @docker build --tag=gazebo:gzweb5			gzweb5/.
+	@docker build --tag=gazebo:gzserver5-trusty	gzserver5/.
+	@docker build --tag=gazebo:libgazebo5-trusty	libgazebo5/.
+	# @docker build --tag=gazebo:gzclient5-trusty	gzclient5/.
+	# @docker build --tag=gazebo:gzweb5-trusty			gzweb5/.
 
 pull:
-	@docker pull gazebo:libgazebo5
-	@docker pull gazebo:gzserver5
-	# @docker pull gazebo:gzclient5
-	# @docker pull gazebo:gzweb5
+	@docker pull gazebo:libgazebo5-trusty
+	@docker pull gazebo:gzserver5-trusty
+	# @docker pull gazebo:gzclient5-trusty
+	# @docker pull gazebo:gzweb5-trusty
 
 clean:
-	@docker rmi -f gazebo:libgazebo5
-	@docker rmi -f gazebo:gzserver5
-	# @docker rmi -f gazebo:gzclient5
-	# @docker rmi -f gazebo:gzweb5
+	@docker rmi -f gazebo:libgazebo5-trusty
+	@docker rmi -f gazebo:gzserver5-trusty
+	# @docker rmi -f gazebo:gzclient5-trusty
+	# @docker rmi -f gazebo:gzweb5-trusty

--- a/gazebo/6/ubuntu/trusty/Makefile
+++ b/gazebo/6/ubuntu/trusty/Makefile
@@ -10,19 +10,19 @@ help:
 	@echo ""
 
 build:
-	@docker build --tag=gazebo:gzserver6	gzserver6/.
-	@docker build --tag=gazebo:libgazebo6	libgazebo6/.
-	# @docker build --tag=gazebo:gzclient6	gzclient6/.
-	# @docker build --tag=gazebo:gzweb6			gzweb6/.
+	@docker build --tag=gazebo:gzserver6-trusty	gzserver6/.
+	@docker build --tag=gazebo:libgazebo6-trusty	libgazebo6/.
+	# @docker build --tag=gazebo:gzclient6-trusty	gzclient6/.
+	# @docker build --tag=gazebo:gzweb6-trusty			gzweb6/.
 
 pull:
-	@docker pull gazebo:libgazebo6
-	@docker pull gazebo:gzserver6
-	# @docker pull gazebo:gzclient6
-	# @docker pull gazebo:gzweb6
+	@docker pull gazebo:libgazebo6-trusty
+	@docker pull gazebo:gzserver6-trusty
+	# @docker pull gazebo:gzclient6-trusty
+	# @docker pull gazebo:gzweb6-trusty
 
 clean:
-	@docker rmi -f gazebo:libgazebo6
-	@docker rmi -f gazebo:gzserver6
-	# @docker rmi -f gazebo:gzclient6
-	# @docker rmi -f gazebo:gzweb6
+	@docker rmi -f gazebo:libgazebo6-trusty
+	@docker rmi -f gazebo:gzserver6-trusty
+	# @docker rmi -f gazebo:gzclient6-trusty
+	# @docker rmi -f gazebo:gzweb6-trusty

--- a/gazebo/7/ubuntu/xenial/Makefile
+++ b/gazebo/7/ubuntu/xenial/Makefile
@@ -10,19 +10,19 @@ help:
 	@echo ""
 
 build:
-	@docker build --tag=gazebo:gzserver7	gzserver7/.
-	@docker build --tag=gazebo:libgazebo7	libgazebo7/.
-	# @docker build --tag=gazebo:gzclient7	gzclient7/.
-	# @docker build --tag=gazebo:gzweb7			gzweb7/.
+	@docker build --tag=gazebo:gzserver7-xenial	gzserver7/.
+	@docker build --tag=gazebo:libgazebo7-xenial	libgazebo7/.
+	# @docker build --tag=gazebo:gzclient7-xenial	gzclient7/.
+	# @docker build --tag=gazebo:gzweb7-xenial			gzweb7/.
 
 pull:
-	@docker pull gazebo:libgazebo7
-	@docker pull gazebo:gzserver7
-	# @docker pull gazebo:gzclient7
-	# @docker pull gazebo:gzweb7
+	@docker pull gazebo:libgazebo7-xenial
+	@docker pull gazebo:gzserver7-xenial
+	# @docker pull gazebo:gzclient7-xenial
+	# @docker pull gazebo:gzweb7-xenial
 
 clean:
-	@docker rmi -f gazebo:libgazebo7
-	@docker rmi -f gazebo:gzserver7
-	# @docker rmi -f gazebo:gzclient7
-	# @docker rmi -f gazebo:gzweb7
+	@docker rmi -f gazebo:libgazebo7-xenial
+	@docker rmi -f gazebo:gzserver7-xenial
+	# @docker rmi -f gazebo:gzclient7-xenial
+	# @docker rmi -f gazebo:gzweb7-xenial

--- a/gazebo/8/ubuntu/xenial/Makefile
+++ b/gazebo/8/ubuntu/xenial/Makefile
@@ -10,19 +10,19 @@ help:
 	@echo ""
 
 build:
-	@docker build --tag=gazebo:gzserver8	gzserver8/.
-	@docker build --tag=gazebo:libgazebo8	libgazebo8/.
-	# @docker build --tag=gazebo:gzclient8	gzclient8/.
-	# @docker build --tag=gazebo:gzweb8			gzweb8/.
+	@docker build --tag=gazebo:gzserver8-xenial	gzserver8/.
+	@docker build --tag=gazebo:libgazebo8-xenial	libgazebo8/.
+	# @docker build --tag=gazebo:gzclient8-xenial	gzclient8/.
+	# @docker build --tag=gazebo:gzweb8-xenial			gzweb8/.
 
 pull:
-	@docker pull gazebo:libgazebo8
-	@docker pull gazebo:gzserver8
-	# @docker pull gazebo:gzclient8
-	# @docker pull gazebo:gzweb8
+	@docker pull gazebo:libgazebo8-xenial
+	@docker pull gazebo:gzserver8-xenial
+	# @docker pull gazebo:gzclient8-xenial
+	# @docker pull gazebo:gzweb8-xenial
 
 clean:
-	@docker rmi -f gazebo:libgazebo8
-	@docker rmi -f gazebo:gzserver8
-	# @docker rmi -f gazebo:gzclient8
-	# @docker rmi -f gazebo:gzweb8
+	@docker rmi -f gazebo:libgazebo8-xenial
+	@docker rmi -f gazebo:gzserver8-xenial
+	# @docker rmi -f gazebo:gzclient8-xenial
+	# @docker rmi -f gazebo:gzweb8-xenial

--- a/gazebo/9/debian/stretch/Makefile
+++ b/gazebo/9/debian/stretch/Makefile
@@ -1,0 +1,28 @@
+all: help
+
+help:
+	@echo ""
+	@echo "-- Help Menu"
+	@echo ""
+	@echo "   1. make build            - build all images"
+	@echo "   2. make pull             - pull all images"
+	@echo "   3. make clean            - remove all images"
+	@echo ""
+
+build:
+	@docker build --tag=gazebo:gzserver9-stretch	gzserver9/.
+	@docker build --tag=gazebo:libgazebo9-stretch	libgazebo9/.
+	# @docker build --tag=gazebo:gzclient9-stretch	gzclient9/.
+	# @docker build --tag=gazebo:gzweb9-stretch			gzweb9/.
+
+pull:
+	@docker pull gazebo:libgazebo9-stretch
+	@docker pull gazebo:gzserver9-stretch
+	# @docker pull gazebo:gzclient9-stretch
+	# @docker pull gazebo:gzweb9-stretch
+
+clean:
+	@docker rmi -f gazebo:libgazebo9-stretch
+	@docker rmi -f gazebo:gzserver9-stretch
+	# @docker rmi -f gazebo:gzclient9-stretch
+	# @docker rmi -f gazebo:gzweb9-stretch

--- a/gazebo/9/debian/stretch/gzclient9/Dockerfile
+++ b/gazebo/9/debian/stretch/gzclient9/Dockerfile
@@ -1,0 +1,16 @@
+# This is an auto generated Dockerfile for gazebo:gzclient9
+# generated from docker_images/create_gzclient_image.Dockerfile.em
+FROM gazebo:gzserver9-stretch
+
+# install packages
+RUN apt-get update && apt-get install -q -y \
+    binutils \
+    mesa-utils \
+    module-init-tools \
+    x-window-system \
+    && rm -rf /var/lib/apt/lists/*
+
+# install gazebo packages
+RUN apt-get update && apt-get install -q -y \
+    gazebo9=9.0.0-2* \
+    && rm -rf /var/lib/apt/lists/*

--- a/gazebo/9/debian/stretch/gzserver9/Dockerfile
+++ b/gazebo/9/debian/stretch/gzserver9/Dockerfile
@@ -1,0 +1,31 @@
+# This is an auto generated Dockerfile for gazebo:gzserver9
+# generated from docker_images/create_gzserver_image.Dockerfile.em
+FROM debian:stretch
+
+# install packages
+RUN apt-get update && apt-get install -q -y \
+    dirmngr \
+    gnupg2 \
+    lsb-release \
+    && rm -rf /var/lib/apt/lists/*
+
+# setup keys
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys D2486D2DD83DB69272AFE98867170598AF249743
+
+# setup sources.list
+RUN . /etc/os-release \
+    && echo "deb http://packages.osrfoundation.org/gazebo/$ID-stable `lsb_release -sc` main" > /etc/apt/sources.list.d/gazebo-latest.list
+
+# install gazebo packages
+RUN apt-get update && apt-get install -q -y \
+    gazebo9=9.0.0-2* \
+    && rm -rf /var/lib/apt/lists/*
+
+# setup environment
+EXPOSE 11345
+
+# setup entrypoint
+COPY ./gzserver_entrypoint.sh /
+
+ENTRYPOINT ["/gzserver_entrypoint.sh"]
+CMD ["gzserver"]

--- a/gazebo/9/debian/stretch/gzserver9/gzserver_entrypoint.sh
+++ b/gazebo/9/debian/stretch/gzserver9/gzserver_entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+# setup gazebo environment
+source "/usr/share/gazebo/setup.sh"
+exec "$@"

--- a/gazebo/9/debian/stretch/gzweb9/Dockerfile
+++ b/gazebo/9/debian/stretch/gzweb9/Dockerfile
@@ -1,0 +1,42 @@
+# This is an auto generated Dockerfile for gazebo:gzweb9
+# generated from docker_images/create_gzweb_image.Dockerfile.em
+FROM gazebo:libgazebo9-stretch
+
+# install packages
+RUN apt-get update && apt-get install -q -y \
+    build-essential \
+    cmake \
+    imagemagick \
+    libboost-all-dev \
+    libgts-dev \
+    libjansson-dev \
+    libtinyxml-dev \
+    mercurial \
+    nodejs \
+    nodejs-legacy \
+    npm \
+    pkg-config \
+    psmisc \
+    xvfb \
+    && rm -rf /var/lib/apt/lists/*
+
+# install gazebo packages
+RUN apt-get update && apt-get install -q -y \
+    libgazebo9-dev=9.0.0-2* \
+    && rm -rf /var/lib/apt/lists/*
+
+# clone gzweb
+ENV GZWEB_WS /root/gzweb
+RUN hg clone https://bitbucket.org/osrf/gzweb $GZWEB_WS
+WORKDIR $GZWEB_WS
+
+# build gzweb
+RUN hg up default \
+    && xvfb-run -s "-screen 0 1280x1024x24" ./deploy.sh -m -t
+
+# setup environment
+EXPOSE 8080
+EXPOSE 7681
+
+# run gzserver and gzweb
+CMD gzserver --verbose & npm start

--- a/gazebo/9/debian/stretch/images.yaml.em
+++ b/gazebo/9/debian/stretch/images.yaml.em
@@ -1,0 +1,57 @@
+%YAML 1.1
+# Gazebo Dockerfile database
+---
+images:
+    gzserver@(gazebo_version):
+        base_image: @(os_name):@(os_code_name)
+        maintainer_name: @(maintainer_name)
+        template_name: docker_images/create_gzserver_image.Dockerfile.em
+        entrypoint_name: docker_images/gzserver_entrypoint.sh
+        template_packages:
+            - docker_templates
+        gazebo_packages:
+            - gazebo@(gazebo_version)
+    libgazebo@(gazebo_version):
+        base_image: @(user_name):gzserver@(gazebo_version)-@(os_code_name)
+        maintainer_name: @(maintainer_name)
+        template_name: docker_images/create_gzclient_image.Dockerfile.em
+        template_packages:
+            - docker_templates
+        gazebo_packages:
+            - libgazebo@(gazebo_version)-dev
+    gzweb@(gazebo_version):
+        base_image: @(user_name):libgazebo@(gazebo_version)-@(os_code_name)
+        maintainer_name: @(maintainer_name)
+        template_name: docker_images/create_gzweb_image.Dockerfile.em
+        template_packages:
+            - docker_templates
+        upstream_packages:
+            - build-essential
+            - cmake
+            - imagemagick
+            - libboost-all-dev
+            - libgts-dev
+            - libjansson-dev
+            - libtinyxml-dev
+            - mercurial
+            - nodejs
+            - nodejs-legacy
+            - npm
+            - pkg-config
+            - psmisc
+            - xvfb
+        gazebo_packages:
+            - libgazebo@(gazebo_version)-dev
+    gzclient@(gazebo_version):
+        base_image: @(user_name):gzserver@(gazebo_version)-@(os_code_name)
+        maintainer_name: @(maintainer_name)
+        template_name: docker_images/create_gzclient_image.Dockerfile.em
+        template_packages:
+            - docker_templates
+        upstream_packages:
+            - binutils
+            - mesa-utils
+            - module-init-tools
+            - x-window-system
+        gazebo_packages:
+            - gazebo@(gazebo_version)

--- a/gazebo/9/debian/stretch/libgazebo9/Dockerfile
+++ b/gazebo/9/debian/stretch/libgazebo9/Dockerfile
@@ -1,0 +1,7 @@
+# This is an auto generated Dockerfile for gazebo:libgazebo9
+# generated from docker_images/create_gzclient_image.Dockerfile.em
+FROM gazebo:gzserver9-stretch
+# install gazebo packages
+RUN apt-get update && apt-get install -q -y \
+    libgazebo9-dev=9.0.0-2* \
+    && rm -rf /var/lib/apt/lists/*

--- a/gazebo/9/debian/stretch/platform.yaml
+++ b/gazebo/9/debian/stretch/platform.yaml
@@ -1,0 +1,13 @@
+%YAML 1.1
+# Gazebo Dockerfile database
+---
+platform:
+    os_name: debian
+    os_code_name: stretch
+    gazebo_version: 9
+    user_name: gazebo
+    maintainer_name:
+    arch: amd64
+    type: distribution
+    version:
+    release: stable

--- a/gazebo/9/ubuntu/bionic/Makefile
+++ b/gazebo/9/ubuntu/bionic/Makefile
@@ -10,19 +10,19 @@ help:
 	@echo ""
 
 build:
-	@docker build --tag=gazebo:gzserver9	gzserver9/.
-	@docker build --tag=gazebo:libgazebo9	libgazebo9/.
-	# @docker build --tag=gazebo:gzclient9	gzclient9/.
-	# @docker build --tag=gazebo:gzweb9			gzweb9/.
+	@docker build --tag=gazebo:gzserver9-bionic	gzserver9/.
+	@docker build --tag=gazebo:libgazebo9-bionic	libgazebo9/.
+	# @docker build --tag=gazebo:gzclient9-bionic	gzclient9/.
+	# @docker build --tag=gazebo:gzweb9-bionic			gzweb9/.
 
 pull:
-	@docker pull gazebo:libgazebo9
-	@docker pull gazebo:gzserver9
-	# @docker pull gazebo:gzclient9
-	# @docker pull gazebo:gzweb9
+	@docker pull gazebo:libgazebo9-bionic
+	@docker pull gazebo:gzserver9-bionic
+	# @docker pull gazebo:gzclient9-bionic
+	# @docker pull gazebo:gzweb9-bionic
 
 clean:
-	@docker rmi -f gazebo:libgazebo9
-	@docker rmi -f gazebo:gzserver9
-	# @docker rmi -f gazebo:gzclient9
-	# @docker rmi -f gazebo:gzweb9
+	@docker rmi -f gazebo:libgazebo9-bionic
+	@docker rmi -f gazebo:gzserver9-bionic
+	# @docker rmi -f gazebo:gzclient9-bionic
+	# @docker rmi -f gazebo:gzweb9-bionic

--- a/gazebo/9/ubuntu/xenial/Makefile
+++ b/gazebo/9/ubuntu/xenial/Makefile
@@ -10,19 +10,19 @@ help:
 	@echo ""
 
 build:
-	@docker build --tag=gazebo:gzserver9	gzserver9/.
-	@docker build --tag=gazebo:libgazebo9	libgazebo9/.
-	# @docker build --tag=gazebo:gzclient9	gzclient9/.
-	# @docker build --tag=gazebo:gzweb9			gzweb9/.
+	@docker build --tag=gazebo:gzserver9-xenial	gzserver9/.
+	@docker build --tag=gazebo:libgazebo9-xenial	libgazebo9/.
+	# @docker build --tag=gazebo:gzclient9-xenial	gzclient9/.
+	# @docker build --tag=gazebo:gzweb9-xenial			gzweb9/.
 
 pull:
-	@docker pull gazebo:libgazebo9
-	@docker pull gazebo:gzserver9
-	# @docker pull gazebo:gzclient9
-	# @docker pull gazebo:gzweb9
+	@docker pull gazebo:libgazebo9-xenial
+	@docker pull gazebo:gzserver9-xenial
+	# @docker pull gazebo:gzclient9-xenial
+	# @docker pull gazebo:gzweb9-xenial
 
 clean:
-	@docker rmi -f gazebo:libgazebo9
-	@docker rmi -f gazebo:gzserver9
-	# @docker rmi -f gazebo:gzclient9
-	# @docker rmi -f gazebo:gzweb9
+	@docker rmi -f gazebo:libgazebo9-xenial
+	@docker rmi -f gazebo:gzserver9-xenial
+	# @docker rmi -f gazebo:gzclient9-xenial
+	# @docker rmi -f gazebo:gzweb9-xenial

--- a/gazebo/gazebo
+++ b/gazebo/gazebo
@@ -9,12 +9,12 @@ GitRepo: https://github.com/osrf/docker_images.git
 
 Tags: gzserver7, gzserver7-xenial
 Architectures: amd64
-GitCommit: c5ca5054c6921645802f21e888b79f464863eb1a
+GitCommit: ed75e08b51ca57c98fad49705091ceb89a96814c
 Directory: gazebo/7/ubuntu/xenial/gzserver7
 
 Tags: libgazebo7, libgazebo7-xenial
 Architectures: amd64
-GitCommit: c5ca5054c6921645802f21e888b79f464863eb1a
+GitCommit: ed75e08b51ca57c98fad49705091ceb89a96814c
 Directory: gazebo/7/ubuntu/xenial/libgazebo7
 
 
@@ -26,12 +26,12 @@ Directory: gazebo/7/ubuntu/xenial/libgazebo7
 
 Tags: gzserver8, gzserver8-xenial
 Architectures: amd64
-GitCommit: c5ca5054c6921645802f21e888b79f464863eb1a
+GitCommit: ed75e08b51ca57c98fad49705091ceb89a96814c
 Directory: gazebo/8/ubuntu/xenial/gzserver8
 
 Tags: libgazebo8, libgazebo8-xenial
 Architectures: amd64
-GitCommit: c5ca5054c6921645802f21e888b79f464863eb1a
+GitCommit: ed75e08b51ca57c98fad49705091ceb89a96814c
 Directory: gazebo/8/ubuntu/xenial/libgazebo8
 
 
@@ -43,12 +43,12 @@ Directory: gazebo/8/ubuntu/xenial/libgazebo8
 
 Tags: gzserver9-xenial
 Architectures: amd64
-GitCommit: df787a9fad9aacbea3ae2e85aa6247d8baa522fd
+GitCommit: ed75e08b51ca57c98fad49705091ceb89a96814c
 Directory: gazebo/9/ubuntu/xenial/gzserver9
 
 Tags: libgazebo9-xenial
 Architectures: amd64
-GitCommit: df787a9fad9aacbea3ae2e85aa6247d8baa522fd
+GitCommit: ed75e08b51ca57c98fad49705091ceb89a96814c
 Directory: gazebo/9/ubuntu/xenial/libgazebo9
 
 ########################################
@@ -56,11 +56,24 @@ Directory: gazebo/9/ubuntu/xenial/libgazebo9
 
 Tags: gzserver9, gzserver9-bionic
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: df787a9fad9aacbea3ae2e85aa6247d8baa522fd
+GitCommit: ed75e08b51ca57c98fad49705091ceb89a96814c
 Directory: gazebo/9/ubuntu/bionic/gzserver9
 
 Tags: libgazebo9, libgazebo9-bionic, latest
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: df787a9fad9aacbea3ae2e85aa6247d8baa522fd
+GitCommit: ed75e08b51ca57c98fad49705091ceb89a96814c
 Directory: gazebo/9/ubuntu/bionic/libgazebo9
+
+########################################
+# Distro: debian:stretch
+
+Tags: gzserver9-stretch
+Architectures: amd64, arm32v7, arm64v8
+GitCommit: 6b86a1aa2adc393e026e86d704032cd2d8d1e1ac
+Directory: gazebo/9/debian/stretch/gzserver9
+
+Tags: libgazebo9-stretch
+Architectures: amd64, arm32v7, arm64v8
+GitCommit: 6b86a1aa2adc393e026e86d704032cd2d8d1e1ac
+Directory: gazebo/9/debian/stretch/libgazebo9
 

--- a/gazebo/gazebo
+++ b/gazebo/gazebo
@@ -55,12 +55,12 @@ Directory: gazebo/9/ubuntu/xenial/libgazebo9
 # Distro: ubuntu:bionic
 
 Tags: gzserver9, gzserver9-bionic
-Architectures: amd64
+Architectures: amd64, arm32v7, arm64v8
 GitCommit: df787a9fad9aacbea3ae2e85aa6247d8baa522fd
 Directory: gazebo/9/ubuntu/bionic/gzserver9
 
 Tags: libgazebo9, libgazebo9-bionic, latest
-Architectures: amd64
+Architectures: amd64, arm32v7, arm64v8
 GitCommit: df787a9fad9aacbea3ae2e85aa6247d8baa522fd
 Directory: gazebo/9/ubuntu/bionic/libgazebo9
 

--- a/gazebo/manifest.yaml
+++ b/gazebo/manifest.yaml
@@ -125,6 +125,8 @@ release_names:
                         <<: *DEFAULT
                         archs:
                             - amd64
+                            - arm32v7
+                            - arm64v8
                         tag_names:
                             gzserver9:
                                 aliases:

--- a/gazebo/manifest.yaml
+++ b/gazebo/manifest.yaml
@@ -27,12 +27,12 @@ release_names:
     #                     tag_names:
     #                         gzserver4:
     #                             aliases:
-    #                                 - "gzserver4"
-    #                                 - "gzserver4-$os_code_name"
+    #                                 - "gzserver$release_name"
+    #                                 - "gzserver$release_name-$os_code_name"
     #                         libgazebo4:
     #                             aliases:
-    #                                 - "libgazebo4"
-    #                                 - "libgazebo4-$os_code_name"
+    #                                 - "libgazebo$release_name"
+    #                                 - "libgazebo$release_name-$os_code_name"
     # '5':
     #     eol: 2017-01-25
     #     os_names:
@@ -45,12 +45,12 @@ release_names:
     #                     tag_names:
     #                         gzserver5:
     #                             aliases:
-    #                                 - "gzserver5"
-    #                                 - "gzserver5-$os_code_name"
+    #                                 - "gzserver$release_name"
+    #                                 - "gzserver$release_name-$os_code_name"
     #                         libgazebo5:
     #                             aliases:
-    #                                 - "libgazebo5"
-    #                                 - "libgazebo5-$os_code_name"
+    #                                 - "libgazebo$release_name"
+    #                                 - "libgazebo$release_name-$os_code_name"
     # '6':
     #     eol: 2017-01-25
     #     os_names:
@@ -63,12 +63,12 @@ release_names:
     #                     tag_names:
     #                         gzserver6:
     #                             aliases:
-    #                                 - "gzserver6"
-    #                                 - "gzserver6-$os_code_name"
+    #                                 - "gzserver$release_name"
+    #                                 - "gzserver$release_name-$os_code_name"
     #                         libgazebo6:
     #                             aliases:
-    #                                 - "libgazebo6"
-    #                                 - "libgazebo6-$os_code_name"
+    #                                 - "libgazebo$release_name"
+    #                                 - "libgazebo$release_name-$os_code_name"
     '7':
         eol: 2021-01-25
         os_names:
@@ -81,12 +81,12 @@ release_names:
                         tag_names:
                             gzserver7:
                                 aliases:
-                                    - "gzserver7"
-                                    - "gzserver7-$os_code_name"
+                                    - "gzserver$release_name"
+                                    - "gzserver$release_name-$os_code_name"
                             libgazebo7:
                                 aliases:
-                                    - "libgazebo7"
-                                    - "libgazebo7-$os_code_name"
+                                    - "libgazebo$release_name"
+                                    - "libgazebo$release_name-$os_code_name"
     '8':
         eol: 2019-01-25
         os_names:
@@ -99,12 +99,12 @@ release_names:
                         tag_names:
                             gzserver8:
                                 aliases:
-                                    - "gzserver8"
-                                    - "gzserver8-$os_code_name"
+                                    - "gzserver$release_name"
+                                    - "gzserver$release_name-$os_code_name"
                             libgazebo8:
                                 aliases:
-                                    - "libgazebo8"
-                                    - "libgazebo8-$os_code_name"
+                                    - "libgazebo$release_name"
+                                    - "libgazebo$release_name-$os_code_name"
     '9':
         eol: 2023-01-25
         os_names:
@@ -117,10 +117,10 @@ release_names:
                         tag_names:
                             gzserver9:
                                 aliases:
-                                    - "gzserver9-$os_code_name"
+                                    - "gzserver$release_name-$os_code_name"
                             libgazebo9:
                                 aliases:
-                                    - "libgazebo9-$os_code_name"
+                                    - "libgazebo$release_name-$os_code_name"
                     bionic:
                         <<: *DEFAULT
                         archs:
@@ -130,13 +130,28 @@ release_names:
                         tag_names:
                             gzserver9:
                                 aliases:
-                                    - "gzserver9"
-                                    - "gzserver9-$os_code_name"
+                                    - "gzserver$release_name"
+                                    - "gzserver$release_name-$os_code_name"
                             libgazebo9:
                                 aliases:
-                                    - "libgazebo9"
-                                    - "libgazebo9-$os_code_name"
+                                    - "libgazebo$release_name"
+                                    - "libgazebo$release_name-$os_code_name"
                                     - latest
+            debian:
+                os_code_names:
+                    stretch:
+                        <<: *DEFAULT
+                        archs:
+                            - amd64
+                            - arm32v7
+                            - arm64v8
+                        tag_names:
+                            gzserver9:
+                                aliases:
+                                    - "gzserver$release_name-$os_code_name"
+                            libgazebo9:
+                                aliases:
+                                    - "libgazebo$release_name-$os_code_name"
 
 meta:
     maintainers:


### PR DESCRIPTION
Fixes: https://github.com/osrf/docker_images/issues/173

See available package listings:
* http://packages.osrfoundation.org/gazebo/ubuntu-stable/dists/bionic/main/binary-amd64/Packages
* http://packages.osrfoundation.org/gazebo/ubuntu-stable/dists/bionic/main/binary-armhf/Packages
* http://packages.osrfoundation.org/gazebo/ubuntu-stable/dists/bionic/main/binary-arm64/Packages 
* http://packages.osrfoundation.org/gazebo/debian-stable/dists/stretch/main/binary-amd64/Packages
* http://packages.osrfoundation.org/gazebo/debian-stable/dists/stretch/main/binary-armhf/Packages
* http://packages.osrfoundation.org/gazebo/debian-stable/dists/stretch/main/binary-arm64/Packages 