### PR TITLE
ROS 2 uses same rosdistro URL as ROS 1

### DIFF
--- a/ros2/source/images.yaml.em
+++ b/ros2/source/images.yaml.em
@@ -39,7 +39,7 @@ images:
                 -DSECURITY=ON --no-warn-unused-cli
             - --symlink-install
         rosdep:
-            rosdistro_index_url: https://raw.githubusercontent.com/ros2/rosdistro/ros2/index.yaml
+            rosdistro_index_url: https://raw.githubusercontent.com/ros/rosdistro/master/index.yaml
             install:
                 - --from-paths src
                 - --ignore-src


### PR DESCRIPTION
I mistakenly merged #224, forgetting that file is generated