### PR TITLE
Update source image to build dashing release

### DIFF
--- a/ros2/source/images.yaml.em
+++ b/ros2/source/images.yaml.em
@@ -33,7 +33,7 @@ images:
         upstream_packages:
             - libasio-dev
             - libtinyxml2-dev
-        ros2_distro: crystal
+        ros2_distro: dashing
         ws: /opt/ros2_ws
         colcon_args:
             - build

--- a/ros2/source/source/Dockerfile
+++ b/ros2/source/source/Dockerfile
@@ -11,14 +11,14 @@ RUN apt-get update && apt-get install -q -y \
     wget \
     && rm -rf /var/lib/apt/lists/*
 
-ARG ROS_DISTRO=crystal
+ARG ROS_DISTRO=dashing
 ENV ROS_DISTRO=$ROS_DISTRO
 ENV ROS_VERSION=2 \
     ROS_PYTHON_VERSION=3
 
 WORKDIR $ROS2_WS
 
-RUN wget https://raw.githubusercontent.com/ros2/ros2/$ROS_DISTRO/ros2.repos \
+RUN wget https://raw.githubusercontent.com/ros2/ros2/$ROS_DISTRO-release/ros2.repos \
     && vcs import src < ros2.repos
 
 # install dependencies


### PR DESCRIPTION
This will result in getting the `https://raw.githubusercontent.com/ros2/ros2/dashing/ros2.repos` repos file for building the workspace.

It looks like there is a `dashing-release` branch (https://github.com/ros2/ros2/pull/716) allowing to get the pinned down versions instead of the dashing development branches. Using that url (raw.githubusercontent.com/ros2/ros2/**$ROS_DISTRO-release**/ros2.repos)  would be better for getting the same code as the released debs.

@nuclearsandwich Is that the preferred repos file to use? If yes, is there a plan on providing a `crystal-release` branch as well ?

---
Note the source image will still not build after this update, this is tracked at https://github.com/osrf/docker_images/issues/270
