### PR TITLE
Remove rosdistro index url from ROS2 source image

### DIFF
--- a/ros2/source/images.yaml.em
+++ b/ros2/source/images.yaml.em
@@ -39,7 +39,6 @@ images:
                 -DSECURITY=ON --no-warn-unused-cli
             - --symlink-install
         rosdep:
-            rosdistro_index_url: https://raw.githubusercontent.com/ros2/rosdistro/ros2/index.yaml
             install:
                 - --from-paths src
                 - --ignore-src

--- a/ros2/source/source/Dockerfile
+++ b/ros2/source/source/Dockerfile
@@ -54,7 +54,6 @@ RUN pip3 install -U \
     pytest-rerunfailures
 
 # bootstrap rosdep
-ENV ROSDISTRO_INDEX_URL https://raw.githubusercontent.com/ros/rosdistro/master/index.yaml
 RUN rosdep init \
     && rosdep update
 


### PR DESCRIPTION
Follow-up of https://github.com/osrf/docker_images/pull/224 and replacement of https://github.com/osrf/docker_images/pull/225
Requires https://github.com/osrf/docker_templates/pull/50 that has been merged