### PR TITLE
Fix Dashing images that are broken since Dashing patch 1 came out

### DIFF
--- a/ros/dashing/ubuntu/bionic/desktop/Dockerfile
+++ b/ros/dashing/ubuntu/bionic/desktop/Dockerfile
@@ -3,6 +3,6 @@
 FROM ros:dashing-ros-base-bionic
 # install ros2 packages
 RUN apt-get update && apt-get install -y \
-    ros-dashing-desktop=0.7.0-1* \
+    ros-dashing-desktop=0.7.2-1* \
     && rm -rf /var/lib/apt/lists/*
 

--- a/ros/dashing/ubuntu/bionic/ros-base/Dockerfile
+++ b/ros/dashing/ubuntu/bionic/ros-base/Dockerfile
@@ -3,6 +3,6 @@
 FROM ros:dashing-ros-core-bionic
 # install ros2 packages
 RUN apt-get update && apt-get install -y \
-    ros-dashing-ros-base=0.7.0-1* \
+    ros-dashing-ros-base=0.7.2-1* \
     && rm -rf /var/lib/apt/lists/*
 

--- a/ros/dashing/ubuntu/bionic/ros-core/Dockerfile
+++ b/ros/dashing/ubuntu/bionic/ros-core/Dockerfile
@@ -44,7 +44,7 @@ RUN pip3 install -U \
 # install ros2 packages
 ENV ROS_DISTRO dashing
 RUN apt-get update && apt-get install -y \
-    ros-dashing-ros-core=0.7.0-1* \
+    ros-dashing-ros-core=0.7.2-1* \
     && rm -rf /var/lib/apt/lists/*
 
 # setup entrypoint

--- a/ros/dashing/ubuntu/bionic/ros1-bridge/Dockerfile
+++ b/ros/dashing/ubuntu/bionic/ros1-bridge/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update && apt-get install -y \
 
 # install ros2 packages
 RUN apt-get update && apt-get install -y \
-    ros-dashing-ros1-bridge=0.7.2-1* \
+    ros-dashing-ros1-bridge=0.7.2-4* \
     && rm -rf /var/lib/apt/lists/*
 
 # setup entrypoint

--- a/ros/ros
+++ b/ros/ros
@@ -163,12 +163,12 @@ Directory: ros/melodic/debian/stretch/perception
 
 Tags: bouncy-ros-core, bouncy-ros-core-bionic
 Architectures: amd64, arm64v8
-GitCommit: fb0fe0a628d023eec6ea1444551fa28209bd28d6
+GitCommit: 32244a8fafcf7d3c69c48e3a3aa082e4acc1fbf7
 Directory: ros/bouncy/ubuntu/bionic/ros-core
 
 Tags: bouncy-ros-base, bouncy-ros-base-bionic, bouncy
 Architectures: amd64, arm64v8
-GitCommit: fb0fe0a628d023eec6ea1444551fa28209bd28d6
+GitCommit: 32244a8fafcf7d3c69c48e3a3aa082e4acc1fbf7
 Directory: ros/bouncy/ubuntu/bionic/ros-base
 
 
@@ -180,12 +180,12 @@ Directory: ros/bouncy/ubuntu/bionic/ros-base
 
 Tags: crystal-ros-core, crystal-ros-core-bionic
 Architectures: amd64, arm64v8
-GitCommit: fb0fe0a628d023eec6ea1444551fa28209bd28d6
+GitCommit: 32244a8fafcf7d3c69c48e3a3aa082e4acc1fbf7
 Directory: ros/crystal/ubuntu/bionic/ros-core
 
 Tags: crystal-ros-base, crystal-ros-base-bionic, crystal
 Architectures: amd64, arm64v8
-GitCommit: fb0fe0a628d023eec6ea1444551fa28209bd28d6
+GitCommit: 32244a8fafcf7d3c69c48e3a3aa082e4acc1fbf7
 Directory: ros/crystal/ubuntu/bionic/ros-base
 
 
@@ -197,11 +197,11 @@ Directory: ros/crystal/ubuntu/bionic/ros-base
 
 Tags: dashing-ros-core, dashing-ros-core-bionic
 Architectures: amd64, arm64v8
-GitCommit: b832b00758b1cde2893b80f2f769b076164d9982
+GitCommit: 32244a8fafcf7d3c69c48e3a3aa082e4acc1fbf7
 Directory: ros/dashing/ubuntu/bionic/ros-core
 
 Tags: dashing-ros-base, dashing-ros-base-bionic, dashing
 Architectures: amd64, arm64v8
-GitCommit: b832b00758b1cde2893b80f2f769b076164d9982
+GitCommit: 32244a8fafcf7d3c69c48e3a3aa082e4acc1fbf7
 Directory: ros/dashing/ubuntu/bionic/ros-base
 


### PR DESCRIPTION
Currently Dashing image builds are broken:
```
E: Version '0.7.0-1*' for 'ros-dashing-ros-core' was not found
```

I'm not sure why @osrf-docker-builder didnt pick it up and submit an automated PR though

---

The changes for bouncy and crystal in the manifest don't actually come with any changes in the dockerfiles going to the official library. Commit hash is updated only because the ros1_bridge dockerfiles changed