### PR TITLE
remove more custom rosdep rules

### DIFF
--- a/ros2/nightly/nightly/prereqs.yaml
+++ b/ros2/nightly/nightly/prereqs.yaml
@@ -1,6 +1,4 @@
 console_bridge: {ubuntu: []}
 fastcdr: {ubuntu: []}
 fastrtps: {ubuntu: []}
-osrf_testing_tools_cpp: {ubuntu: []}
-tinydir_vendor: {ubuntu: []}
 urdfdom_headers: {ubuntu: []}


### PR DESCRIPTION
With https://github.com/ros2/tinydir_vendor/pull/6 and https://github.com/osrf/osrf_testing_tools_cpp/pull/29 merged, we can remove their empty rosdep keys

@ruffsl FYI