### PR TITLE
update index.yaml to use ros1 rosdistro

### DIFF
--- a/ros2/source/source/Dockerfile
+++ b/ros2/source/source/Dockerfile
@@ -54,7 +54,7 @@ RUN pip3 install -U \
     pytest-rerunfailures
 
 # bootstrap rosdep
-ENV ROSDISTRO_INDEX_URL https://raw.githubusercontent.com/ros2/rosdistro/ros2/index.yaml
+ENV ROSDISTRO_INDEX_URL https://raw.githubusercontent.com/ros/rosdistro/master/index.yaml
 RUN rosdep init \
     && rosdep update
 


### PR DESCRIPTION
the original link is not working any longer, results in 404 and thus the dockerfile doesn't complete.