### PR TITLE
Relocate ROS2_WS to /opt

### DIFF
--- a/ros2/source/images.yaml.em
+++ b/ros2/source/images.yaml.em
@@ -32,7 +32,7 @@ images:
             - flake8-quotes
             - pytest-repeat
             - pytest-rerunfailures
-        ws: /root/ros2_ws
+        ws: /opt/ros2_ws
         colcon_args:
             - build
             - --cmake-args

--- a/ros2/source/source/Dockerfile
+++ b/ros2/source/source/Dockerfile
@@ -58,7 +58,7 @@ RUN rosdep init \
     && rosdep update
 
 # clone source
-ENV ROS2_WS /root/ros2_ws
+ENV ROS2_WS /opt/ros2_ws
 RUN mkdir -p $ROS2_WS/src
 WORKDIR $ROS2_WS
 RUN wget https://raw.githubusercontent.com/ros2/ros2/release-latest/ros2.repos \


### PR DESCRIPTION
To better allow the workspace to be used by users other than root in the container