### PR TITLE
[ros2/source] Skip libopensplice69 key

### DIFF
--- a/ros2/source/images.yaml.em
+++ b/ros2/source/images.yaml.em
@@ -44,7 +44,7 @@ images:
                 - --from-paths src
                 - --ignore-src
                 - --rosdistro bouncy
-                - --skip-keys "console_bridge fastcdr fastrtps libopensplice67 rti-connext-dds-5.3.1 urdfdom_headers"
+                - --skip-keys "console_bridge fastcdr fastrtps libopensplice67 libopensplice69 rti-connext-dds-5.3.1 urdfdom_headers"
         vcs:
             ros2:
                 repos: https://raw.githubusercontent.com/ros2/ros2/release-latest/ros2.repos

--- a/ros2/source/source/Dockerfile
+++ b/ros2/source/source/Dockerfile
@@ -70,7 +70,7 @@ RUN apt-get update && rosdep install -y \
     --from-paths src \
     --ignore-src \
     --rosdistro bouncy \
-    --skip-keys "console_bridge fastcdr fastrtps libopensplice67 rti-connext-dds-5.3.1 urdfdom_headers" \
+    --skip-keys "console_bridge fastcdr fastrtps libopensplice67 libopensplice69 rti-connext-dds-5.3.1 urdfdom_headers" \
     && rm -rf /var/lib/apt/lists/*
 
 # build source


### PR DESCRIPTION
Otherwise opensplice is installed and message libraries are built for it