### PR TITLE
[ros2/nightly] narrowing down skipped rosdep keys

### DIFF
--- a/ros2/nightly/nightly/Dockerfile
+++ b/ros2/nightly/nightly/Dockerfile
@@ -65,9 +65,6 @@ RUN apt-get update && rosdep install -y \
       --ignore-src \
       --skip-keys "\
         libopensplice69 \
-        rmw_connext_cpp \
-        rosidl_typesupport_connext_c \
-        rosidl_typesupport_connext_cpp \
         rti-connext-dds-5.3.1 "\
     && rm -rf /var/lib/apt/lists/*
 

--- a/ros2/nightly/nightly/prereqs.yaml
+++ b/ros2/nightly/nightly/prereqs.yaml
@@ -2,8 +2,4 @@ console_bridge: {ubuntu: []}
 fastcdr: {ubuntu: []}
 fastrtps: {ubuntu: []}
 osrf_testing_tools_cpp: {ubuntu: []}
-poco_vendor: {ubuntu: []}
-tinyxml_vendor: {ubuntu: []}
-tinyxml2_vendor: {ubuntu: []}
-urdfdom: {ubuntu: []}
 urdfdom_headers: {ubuntu: []}

--- a/ros2/nightly/nightly/prereqs.yaml
+++ b/ros2/nightly/nightly/prereqs.yaml
@@ -2,5 +2,4 @@ console_bridge: {ubuntu: []}
 fastcdr: {ubuntu: []}
 fastrtps: {ubuntu: []}
 osrf_testing_tools_cpp: {ubuntu: []}
-tinydir_vendor: {ubuntu: []}
 urdfdom_headers: {ubuntu: []}

--- a/ros2/nightly/nightly/prereqs.yaml
+++ b/ros2/nightly/nightly/prereqs.yaml
@@ -2,4 +2,5 @@ console_bridge: {ubuntu: []}
 fastcdr: {ubuntu: []}
 fastrtps: {ubuntu: []}
 osrf_testing_tools_cpp: {ubuntu: []}
+tinydir_vendor: {ubuntu: []}
 urdfdom_headers: {ubuntu: []}


### PR DESCRIPTION
These packages are provided in the nightly archives so they don't need to be skipped as they are in the src.