### PR TITLE
EOL ardent

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ env:
   # ros2
   - HUB_REPO=ros   HUB_RELEASE=crystal  HUB_OS_NAME=ubuntu HUB_OS_CODE_NAME=bionic
   - HUB_REPO=ros   HUB_RELEASE=bouncy   HUB_OS_NAME=ubuntu HUB_OS_CODE_NAME=bionic
-  - HUB_REPO=ros   HUB_RELEASE=ardent   HUB_OS_NAME=ubuntu HUB_OS_CODE_NAME=xenial
   # ros
   - HUB_REPO=ros    HUB_RELEASE=melodic HUB_OS_NAME=ubuntu HUB_OS_CODE_NAME=bionic
   - HUB_REPO=ros    HUB_RELEASE=melodic HUB_OS_NAME=debian HUB_OS_CODE_NAME=stretch

--- a/ros/manifest.yaml
+++ b/ros/manifest.yaml
@@ -336,15 +336,16 @@ release_names:
                             - amd64
                             - arm64v8
                         tag_names:
-                            ros-core:
-                                aliases:
-                                    - "$release_name-ros-core"
-                                    - "$release_name-ros-core-$os_code_name"
-                            ros-base:
-                                aliases:
-                                    - "$release_name-ros-base"
-                                    - "$release_name-ros-base-$os_code_name"
-                                    - "$release_name"
+                            # EOL
+                            # ros-core:
+                            #     aliases:
+                            #         - "$release_name-ros-core"
+                            #         - "$release_name-ros-core-$os_code_name"
+                            # ros-base:
+                            #     aliases:
+                            #         - "$release_name-ros-base"
+                            #         - "$release_name-ros-base-$os_code_name"
+                            #         - "$release_name"
     bouncy:
         eol: 2019-07
         os_names:
@@ -510,10 +511,11 @@ hacks:
                 os_code_names:
                     xenial:
                         tag_names:
-                            desktop:
-                                <<: *DEFAULT_HOOKS
-                            ros1-bridge:
-                                <<: *DEFAULT_HOOKS
+                            # EOL
+                            # desktop:
+                            #     <<: *DEFAULT_HOOKS
+                            # ros1-bridge:
+                            #     <<: *DEFAULT_HOOKS
     bouncy:
         os_names:
             ubuntu:

--- a/ros/ros
+++ b/ros/ros
@@ -156,23 +156,6 @@ Directory: ros/melodic/debian/stretch/perception
 
 
 ################################################################################
-# Release: ardent
-
-########################################
-# Distro: ubuntu:xenial
-
-Tags: ardent-ros-core, ardent-ros-core-xenial
-Architectures: amd64, arm64v8
-GitCommit: 4f09cf3ebe9300879f9a27eca2c60632ff980431
-Directory: ros/ardent/ubuntu/xenial/ros-core
-
-Tags: ardent-ros-base, ardent-ros-base-xenial, ardent
-Architectures: amd64, arm64v8
-GitCommit: 4f09cf3ebe9300879f9a27eca2c60632ff980431
-Directory: ros/ardent/ubuntu/xenial/ros-base
-
-
-################################################################################
 # Release: bouncy
 
 ########################################


### PR DESCRIPTION
EOL ardent docker images as the distribution is EOL since December and the buildfarm doesn't build packages for it anymore