### PR TITLE
Rotate keys for ros2 apt repos

### DIFF
--- a/ros/ardent/ubuntu/xenial/ros-core/Dockerfile
+++ b/ros/ardent/ubuntu/xenial/ros-core/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get install -q -y \
     && rm -rf /var/lib/apt/lists/*
 
 # setup ros2 keys
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
 
 # setup sources.list
 RUN echo "deb http://packages.ros.org/ros2/ubuntu `lsb_release -sc` main" > /etc/apt/sources.list.d/ros2-latest.list

--- a/ros/bouncy/ubuntu/bionic/ros-core/Dockerfile
+++ b/ros/bouncy/ubuntu/bionic/ros-core/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update && apt-get install -q -y \
     && rm -rf /var/lib/apt/lists/*
 
 # setup ros2 keys
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
 
 # setup sources.list
 RUN echo "deb http://packages.ros.org/ros2/ubuntu `lsb_release -sc` main" > /etc/apt/sources.list.d/ros2-latest.list

--- a/ros/crystal/ubuntu/bionic/ros-core/Dockerfile
+++ b/ros/crystal/ubuntu/bionic/ros-core/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update && apt-get install -q -y \
     && rm -rf /var/lib/apt/lists/*
 
 # setup ros2 keys
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
 
 # setup sources.list
 RUN echo "deb http://packages.ros.org/ros2/ubuntu `lsb_release -sc` main" > /etc/apt/sources.list.d/ros2-latest.list

--- a/ros/ros
+++ b/ros/ros
@@ -9,22 +9,22 @@ GitRepo: https://github.com/osrf/docker_images.git
 
 Tags: indigo-ros-core, indigo-ros-core-trusty
 Architectures: amd64, arm32v7
-GitCommit: 49d22242e02e9c541a9e85b657e1785617b6f470
+GitCommit: a328e5aa68889ab5ae50ec87c1fd3a8b14e5d11f
 Directory: ros/indigo/ubuntu/trusty/ros-core
 
 Tags: indigo-ros-base, indigo-ros-base-trusty, indigo
 Architectures: amd64, arm32v7
-GitCommit: 49d22242e02e9c541a9e85b657e1785617b6f470
+GitCommit: a328e5aa68889ab5ae50ec87c1fd3a8b14e5d11f
 Directory: ros/indigo/ubuntu/trusty/ros-base
 
 Tags: indigo-robot, indigo-robot-trusty
 Architectures: amd64, arm32v7
-GitCommit: 49d22242e02e9c541a9e85b657e1785617b6f470
+GitCommit: a328e5aa68889ab5ae50ec87c1fd3a8b14e5d11f
 Directory: ros/indigo/ubuntu/trusty/robot
 
 Tags: indigo-perception, indigo-perception-trusty
 Architectures: amd64, arm32v7
-GitCommit: 49d22242e02e9c541a9e85b657e1785617b6f470
+GitCommit: a328e5aa68889ab5ae50ec87c1fd3a8b14e5d11f
 Directory: ros/indigo/ubuntu/trusty/perception
 
 
@@ -36,22 +36,22 @@ Directory: ros/indigo/ubuntu/trusty/perception
 
 Tags: kinetic-ros-core, kinetic-ros-core-xenial
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 49d22242e02e9c541a9e85b657e1785617b6f470
+GitCommit: a328e5aa68889ab5ae50ec87c1fd3a8b14e5d11f
 Directory: ros/kinetic/ubuntu/xenial/ros-core
 
 Tags: kinetic-ros-base, kinetic-ros-base-xenial, kinetic
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 49d22242e02e9c541a9e85b657e1785617b6f470
+GitCommit: a328e5aa68889ab5ae50ec87c1fd3a8b14e5d11f
 Directory: ros/kinetic/ubuntu/xenial/ros-base
 
 Tags: kinetic-robot, kinetic-robot-xenial
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 49d22242e02e9c541a9e85b657e1785617b6f470
+GitCommit: a328e5aa68889ab5ae50ec87c1fd3a8b14e5d11f
 Directory: ros/kinetic/ubuntu/xenial/robot
 
 Tags: kinetic-perception, kinetic-perception-xenial
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 49d22242e02e9c541a9e85b657e1785617b6f470
+GitCommit: a328e5aa68889ab5ae50ec87c1fd3a8b14e5d11f
 Directory: ros/kinetic/ubuntu/xenial/perception
 
 
@@ -63,22 +63,22 @@ Directory: ros/kinetic/ubuntu/xenial/perception
 
 Tags: lunar-ros-core, lunar-ros-core-xenial
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 49d22242e02e9c541a9e85b657e1785617b6f470
+GitCommit: a328e5aa68889ab5ae50ec87c1fd3a8b14e5d11f
 Directory: ros/lunar/ubuntu/xenial/ros-core
 
 Tags: lunar-ros-base, lunar-ros-base-xenial, lunar
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 49d22242e02e9c541a9e85b657e1785617b6f470
+GitCommit: a328e5aa68889ab5ae50ec87c1fd3a8b14e5d11f
 Directory: ros/lunar/ubuntu/xenial/ros-base
 
 Tags: lunar-robot, lunar-robot-xenial
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 49d22242e02e9c541a9e85b657e1785617b6f470
+GitCommit: a328e5aa68889ab5ae50ec87c1fd3a8b14e5d11f
 Directory: ros/lunar/ubuntu/xenial/robot
 
 Tags: lunar-perception, lunar-perception-xenial
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 49d22242e02e9c541a9e85b657e1785617b6f470
+GitCommit: a328e5aa68889ab5ae50ec87c1fd3a8b14e5d11f
 Directory: ros/lunar/ubuntu/xenial/perception
 
 ########################################
@@ -86,22 +86,22 @@ Directory: ros/lunar/ubuntu/xenial/perception
 
 Tags: lunar-ros-core-stretch
 Architectures: amd64, arm64v8
-GitCommit: 49d22242e02e9c541a9e85b657e1785617b6f470
+GitCommit: a328e5aa68889ab5ae50ec87c1fd3a8b14e5d11f
 Directory: ros/lunar/debian/stretch/ros-core
 
 Tags: lunar-ros-base-stretch
 Architectures: amd64, arm64v8
-GitCommit: 49d22242e02e9c541a9e85b657e1785617b6f470
+GitCommit: a328e5aa68889ab5ae50ec87c1fd3a8b14e5d11f
 Directory: ros/lunar/debian/stretch/ros-base
 
 Tags: lunar-robot-stretch
 Architectures: amd64, arm64v8
-GitCommit: 49d22242e02e9c541a9e85b657e1785617b6f470
+GitCommit: a328e5aa68889ab5ae50ec87c1fd3a8b14e5d11f
 Directory: ros/lunar/debian/stretch/robot
 
 Tags: lunar-perception-stretch
 Architectures: amd64, arm64v8
-GitCommit: 49d22242e02e9c541a9e85b657e1785617b6f470
+GitCommit: a328e5aa68889ab5ae50ec87c1fd3a8b14e5d11f
 Directory: ros/lunar/debian/stretch/perception
 
 
@@ -113,22 +113,22 @@ Directory: ros/lunar/debian/stretch/perception
 
 Tags: melodic-ros-core, melodic-ros-core-bionic
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: eaca344ae304c30254451da89bae328eb65ee385
+GitCommit: a328e5aa68889ab5ae50ec87c1fd3a8b14e5d11f
 Directory: ros/melodic/ubuntu/bionic/ros-core
 
 Tags: melodic-ros-base, melodic-ros-base-bionic, melodic, latest
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: eaca344ae304c30254451da89bae328eb65ee385
+GitCommit: a328e5aa68889ab5ae50ec87c1fd3a8b14e5d11f
 Directory: ros/melodic/ubuntu/bionic/ros-base
 
 Tags: melodic-robot, melodic-robot-bionic
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: eaca344ae304c30254451da89bae328eb65ee385
+GitCommit: a328e5aa68889ab5ae50ec87c1fd3a8b14e5d11f
 Directory: ros/melodic/ubuntu/bionic/robot
 
 Tags: melodic-perception, melodic-perception-bionic
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: eaca344ae304c30254451da89bae328eb65ee385
+GitCommit: a328e5aa68889ab5ae50ec87c1fd3a8b14e5d11f
 Directory: ros/melodic/ubuntu/bionic/perception
 
 ########################################
@@ -136,22 +136,22 @@ Directory: ros/melodic/ubuntu/bionic/perception
 
 Tags: melodic-ros-core-stretch
 Architectures: amd64, arm64v8
-GitCommit: 49d22242e02e9c541a9e85b657e1785617b6f470
+GitCommit: a328e5aa68889ab5ae50ec87c1fd3a8b14e5d11f
 Directory: ros/melodic/debian/stretch/ros-core
 
 Tags: melodic-ros-base-stretch
 Architectures: amd64, arm64v8
-GitCommit: 49d22242e02e9c541a9e85b657e1785617b6f470
+GitCommit: a328e5aa68889ab5ae50ec87c1fd3a8b14e5d11f
 Directory: ros/melodic/debian/stretch/ros-base
 
 Tags: melodic-robot-stretch
 Architectures: amd64, arm64v8
-GitCommit: 49d22242e02e9c541a9e85b657e1785617b6f470
+GitCommit: a328e5aa68889ab5ae50ec87c1fd3a8b14e5d11f
 Directory: ros/melodic/debian/stretch/robot
 
 Tags: melodic-perception-stretch
 Architectures: amd64, arm64v8
-GitCommit: 49d22242e02e9c541a9e85b657e1785617b6f470
+GitCommit: a328e5aa68889ab5ae50ec87c1fd3a8b14e5d11f
 Directory: ros/melodic/debian/stretch/perception
 
 
@@ -163,12 +163,12 @@ Directory: ros/melodic/debian/stretch/perception
 
 Tags: bouncy-ros-core, bouncy-ros-core-bionic
 Architectures: amd64, arm64v8
-GitCommit: 2fc9fc270ce866cd52af11e22c7d3e403efc6c61
+GitCommit: fb0fe0a628d023eec6ea1444551fa28209bd28d6
 Directory: ros/bouncy/ubuntu/bionic/ros-core
 
 Tags: bouncy-ros-base, bouncy-ros-base-bionic, bouncy
 Architectures: amd64, arm64v8
-GitCommit: 2fc9fc270ce866cd52af11e22c7d3e403efc6c61
+GitCommit: fb0fe0a628d023eec6ea1444551fa28209bd28d6
 Directory: ros/bouncy/ubuntu/bionic/ros-base
 
 
@@ -180,11 +180,11 @@ Directory: ros/bouncy/ubuntu/bionic/ros-base
 
 Tags: crystal-ros-core, crystal-ros-core-bionic
 Architectures: amd64, arm64v8
-GitCommit: 807b791d234b2c19e3615babf656e98ddcb60dc9
+GitCommit: fb0fe0a628d023eec6ea1444551fa28209bd28d6
 Directory: ros/crystal/ubuntu/bionic/ros-core
 
 Tags: crystal-ros-base, crystal-ros-base-bionic, crystal
 Architectures: amd64, arm64v8
-GitCommit: 807b791d234b2c19e3615babf656e98ddcb60dc9
+GitCommit: fb0fe0a628d023eec6ea1444551fa28209bd28d6
 Directory: ros/crystal/ubuntu/bionic/ros-base
 

--- a/ros2/nightly/nightly/Dockerfile
+++ b/ros2/nightly/nightly/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update && apt-get install -q -y \
     && rm -rf /var/lib/apt/lists/*
 
 # setup ros2 keys
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
 
 # setup sources.list
 RUN echo "deb http://packages.ros.org/ros2-testing/ubuntu `lsb_release -sc` main" > /etc/apt/sources.list.d/ros2-testing.list

--- a/ros2/source/devel/Dockerfile
+++ b/ros2/source/devel/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update && apt-get install -q -y \
     && rm -rf /var/lib/apt/lists/*
 
 # setup keys
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
 
 # setup sources.list
 RUN echo "deb http://packages.ros.org/ros2/ubuntu `lsb_release -sc` main" > /etc/apt/sources.list.d/ros2-latest.list


### PR DESCRIPTION
Update ros2 templates with latest signing key for ROS 2 apt repositories.
Context: https://discourse.ros.org/t/key-rotation-for-ros-2-apt-repositories/9363
Related: https://github.com/osrf/docker_templates/pull/61