### PR TITLE
[WIP] Remove EOL ROS releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,7 @@ env:
   # ros
   - HUB_REPO=ros    HUB_RELEASE=melodic HUB_OS_NAME=ubuntu HUB_OS_CODE_NAME=bionic
   - HUB_REPO=ros    HUB_RELEASE=melodic HUB_OS_NAME=debian HUB_OS_CODE_NAME=stretch
-  - HUB_REPO=ros    HUB_RELEASE=lunar   HUB_OS_NAME=ubuntu HUB_OS_CODE_NAME=xenial
-  - HUB_REPO=ros    HUB_RELEASE=lunar   HUB_OS_NAME=debian HUB_OS_CODE_NAME=stretch
   - HUB_REPO=ros    HUB_RELEASE=kinetic HUB_OS_NAME=ubuntu HUB_OS_CODE_NAME=xenial
-  - HUB_REPO=ros    HUB_RELEASE=indigo  HUB_OS_NAME=ubuntu HUB_OS_CODE_NAME=trusty
   # gazebo
   - HUB_REPO=gazebo HUB_RELEASE=10      HUB_OS_NAME=ubuntu HUB_OS_CODE_NAME=bionic
   - HUB_REPO=gazebo HUB_RELEASE=9       HUB_OS_NAME=ubuntu HUB_OS_CODE_NAME=bionic

--- a/ros/manifest.yaml
+++ b/ros/manifest.yaml
@@ -111,23 +111,24 @@ release_names:
                             - amd64
                             - arm32v7
                         tag_names:
-                            ros-core:
-                                aliases:
-                                    - "$release_name-ros-core"
-                                    - "$release_name-ros-core-$os_code_name"
-                            ros-base:
-                                aliases:
-                                    - "$release_name-ros-base"
-                                    - "$release_name-ros-base-$os_code_name"
-                                    - "$release_name"
-                            robot:
-                                aliases:
-                                    - "$release_name-robot"
-                                    - "$release_name-robot-$os_code_name"
-                            perception:
-                                aliases:
-                                    - "$release_name-perception"
-                                    - "$release_name-perception-$os_code_name"
+                            # EOL
+                            # ros-core:
+                            #     aliases:
+                            #         - "$release_name-ros-core"
+                            #         - "$release_name-ros-core-$os_code_name"
+                            # ros-base:
+                            #     aliases:
+                            #         - "$release_name-ros-base"
+                            #         - "$release_name-ros-base-$os_code_name"
+                            #         - "$release_name"
+                            # robot:
+                            #     aliases:
+                            #         - "$release_name-robot"
+                            #         - "$release_name-robot-$os_code_name"
+                            # perception:
+                            #     aliases:
+                            #         - "$release_name-perception"
+                            #         - "$release_name-perception-$os_code_name"
     jade:
         eol: 2017-04
         os_names:
@@ -219,23 +220,24 @@ release_names:
                             - arm32v7
                             - arm64v8
                         tag_names:
-                            ros-core:
-                                aliases:
-                                    - "$release_name-ros-core"
-                                    - "$release_name-ros-core-$os_code_name"
-                            ros-base:
-                                aliases:
-                                    - "$release_name-ros-base"
-                                    - "$release_name-ros-base-$os_code_name"
-                                    - "$release_name"
-                            robot:
-                                aliases:
-                                    - "$release_name-robot"
-                                    - "$release_name-robot-$os_code_name"
-                            perception:
-                                aliases:
-                                    - "$release_name-perception"
-                                    - "$release_name-perception-$os_code_name"
+                            # EOL
+                            # ros-core:
+                            #     aliases:
+                            #         - "$release_name-ros-core"
+                            #         - "$release_name-ros-core-$os_code_name"
+                            # ros-base:
+                            #     aliases:
+                            #         - "$release_name-ros-base"
+                            #         - "$release_name-ros-base-$os_code_name"
+                            #         - "$release_name"
+                            # robot:
+                            #     aliases:
+                            #         - "$release_name-robot"
+                            #         - "$release_name-robot-$os_code_name"
+                            # perception:
+                            #     aliases:
+                            #         - "$release_name-perception"
+                            #         - "$release_name-perception-$os_code_name"
                     zesty:
                         <<: *DEFAULT_ROS1
                         archs:
@@ -262,18 +264,19 @@ release_names:
                             - amd64
                             - arm64v8
                         tag_names:
-                            ros-core:
-                                aliases:
-                                    - "$release_name-ros-core-$os_code_name"
-                            ros-base:
-                                aliases:
-                                    - "$release_name-ros-base-$os_code_name"
-                            robot:
-                                aliases:
-                                    - "$release_name-robot-$os_code_name"
-                            perception:
-                                aliases:
-                                    - "$release_name-perception-$os_code_name"
+                            # EOL
+                            # ros-core:
+                            #     aliases:
+                            #         - "$release_name-ros-core-$os_code_name"
+                            # ros-base:
+                            #     aliases:
+                            #         - "$release_name-ros-base-$os_code_name"
+                            # robot:
+                            #     aliases:
+                            #         - "$release_name-robot-$os_code_name"
+                            # perception:
+                            #     aliases:
+                            #         - "$release_name-perception-$os_code_name"
     melodic:
         eol: 2023-05
         os_names:
@@ -460,10 +463,11 @@ hacks:
                 os_code_names:
                     trusty:
                         tag_names:
-                            desktop:
-                                <<: *DEFAULT_HOOKS
-                            desktop-full:
-                                <<: *DEFAULT_HOOKS
+                            # EOL
+                            # desktop:
+                            #     <<: *DEFAULT_HOOKS
+                            # desktop-full:
+                            #     <<: *DEFAULT_HOOKS
     jade:
         os_names:
             ubuntu:
@@ -491,10 +495,11 @@ hacks:
                 os_code_names:
                     xenial:
                         tag_names:
-                            desktop:
-                                <<: *DEFAULT_HOOKS
-                            desktop-full:
-                                <<: *DEFAULT_HOOKS
+                            # EOL
+                            # desktop:
+                            #     <<: *DEFAULT_HOOKS
+                            # desktop-full:
+                            #     <<: *DEFAULT_HOOKS
     melodic:
         os_names:
             ubuntu:

--- a/ros/ros
+++ b/ros/ros
@@ -2,33 +2,6 @@ Maintainers: Tully Foote <tfoote+buildfarm@osrfoundation.org> (@tfoote)
 GitRepo: https://github.com/osrf/docker_images.git
 
 ################################################################################
-# Release: indigo
-
-########################################
-# Distro: ubuntu:trusty
-
-Tags: indigo-ros-core, indigo-ros-core-trusty
-Architectures: amd64, arm32v7
-GitCommit: a328e5aa68889ab5ae50ec87c1fd3a8b14e5d11f
-Directory: ros/indigo/ubuntu/trusty/ros-core
-
-Tags: indigo-ros-base, indigo-ros-base-trusty, indigo
-Architectures: amd64, arm32v7
-GitCommit: a328e5aa68889ab5ae50ec87c1fd3a8b14e5d11f
-Directory: ros/indigo/ubuntu/trusty/ros-base
-
-Tags: indigo-robot, indigo-robot-trusty
-Architectures: amd64, arm32v7
-GitCommit: a328e5aa68889ab5ae50ec87c1fd3a8b14e5d11f
-Directory: ros/indigo/ubuntu/trusty/robot
-
-Tags: indigo-perception, indigo-perception-trusty
-Architectures: amd64, arm32v7
-GitCommit: a328e5aa68889ab5ae50ec87c1fd3a8b14e5d11f
-Directory: ros/indigo/ubuntu/trusty/perception
-
-
-################################################################################
 # Release: kinetic
 
 ########################################
@@ -53,56 +26,6 @@ Tags: kinetic-perception, kinetic-perception-xenial
 Architectures: amd64, arm32v7, arm64v8
 GitCommit: a328e5aa68889ab5ae50ec87c1fd3a8b14e5d11f
 Directory: ros/kinetic/ubuntu/xenial/perception
-
-
-################################################################################
-# Release: lunar
-
-########################################
-# Distro: ubuntu:xenial
-
-Tags: lunar-ros-core, lunar-ros-core-xenial
-Architectures: amd64, arm32v7, arm64v8
-GitCommit: a328e5aa68889ab5ae50ec87c1fd3a8b14e5d11f
-Directory: ros/lunar/ubuntu/xenial/ros-core
-
-Tags: lunar-ros-base, lunar-ros-base-xenial, lunar
-Architectures: amd64, arm32v7, arm64v8
-GitCommit: a328e5aa68889ab5ae50ec87c1fd3a8b14e5d11f
-Directory: ros/lunar/ubuntu/xenial/ros-base
-
-Tags: lunar-robot, lunar-robot-xenial
-Architectures: amd64, arm32v7, arm64v8
-GitCommit: a328e5aa68889ab5ae50ec87c1fd3a8b14e5d11f
-Directory: ros/lunar/ubuntu/xenial/robot
-
-Tags: lunar-perception, lunar-perception-xenial
-Architectures: amd64, arm32v7, arm64v8
-GitCommit: a328e5aa68889ab5ae50ec87c1fd3a8b14e5d11f
-Directory: ros/lunar/ubuntu/xenial/perception
-
-########################################
-# Distro: debian:stretch
-
-Tags: lunar-ros-core-stretch
-Architectures: amd64, arm64v8
-GitCommit: a328e5aa68889ab5ae50ec87c1fd3a8b14e5d11f
-Directory: ros/lunar/debian/stretch/ros-core
-
-Tags: lunar-ros-base-stretch
-Architectures: amd64, arm64v8
-GitCommit: a328e5aa68889ab5ae50ec87c1fd3a8b14e5d11f
-Directory: ros/lunar/debian/stretch/ros-base
-
-Tags: lunar-robot-stretch
-Architectures: amd64, arm64v8
-GitCommit: a328e5aa68889ab5ae50ec87c1fd3a8b14e5d11f
-Directory: ros/lunar/debian/stretch/robot
-
-Tags: lunar-perception-stretch
-Architectures: amd64, arm64v8
-GitCommit: a328e5aa68889ab5ae50ec87c1fd3a8b14e5d11f
-Directory: ros/lunar/debian/stretch/perception
 
 
 ################################################################################


### PR DESCRIPTION
I'm waiting on https://github.com/osrf/docker_images/pull/269 being upstreamed first before turning off builds for these EOL'd releases.