### PR TITLE
Ros2 devel

### DIFF
--- a/ros2/source/Makefile
+++ b/ros2/source/Makefile
@@ -10,10 +10,13 @@ help:
 	@echo ""
 
 build:
+	@docker build --tag=ros2:devel			devel/.
 	@docker build --tag=ros2:source			source/.
 
 pull:
+	@docker pull ros2:devel
 	@docker pull ros2:source
 
 clean:
+	@docker rmi -f ros2:devel
 	@docker rmi -f ros2:source

--- a/ros2/source/devel/Dockerfile
+++ b/ros2/source/devel/Dockerfile
@@ -1,0 +1,75 @@
+# This is an auto generated Dockerfile for ros2:devel
+# generated from docker_images_ros2/source/create_ros_image.Dockerfile.em
+FROM ubuntu:bionic
+
+# setup timezone
+RUN echo 'Etc/UTC' > /etc/timezone && \
+    ln -s /usr/share/zoneinfo/Etc/UTC /etc/localtime && \
+    apt-get update && apt-get install -q -y tzdata && rm -rf /var/lib/apt/lists/*
+
+# install packages
+RUN apt-get update && apt-get install -q -y \
+    bash-completion \
+    dirmngr \
+    gnupg2 \
+    lsb-release \
+    python3-pip \
+    wget \
+    && rm -rf /var/lib/apt/lists/*
+
+# setup keys
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
+
+# setup sources.list
+RUN echo "deb http://packages.ros.org/ros2/ubuntu `lsb_release -sc` main" > /etc/apt/sources.list.d/ros2-latest.list
+
+# setup environment
+ENV LANG C.UTF-8
+ENV LC_ALL C.UTF-8
+
+# install bootstrap tools
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    git \
+    python3-colcon-common-extensions \
+    python3-rosdep \
+    python3-vcstool \
+    && rm -rf /var/lib/apt/lists/*
+
+# install python packages
+RUN pip3 install -U \
+    argcomplete \
+    flake8 \
+    flake8-blind-except \
+    flake8-builtins \
+    flake8-class-newline \
+    flake8-comprehensions \
+    flake8-deprecated \
+    flake8-docstrings \
+    flake8-import-order \
+    flake8-quotes \
+    pytest-repeat \
+    pytest-rerunfailures
+
+# bootstrap rosdep
+RUN rosdep init \
+    && rosdep update
+
+# clone source
+ENV ROS2_WS /opt/ros2_ws
+RUN mkdir -p $ROS2_WS/src
+WORKDIR $ROS2_WS
+
+# build source
+RUN colcon \
+    build \
+    --cmake-args -DSECURITY=ON --no-warn-unused-cli \
+    --symlink-install
+
+# setup bashrc
+RUN cp /etc/skel/.bashrc ~/
+
+# setup entrypoint
+COPY ./ros_entrypoint.sh /
+
+ENTRYPOINT ["/ros_entrypoint.sh"]
+CMD ["bash"]

--- a/ros2/source/devel/Dockerfile
+++ b/ros2/source/devel/Dockerfile
@@ -1,6 +1,7 @@
 # This is an auto generated Dockerfile for ros2:devel
-# generated from docker_images_ros2/source/create_ros_image.Dockerfile.em
-FROM ubuntu:bionic
+# generated from docker_images_ros2/devel/create_ros_image.Dockerfile.em
+ARG FROM_IMAGE=ubuntu:bionic
+FROM $FROM_IMAGE
 
 # setup timezone
 RUN echo 'Etc/UTC' > /etc/timezone && \
@@ -14,7 +15,6 @@ RUN apt-get update && apt-get install -q -y \
     gnupg2 \
     lsb-release \
     python3-pip \
-    wget \
     && rm -rf /var/lib/apt/lists/*
 
 # setup keys
@@ -50,8 +50,6 @@ RUN pip3 install -U \
     pytest-repeat \
     pytest-rerunfailures
 
-ENV ROS_DISTRO crystal
-
 # bootstrap rosdep
 RUN rosdep init \
     && rosdep update
@@ -64,7 +62,8 @@ WORKDIR $ROS2_WS
 # build source
 RUN colcon \
     build \
-    --cmake-args -DSECURITY=ON --no-warn-unused-cli \
+    --cmake-args \
+      -DSECURITY=ON --no-warn-unused-cli \
     --symlink-install
 
 # setup bashrc

--- a/ros2/source/devel/Dockerfile
+++ b/ros2/source/devel/Dockerfile
@@ -50,6 +50,8 @@ RUN pip3 install -U \
     pytest-repeat \
     pytest-rerunfailures
 
+ENV ROS_DISTRO crystal
+
 # bootstrap rosdep
 RUN rosdep init \
     && rosdep update

--- a/ros2/source/devel/ros_entrypoint.sh
+++ b/ros2/source/devel/ros_entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+# setup ros2 environment
+source "$ROS2_WS/install/setup.bash"
+exec "$@"

--- a/ros2/source/images.yaml.em
+++ b/ros2/source/images.yaml.em
@@ -50,6 +50,7 @@ images:
         entrypoint_name: docker_images_ros2/source/ros_entrypoint.sh
         template_packages:
             - docker_templates
+        ros2_distro: crystal
         upstream_packages:
             - bash-completion
             - wget

--- a/ros2/source/images.yaml.em
+++ b/ros2/source/images.yaml.em
@@ -42,3 +42,33 @@ images:
         vcs:
             ros2:
                 repos:
+
+    devel:
+        base_image: @(os_name):@(os_code_name)
+        maintainer_name: @(maintainer_name)
+        template_name: docker_images_ros2/source/create_ros_image.Dockerfile.em
+        entrypoint_name: docker_images_ros2/source/ros_entrypoint.sh
+        template_packages:
+            - docker_templates
+        upstream_packages:
+            - bash-completion
+            - wget
+        pip3_install:
+            - argcomplete
+            - flake8
+            - flake8-blind-except
+            - flake8-builtins
+            - flake8-class-newline
+            - flake8-comprehensions
+            - flake8-deprecated
+            - flake8-docstrings
+            - flake8-import-order
+            - flake8-quotes
+            - pytest-repeat
+            - pytest-rerunfailures
+        ws: /opt/ros2_ws
+        colcon_args:
+            - build
+            - --cmake-args
+                -DSECURITY=ON --no-warn-unused-cli
+            - --symlink-install

--- a/ros2/source/images.yaml.em
+++ b/ros2/source/images.yaml.em
@@ -2,19 +2,15 @@
 # ROS2 Dockerfile database
 ---
 images:
-    source:
+    devel:
         base_image: @(os_name):@(os_code_name)
         maintainer_name: @(maintainer_name)
-        template_name: docker_images_ros2/source/create_ros_image.Dockerfile.em
-        entrypoint_name: docker_images_ros2/source/ros_entrypoint.sh
+        template_name: docker_images_ros2/devel/create_ros_image.Dockerfile.em
+        entrypoint_name: docker_images_ros2/devel/ros_entrypoint.sh
         template_packages:
             - docker_templates
         upstream_packages:
             - bash-completion
-            - libasio-dev
-            - libtinyxml2-dev
-            - wget
-        ros2_distro: crystal
         pip3_install:
             - argcomplete
             - flake8
@@ -28,6 +24,16 @@ images:
             - flake8-quotes
             - pytest-repeat
             - pytest-rerunfailures
+        ws: /opt/ros2_ws
+    source:
+        maintainer_name: @(maintainer_name)
+        template_name: docker_images_ros2/source/create_ros_image.Dockerfile.em
+        template_packages:
+            - docker_templates
+        upstream_packages:
+            - libasio-dev
+            - libtinyxml2-dev
+        ros2_distro: crystal
         ws: /opt/ros2_ws
         colcon_args:
             - build
@@ -40,36 +46,5 @@ images:
                 - --ignore-src
                 - --skip-keys "console_bridge fastcdr fastrtps libopensplice67 libopensplice69 rti-connext-dds-5.3.1 urdfdom_headers"
         vcs:
-            ros2:
+            imports:
                 repos:
-
-    devel:
-        base_image: @(os_name):@(os_code_name)
-        maintainer_name: @(maintainer_name)
-        template_name: docker_images_ros2/source/create_ros_image.Dockerfile.em
-        entrypoint_name: docker_images_ros2/source/ros_entrypoint.sh
-        template_packages:
-            - docker_templates
-        ros2_distro: crystal
-        upstream_packages:
-            - bash-completion
-            - wget
-        pip3_install:
-            - argcomplete
-            - flake8
-            - flake8-blind-except
-            - flake8-builtins
-            - flake8-class-newline
-            - flake8-comprehensions
-            - flake8-deprecated
-            - flake8-docstrings
-            - flake8-import-order
-            - flake8-quotes
-            - pytest-repeat
-            - pytest-rerunfailures
-        ws: /opt/ros2_ws
-        colcon_args:
-            - build
-            - --cmake-args
-                -DSECURITY=ON --no-warn-unused-cli
-            - --symlink-install

--- a/ros2/source/source/Dockerfile
+++ b/ros2/source/source/Dockerfile
@@ -1,66 +1,19 @@
 # This is an auto generated Dockerfile for ros2:source
 # generated from docker_images_ros2/source/create_ros_image.Dockerfile.em
-FROM ubuntu:bionic
 
-# setup timezone
-RUN echo 'Etc/UTC' > /etc/timezone && \
-    ln -s /usr/share/zoneinfo/Etc/UTC /etc/localtime && \
-    apt-get update && apt-get install -q -y tzdata && rm -rf /var/lib/apt/lists/*
+ARG FROM_IMAGE=osrf/ros2:devel
+FROM $FROM_IMAGE
 
 # install packages
 RUN apt-get update && apt-get install -q -y \
-    bash-completion \
-    dirmngr \
-    gnupg2 \
     libasio-dev \
     libtinyxml2-dev \
-    lsb-release \
-    python3-pip \
     wget \
     && rm -rf /var/lib/apt/lists/*
 
-# setup keys
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
+ARG ROS_DISTRO=crystal
+ENV ROS_DISTRO=$ROS_DISTRO
 
-# setup sources.list
-RUN echo "deb http://packages.ros.org/ros2/ubuntu `lsb_release -sc` main" > /etc/apt/sources.list.d/ros2-latest.list
-
-# setup environment
-ENV LANG C.UTF-8
-ENV LC_ALL C.UTF-8
-
-# install bootstrap tools
-RUN apt-get update && apt-get install --no-install-recommends -y \
-    git \
-    python3-colcon-common-extensions \
-    python3-rosdep \
-    python3-vcstool \
-    && rm -rf /var/lib/apt/lists/*
-
-# install python packages
-RUN pip3 install -U \
-    argcomplete \
-    flake8 \
-    flake8-blind-except \
-    flake8-builtins \
-    flake8-class-newline \
-    flake8-comprehensions \
-    flake8-deprecated \
-    flake8-docstrings \
-    flake8-import-order \
-    flake8-quotes \
-    pytest-repeat \
-    pytest-rerunfailures
-
-ENV ROS_DISTRO crystal
-
-# bootstrap rosdep
-RUN rosdep init \
-    && rosdep update
-
-# clone source
-ENV ROS2_WS /opt/ros2_ws
-RUN mkdir -p $ROS2_WS/src
 WORKDIR $ROS2_WS
 
 RUN wget https://raw.githubusercontent.com/ros2/ros2/$ROS_DISTRO/ros2.repos \
@@ -79,11 +32,15 @@ RUN colcon \
     --cmake-args -DSECURITY=ON --no-warn-unused-cli \
     --symlink-install
 
-# setup bashrc
-RUN cp /etc/skel/.bashrc ~/
+ARG RUN_TESTS
+ARG FAIL_ON_TEST_FAILURE
+RUN if [ ! -z "$RUN_TESTS" ]; then \
+        colcon test; \
+        if [ ! -z "$FAIL_ON_TEST_FAILURE" ]; then \
+            colcon test-result; \
+        else \
+            colcon test-result || true; \
+        fi \
+    fi
 
-# setup entrypoint
-COPY ./ros_entrypoint.sh /
-
-ENTRYPOINT ["/ros_entrypoint.sh"]
 CMD ["bash"]

--- a/ros2/source/source/Dockerfile
+++ b/ros2/source/source/Dockerfile
@@ -42,5 +42,3 @@ RUN if [ ! -z "$RUN_TESTS" ]; then \
             colcon test-result || true; \
         fi \
     fi
-
-CMD ["bash"]

--- a/ros2/source/source/Dockerfile
+++ b/ros2/source/source/Dockerfile
@@ -52,8 +52,9 @@ RUN pip3 install -U \
     pytest-repeat \
     pytest-rerunfailures
 
-# bootstrap rosdep
 ENV ROS_DISTRO crystal
+
+# bootstrap rosdep
 RUN rosdep init \
     && rosdep update
 
@@ -61,6 +62,7 @@ RUN rosdep init \
 ENV ROS2_WS /opt/ros2_ws
 RUN mkdir -p $ROS2_WS/src
 WORKDIR $ROS2_WS
+
 RUN wget https://raw.githubusercontent.com/ros2/ros2/$ROS_DISTRO/ros2.repos \
     && vcs import src < ros2.repos
 
@@ -72,7 +74,6 @@ RUN apt-get update && rosdep install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # build source
-WORKDIR $ROS2_WS
 RUN colcon \
     build \
     --cmake-args -DSECURITY=ON --no-warn-unused-cli \

--- a/ros2/source/source/ros_entrypoint.sh
+++ b/ros2/source/source/ros_entrypoint.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-set -e
-
-# setup ros2 environment
-source "$ROS2_WS/install/setup.bash"
-exec "$@"

--- a/ros2/source/source/ros_entrypoint.sh
+++ b/ros2/source/source/ros_entrypoint.sh
@@ -2,5 +2,5 @@
 set -e
 
 # setup ros2 environment
-source "$ROS2_WS/install/local_setup.bash"
+source "$ROS2_WS/install/setup.bash"
 exec "$@"


### PR DESCRIPTION
Creates a `ros2:devel` image as discussed in https://github.com/osrf/docker_templates/pull/49

Depends on https://github.com/osrf/docker_templates/pull/54, https://github.com/osrf/docker_templates/pull/51 and https://github.com/osrf/docker_templates/pull/52