### PR TITLE
update ros2:nightly for dashing

### DIFF
--- a/ros2/nightly/nightly/Dockerfile
+++ b/ros2/nightly/nightly/Dockerfile
@@ -55,7 +55,7 @@ RUN pip3 install -U \
     pytest-rerunfailures
 
 # install ros2 packages
-ENV ROS_DISTRO crystal
+ENV ROS_DISTRO dashing
 RUN mkdir -p /opt/ros/$ROS_DISTRO
 ARG ROS2_BINARY_URL=https://ci.ros2.org/view/packaging/job/packaging_linux/lastSuccessfulBuild/artifact/ws/ros2-package-linux-x86_64.tar.bz2
 RUN wget -q $ROS2_BINARY_URL -O - | \

--- a/ros2/nightly/nightly/Dockerfile
+++ b/ros2/nightly/nightly/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update && apt-get install -q -y \
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
 
 # setup sources.list
-RUN echo "deb http://packages.ros.org/ros2/ubuntu `lsb_release -sc` main" > /etc/apt/sources.list.d/ros2-latest.list
+RUN echo "deb http://packages.ros.org/ros2-testing/ubuntu `lsb_release -sc` main" > /etc/apt/sources.list.d/ros2-testing.list
 
 # install bootstrap tools
 RUN apt-get update && apt-get install --no-install-recommends -y \

--- a/ros2/nightly/platform.yaml
+++ b/ros2/nightly/platform.yaml
@@ -5,7 +5,7 @@ platform:
     os_name: ubuntu
     os_code_name: bionic
     rosdistro_name: melodic
-    ros2distro_name: crystal
+    ros2distro_name: dashing
     user_name: ros
     maintainer_name:
     arch: amd64


### PR DESCRIPTION
the `ros_environment` package [now points to `dashing`](https://github.com/ros2/ros2/pull/688) making the value of the environment variable inconsistent in the dockerfile between before and after sourcing the extracted workspace. This causes the nightly image to fail to build for the last week.

This fix needs the `ros-dashing-ros-workspace` deb to be available. I changed the nightly template to use the `ros2-testing` apt repository to get the package, this seems an acceptable workaround for the nightly image to use the latest released packages rather than the ones synced to main. If we prefer to stick to main, this PR needs to wait for the first sync to main of Dashing beta before being merged.

@ruffsl @nuclearsandwich do you know if there are notifications emails for the failing nightly builds ?