### PR TITLE
Ros1 key rotation supported

### DIFF
--- a/ros/indigo/ubuntu/trusty/ros-core/Dockerfile
+++ b/ros/indigo/ubuntu/trusty/ros-core/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get install -q -y \
     && rm -rf /var/lib/apt/lists/*
 
 # setup keys
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
 
 # setup sources.list
 RUN echo "deb http://packages.ros.org/ros/ubuntu `lsb_release -sc` main" > /etc/apt/sources.list.d/ros-latest.list

--- a/ros/kinetic/debian/jessie/ros-core/Dockerfile
+++ b/ros/kinetic/debian/jessie/ros-core/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get install -q -y \
     && rm -rf /var/lib/apt/lists/*
 
 # setup keys
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
 
 # setup sources.list
 RUN echo "deb http://packages.ros.org/ros/ubuntu `lsb_release -sc` main" > /etc/apt/sources.list.d/ros-latest.list

--- a/ros/kinetic/ubuntu/xenial/ros-core/Dockerfile
+++ b/ros/kinetic/ubuntu/xenial/ros-core/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get install -q -y \
     && rm -rf /var/lib/apt/lists/*
 
 # setup keys
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
 
 # setup sources.list
 RUN echo "deb http://packages.ros.org/ros/ubuntu `lsb_release -sc` main" > /etc/apt/sources.list.d/ros-latest.list

--- a/ros/lunar/debian/stretch/ros-core/Dockerfile
+++ b/ros/lunar/debian/stretch/ros-core/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get install -q -y \
     && rm -rf /var/lib/apt/lists/*
 
 # setup keys
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
 
 # setup sources.list
 RUN echo "deb http://packages.ros.org/ros/ubuntu `lsb_release -sc` main" > /etc/apt/sources.list.d/ros-latest.list

--- a/ros/lunar/ubuntu/xenial/ros-core/Dockerfile
+++ b/ros/lunar/ubuntu/xenial/ros-core/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get install -q -y \
     && rm -rf /var/lib/apt/lists/*
 
 # setup keys
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
 
 # setup sources.list
 RUN echo "deb http://packages.ros.org/ros/ubuntu `lsb_release -sc` main" > /etc/apt/sources.list.d/ros-latest.list

--- a/ros/lunar/ubuntu/zesty/ros-core/Dockerfile
+++ b/ros/lunar/ubuntu/zesty/ros-core/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get install -q -y \
     && rm -rf /var/lib/apt/lists/*
 
 # setup keys
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
 
 # setup sources.list
 RUN echo "deb http://packages.ros.org/ros/ubuntu `lsb_release -sc` main" > /etc/apt/sources.list.d/ros-latest.list

--- a/ros/melodic/debian/stretch/ros-core/Dockerfile
+++ b/ros/melodic/debian/stretch/ros-core/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get install -q -y \
     && rm -rf /var/lib/apt/lists/*
 
 # setup keys
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
 
 # setup sources.list
 RUN echo "deb http://packages.ros.org/ros/ubuntu `lsb_release -sc` main" > /etc/apt/sources.list.d/ros-latest.list

--- a/ros/melodic/ubuntu/bionic/ros-core/Dockerfile
+++ b/ros/melodic/ubuntu/bionic/ros-core/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update && apt-get install -q -y \
     && rm -rf /var/lib/apt/lists/*
 
 # setup keys
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
 
 # setup sources.list
 RUN echo "deb http://packages.ros.org/ros/ubuntu `lsb_release -sc` main" > /etc/apt/sources.list.d/ros-latest.list

--- a/ros/ros
+++ b/ros/ros
@@ -9,22 +9,22 @@ GitRepo: https://github.com/osrf/docker_images.git
 
 Tags: indigo-ros-core, indigo-ros-core-trusty
 Architectures: amd64, arm32v7
-GitCommit: a328e5aa68889ab5ae50ec87c1fd3a8b14e5d11f
+GitCommit: 1a1c56d93f309d10c412c6323db5791fc1b23d1b
 Directory: ros/indigo/ubuntu/trusty/ros-core
 
 Tags: indigo-ros-base, indigo-ros-base-trusty, indigo
 Architectures: amd64, arm32v7
-GitCommit: a328e5aa68889ab5ae50ec87c1fd3a8b14e5d11f
+GitCommit: 1a1c56d93f309d10c412c6323db5791fc1b23d1b
 Directory: ros/indigo/ubuntu/trusty/ros-base
 
 Tags: indigo-robot, indigo-robot-trusty
 Architectures: amd64, arm32v7
-GitCommit: a328e5aa68889ab5ae50ec87c1fd3a8b14e5d11f
+GitCommit: 1a1c56d93f309d10c412c6323db5791fc1b23d1b
 Directory: ros/indigo/ubuntu/trusty/robot
 
 Tags: indigo-perception, indigo-perception-trusty
 Architectures: amd64, arm32v7
-GitCommit: a328e5aa68889ab5ae50ec87c1fd3a8b14e5d11f
+GitCommit: 1a1c56d93f309d10c412c6323db5791fc1b23d1b
 Directory: ros/indigo/ubuntu/trusty/perception
 
 
@@ -36,22 +36,22 @@ Directory: ros/indigo/ubuntu/trusty/perception
 
 Tags: kinetic-ros-core, kinetic-ros-core-xenial
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: a328e5aa68889ab5ae50ec87c1fd3a8b14e5d11f
+GitCommit: 1a1c56d93f309d10c412c6323db5791fc1b23d1b
 Directory: ros/kinetic/ubuntu/xenial/ros-core
 
 Tags: kinetic-ros-base, kinetic-ros-base-xenial, kinetic
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: a328e5aa68889ab5ae50ec87c1fd3a8b14e5d11f
+GitCommit: 1a1c56d93f309d10c412c6323db5791fc1b23d1b
 Directory: ros/kinetic/ubuntu/xenial/ros-base
 
 Tags: kinetic-robot, kinetic-robot-xenial
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: a328e5aa68889ab5ae50ec87c1fd3a8b14e5d11f
+GitCommit: 1a1c56d93f309d10c412c6323db5791fc1b23d1b
 Directory: ros/kinetic/ubuntu/xenial/robot
 
 Tags: kinetic-perception, kinetic-perception-xenial
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: a328e5aa68889ab5ae50ec87c1fd3a8b14e5d11f
+GitCommit: 1a1c56d93f309d10c412c6323db5791fc1b23d1b
 Directory: ros/kinetic/ubuntu/xenial/perception
 
 
@@ -63,22 +63,22 @@ Directory: ros/kinetic/ubuntu/xenial/perception
 
 Tags: lunar-ros-core, lunar-ros-core-xenial
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: a328e5aa68889ab5ae50ec87c1fd3a8b14e5d11f
+GitCommit: 1a1c56d93f309d10c412c6323db5791fc1b23d1b
 Directory: ros/lunar/ubuntu/xenial/ros-core
 
 Tags: lunar-ros-base, lunar-ros-base-xenial, lunar
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: a328e5aa68889ab5ae50ec87c1fd3a8b14e5d11f
+GitCommit: 1a1c56d93f309d10c412c6323db5791fc1b23d1b
 Directory: ros/lunar/ubuntu/xenial/ros-base
 
 Tags: lunar-robot, lunar-robot-xenial
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: a328e5aa68889ab5ae50ec87c1fd3a8b14e5d11f
+GitCommit: 1a1c56d93f309d10c412c6323db5791fc1b23d1b
 Directory: ros/lunar/ubuntu/xenial/robot
 
 Tags: lunar-perception, lunar-perception-xenial
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: a328e5aa68889ab5ae50ec87c1fd3a8b14e5d11f
+GitCommit: 1a1c56d93f309d10c412c6323db5791fc1b23d1b
 Directory: ros/lunar/ubuntu/xenial/perception
 
 ########################################
@@ -86,22 +86,22 @@ Directory: ros/lunar/ubuntu/xenial/perception
 
 Tags: lunar-ros-core-stretch
 Architectures: amd64, arm64v8
-GitCommit: a328e5aa68889ab5ae50ec87c1fd3a8b14e5d11f
+GitCommit: 1a1c56d93f309d10c412c6323db5791fc1b23d1b
 Directory: ros/lunar/debian/stretch/ros-core
 
 Tags: lunar-ros-base-stretch
 Architectures: amd64, arm64v8
-GitCommit: a328e5aa68889ab5ae50ec87c1fd3a8b14e5d11f
+GitCommit: 1a1c56d93f309d10c412c6323db5791fc1b23d1b
 Directory: ros/lunar/debian/stretch/ros-base
 
 Tags: lunar-robot-stretch
 Architectures: amd64, arm64v8
-GitCommit: a328e5aa68889ab5ae50ec87c1fd3a8b14e5d11f
+GitCommit: 1a1c56d93f309d10c412c6323db5791fc1b23d1b
 Directory: ros/lunar/debian/stretch/robot
 
 Tags: lunar-perception-stretch
 Architectures: amd64, arm64v8
-GitCommit: a328e5aa68889ab5ae50ec87c1fd3a8b14e5d11f
+GitCommit: 1a1c56d93f309d10c412c6323db5791fc1b23d1b
 Directory: ros/lunar/debian/stretch/perception
 
 
@@ -113,22 +113,22 @@ Directory: ros/lunar/debian/stretch/perception
 
 Tags: melodic-ros-core, melodic-ros-core-bionic
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: a328e5aa68889ab5ae50ec87c1fd3a8b14e5d11f
+GitCommit: 1a1c56d93f309d10c412c6323db5791fc1b23d1b
 Directory: ros/melodic/ubuntu/bionic/ros-core
 
 Tags: melodic-ros-base, melodic-ros-base-bionic, melodic, latest
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: a328e5aa68889ab5ae50ec87c1fd3a8b14e5d11f
+GitCommit: 1a1c56d93f309d10c412c6323db5791fc1b23d1b
 Directory: ros/melodic/ubuntu/bionic/ros-base
 
 Tags: melodic-robot, melodic-robot-bionic
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: a328e5aa68889ab5ae50ec87c1fd3a8b14e5d11f
+GitCommit: 1a1c56d93f309d10c412c6323db5791fc1b23d1b
 Directory: ros/melodic/ubuntu/bionic/robot
 
 Tags: melodic-perception, melodic-perception-bionic
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: a328e5aa68889ab5ae50ec87c1fd3a8b14e5d11f
+GitCommit: 1a1c56d93f309d10c412c6323db5791fc1b23d1b
 Directory: ros/melodic/ubuntu/bionic/perception
 
 ########################################
@@ -136,22 +136,22 @@ Directory: ros/melodic/ubuntu/bionic/perception
 
 Tags: melodic-ros-core-stretch
 Architectures: amd64, arm64v8
-GitCommit: a328e5aa68889ab5ae50ec87c1fd3a8b14e5d11f
+GitCommit: 1a1c56d93f309d10c412c6323db5791fc1b23d1b
 Directory: ros/melodic/debian/stretch/ros-core
 
 Tags: melodic-ros-base-stretch
 Architectures: amd64, arm64v8
-GitCommit: a328e5aa68889ab5ae50ec87c1fd3a8b14e5d11f
+GitCommit: 1a1c56d93f309d10c412c6323db5791fc1b23d1b
 Directory: ros/melodic/debian/stretch/ros-base
 
 Tags: melodic-robot-stretch
 Architectures: amd64, arm64v8
-GitCommit: a328e5aa68889ab5ae50ec87c1fd3a8b14e5d11f
+GitCommit: 1a1c56d93f309d10c412c6323db5791fc1b23d1b
 Directory: ros/melodic/debian/stretch/robot
 
 Tags: melodic-perception-stretch
 Architectures: amd64, arm64v8
-GitCommit: a328e5aa68889ab5ae50ec87c1fd3a8b14e5d11f
+GitCommit: 1a1c56d93f309d10c412c6323db5791fc1b23d1b
 Directory: ros/melodic/debian/stretch/perception
 
 


### PR DESCRIPTION
Prioritizing supported ROS1 distrso and changs from https://github.com/osrf/docker_images/pull/273
Will fix legacy and EOL images afterward.