### PR TITLE
Update ROS EOL images to use snapshots repository

### DIFF
--- a/ros/.config/legacy/platform.yaml.em
+++ b/ros/.config/legacy/platform.yaml.em
@@ -11,3 +11,4 @@ platform:
     type: distribution
     version: False
     release: ros
+    ros_version: 1

--- a/ros/ardent/ubuntu/xenial/images.yaml.em
+++ b/ros/ardent/ubuntu/xenial/images.yaml.em
@@ -38,3 +38,5 @@ images:
             - docker_templates
         ros2_packages:
             - ros1-bridge
+        ros_packages:
+            - ros-comm

--- a/ros/ardent/ubuntu/xenial/ros-core/Dockerfile
+++ b/ros/ardent/ubuntu/xenial/ros-core/Dockerfile
@@ -6,15 +6,14 @@ FROM ubuntu:xenial
 RUN apt-get update && apt-get install -q -y \
     dirmngr \
     gnupg2 \
-    lsb-release \
     python3-pip \
     && rm -rf /var/lib/apt/lists/*
 
-# setup ros2 keys
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
+# setup keys
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys AD19BAB3CBF125EA
 
 # setup sources.list
-RUN echo "deb http://packages.ros.org/ros2/ubuntu `lsb_release -sc` main" > /etc/apt/sources.list.d/ros2-latest.list
+RUN echo "deb http://snapshots.ros.org/ardent/final/ubuntu xenial main" > /etc/apt/sources.list.d/ros2-snapshots.list
 
 # install bootstrap tools
 RUN apt-get update && apt-get install --no-install-recommends -y \

--- a/ros/ardent/ubuntu/xenial/ros1-bridge/Dockerfile
+++ b/ros/ardent/ubuntu/xenial/ros1-bridge/Dockerfile
@@ -3,13 +3,18 @@
 FROM ros:ardent-ros-base-xenial
 
 # setup keys
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
 
 # setup sources.list
-RUN echo "deb http://packages.ros.org/ros/ubuntu `lsb_release -sc` main" > /etc/apt/sources.list.d/ros-latest.list
+RUN echo "deb http://packages.ros.org/ros/ubuntu xenial main" > /etc/apt/sources.list.d/ros1-latest.list
 
 ENV ROS1_DISTRO kinetic
 ENV ROS2_DISTRO ardent
+# install ros packages
+RUN apt-get update && apt-get install -y \
+    ros-kinetic-ros-comm=1.12.14-0* \
+    && rm -rf /var/lib/apt/lists/*
+
 # install ros2 packages
 RUN apt-get update && apt-get install -y \
     ros-ardent-ros1-bridge=0.4.0-0* \

--- a/ros/bouncy/ubuntu/bionic/ros-core/Dockerfile
+++ b/ros/bouncy/ubuntu/bionic/ros-core/Dockerfile
@@ -11,15 +11,14 @@ RUN echo 'Etc/UTC' > /etc/timezone && \
 RUN apt-get update && apt-get install -q -y \
     dirmngr \
     gnupg2 \
-    lsb-release \
     python3-pip \
     && rm -rf /var/lib/apt/lists/*
 
-# setup ros2 keys
+# setup keys
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
 
 # setup sources.list
-RUN echo "deb http://packages.ros.org/ros2/ubuntu `lsb_release -sc` main" > /etc/apt/sources.list.d/ros2-latest.list
+RUN echo "deb http://packages.ros.org/ros2/ubuntu bionic main" > /etc/apt/sources.list.d/ros2-latest.list
 
 # install bootstrap tools
 RUN apt-get update && apt-get install --no-install-recommends -y \

--- a/ros/bouncy/ubuntu/bionic/ros1-bridge/Dockerfile
+++ b/ros/bouncy/ubuntu/bionic/ros1-bridge/Dockerfile
@@ -3,10 +3,10 @@
 FROM ros:bouncy-ros-base-bionic
 
 # setup keys
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
 
 # setup sources.list
-RUN echo "deb http://packages.ros.org/ros/ubuntu `lsb_release -sc` main" > /etc/apt/sources.list.d/ros-latest.list
+RUN echo "deb http://packages.ros.org/ros/ubuntu bionic main" > /etc/apt/sources.list.d/ros1-latest.list
 
 ENV ROS1_DISTRO melodic
 ENV ROS2_DISTRO bouncy

--- a/ros/boxturtle/ubuntu/lucid/platform.yaml
+++ b/ros/boxturtle/ubuntu/lucid/platform.yaml
@@ -11,3 +11,4 @@ platform:
     type: distribution
     version: False
     release: ros
+    ros_version: 1

--- a/ros/boxturtle/ubuntu/lucid/ros/Dockerfile
+++ b/ros/boxturtle/ubuntu/lucid/ros/Dockerfile
@@ -2,14 +2,13 @@
 # generated from docker_images_legacy/create_ros_core_image.Dockerfile.em
 FROM ubuntu:lucid
 
-# setup source.list to old-releases
-RUN sed -i -e 's/archive/old-releases/g' /etc/apt/sources.list
+RUN find /etc/apt/ -name *.list -exec sed -i -e 's/archive.ubuntu.com\|security.ubuntu.com/old-releases.ubuntu.com/g' {} \;
 
 # setup keys
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys AD19BAB3CBF125EA
 
 # setup sources.list
-RUN echo "deb http://packages.ros.org/ros/ubuntu lucid main" > /etc/apt/sources.list.d/ros-latest.list
+RUN echo "deb http://snapshots.ros.org/boxturtle/final/ubuntu lucid main" > /etc/apt/sources.list.d/ros1-snapshots.list
 
 # setup environment
 RUN locale-gen en_US.UTF-8

--- a/ros/crystal/ubuntu/bionic/ros-core/Dockerfile
+++ b/ros/crystal/ubuntu/bionic/ros-core/Dockerfile
@@ -11,15 +11,14 @@ RUN echo 'Etc/UTC' > /etc/timezone && \
 RUN apt-get update && apt-get install -q -y \
     dirmngr \
     gnupg2 \
-    lsb-release \
     python3-pip \
     && rm -rf /var/lib/apt/lists/*
 
-# setup ros2 keys
+# setup keys
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
 
 # setup sources.list
-RUN echo "deb http://packages.ros.org/ros2/ubuntu `lsb_release -sc` main" > /etc/apt/sources.list.d/ros2-latest.list
+RUN echo "deb http://packages.ros.org/ros2/ubuntu bionic main" > /etc/apt/sources.list.d/ros2-latest.list
 
 # install bootstrap tools
 RUN apt-get update && apt-get install --no-install-recommends -y \

--- a/ros/crystal/ubuntu/bionic/ros1-bridge/Dockerfile
+++ b/ros/crystal/ubuntu/bionic/ros1-bridge/Dockerfile
@@ -3,10 +3,10 @@
 FROM ros:crystal-ros-base-bionic
 
 # setup keys
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
 
 # setup sources.list
-RUN echo "deb http://packages.ros.org/ros/ubuntu `lsb_release -sc` main" > /etc/apt/sources.list.d/ros-latest.list
+RUN echo "deb http://packages.ros.org/ros/ubuntu bionic main" > /etc/apt/sources.list.d/ros1-latest.list
 
 ENV ROS1_DISTRO melodic
 ENV ROS2_DISTRO crystal

--- a/ros/cturtle/ubuntu/lucid/platform.yaml
+++ b/ros/cturtle/ubuntu/lucid/platform.yaml
@@ -11,3 +11,4 @@ platform:
     type: distribution
     version: False
     release: ros
+    ros_version: 1

--- a/ros/cturtle/ubuntu/lucid/ros/Dockerfile
+++ b/ros/cturtle/ubuntu/lucid/ros/Dockerfile
@@ -2,14 +2,13 @@
 # generated from docker_images_legacy/create_ros_core_image.Dockerfile.em
 FROM ubuntu:lucid
 
-# setup source.list to old-releases
-RUN sed -i -e 's/archive/old-releases/g' /etc/apt/sources.list
+RUN find /etc/apt/ -name *.list -exec sed -i -e 's/archive.ubuntu.com\|security.ubuntu.com/old-releases.ubuntu.com/g' {} \;
 
 # setup keys
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys AD19BAB3CBF125EA
 
 # setup sources.list
-RUN echo "deb http://packages.ros.org/ros/ubuntu lucid main" > /etc/apt/sources.list.d/ros-latest.list
+RUN echo "deb http://snapshots.ros.org/cturtle/final/ubuntu lucid main" > /etc/apt/sources.list.d/ros1-snapshots.list
 
 # setup environment
 RUN locale-gen en_US.UTF-8

--- a/ros/dashing/ubuntu/bionic/ros-core/Dockerfile
+++ b/ros/dashing/ubuntu/bionic/ros-core/Dockerfile
@@ -11,15 +11,14 @@ RUN echo 'Etc/UTC' > /etc/timezone && \
 RUN apt-get update && apt-get install -q -y \
     dirmngr \
     gnupg2 \
-    lsb-release \
     python3-pip \
     && rm -rf /var/lib/apt/lists/*
 
-# setup ros2 keys
+# setup keys
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
 
 # setup sources.list
-RUN echo "deb http://packages.ros.org/ros2/ubuntu `lsb_release -sc` main" > /etc/apt/sources.list.d/ros2-latest.list
+RUN echo "deb http://packages.ros.org/ros2/ubuntu bionic main" > /etc/apt/sources.list.d/ros2-latest.list
 
 # install bootstrap tools
 RUN apt-get update && apt-get install --no-install-recommends -y \

--- a/ros/dashing/ubuntu/bionic/ros1-bridge/Dockerfile
+++ b/ros/dashing/ubuntu/bionic/ros1-bridge/Dockerfile
@@ -3,10 +3,10 @@
 FROM ros:dashing-ros-base-bionic
 
 # setup keys
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
 
 # setup sources.list
-RUN echo "deb http://packages.ros.org/ros/ubuntu `lsb_release -sc` main" > /etc/apt/sources.list.d/ros-latest.list
+RUN echo "deb http://packages.ros.org/ros/ubuntu bionic main" > /etc/apt/sources.list.d/ros1-latest.list
 
 ENV ROS1_DISTRO melodic
 ENV ROS2_DISTRO dashing

--- a/ros/diamondback/ubuntu/lucid/platform.yaml
+++ b/ros/diamondback/ubuntu/lucid/platform.yaml
@@ -11,3 +11,4 @@ platform:
     type: distribution
     version: False
     release: ros
+    ros_version: 1

--- a/ros/diamondback/ubuntu/lucid/ros/Dockerfile
+++ b/ros/diamondback/ubuntu/lucid/ros/Dockerfile
@@ -2,14 +2,13 @@
 # generated from docker_images_legacy/create_ros_core_image.Dockerfile.em
 FROM ubuntu:lucid
 
-# setup source.list to old-releases
-RUN sed -i -e 's/archive/old-releases/g' /etc/apt/sources.list
+RUN find /etc/apt/ -name *.list -exec sed -i -e 's/archive.ubuntu.com\|security.ubuntu.com/old-releases.ubuntu.com/g' {} \;
 
 # setup keys
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys AD19BAB3CBF125EA
 
 # setup sources.list
-RUN echo "deb http://packages.ros.org/ros/ubuntu lucid main" > /etc/apt/sources.list.d/ros-latest.list
+RUN echo "deb http://snapshots.ros.org/diamondback/final/ubuntu lucid main" > /etc/apt/sources.list.d/ros1-snapshots.list
 
 # setup environment
 RUN locale-gen en_US.UTF-8

--- a/ros/electric/ubuntu/lucid/platform.yaml
+++ b/ros/electric/ubuntu/lucid/platform.yaml
@@ -11,3 +11,4 @@ platform:
     type: distribution
     version: False
     release: ros
+    ros_version: 1

--- a/ros/electric/ubuntu/lucid/ros/Dockerfile
+++ b/ros/electric/ubuntu/lucid/ros/Dockerfile
@@ -2,14 +2,13 @@
 # generated from docker_images_legacy/create_ros_core_image.Dockerfile.em
 FROM ubuntu:lucid
 
-# setup source.list to old-releases
-RUN sed -i -e 's/archive/old-releases/g' /etc/apt/sources.list
+RUN find /etc/apt/ -name *.list -exec sed -i -e 's/archive.ubuntu.com\|security.ubuntu.com/old-releases.ubuntu.com/g' {} \;
 
 # setup keys
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys AD19BAB3CBF125EA
 
 # setup sources.list
-RUN echo "deb http://packages.ros.org/ros/ubuntu lucid main" > /etc/apt/sources.list.d/ros-latest.list
+RUN echo "deb http://snapshots.ros.org/electric/final/ubuntu lucid main" > /etc/apt/sources.list.d/ros1-snapshots.list
 
 # setup environment
 RUN locale-gen en_US.UTF-8

--- a/ros/fuerte/ubuntu/precise/platform.yaml
+++ b/ros/fuerte/ubuntu/precise/platform.yaml
@@ -11,3 +11,4 @@ platform:
     type: distribution
     version: False
     release: ros
+    ros_version: 1

--- a/ros/fuerte/ubuntu/precise/ros/Dockerfile
+++ b/ros/fuerte/ubuntu/precise/ros/Dockerfile
@@ -2,14 +2,13 @@
 # generated from docker_images_legacy/create_ros_core_image.Dockerfile.em
 FROM ubuntu:precise
 
-# setup source.list to old-releases
-RUN sed -i -e 's/archive/old-releases/g' /etc/apt/sources.list
+RUN find /etc/apt/ -name *.list -exec sed -i -e 's/archive.ubuntu.com\|security.ubuntu.com/old-releases.ubuntu.com/g' {} \;
 
 # setup keys
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys AD19BAB3CBF125EA
 
 # setup sources.list
-RUN echo "deb http://packages.ros.org/ros/ubuntu precise main" > /etc/apt/sources.list.d/ros-latest.list
+RUN echo "deb http://snapshots.ros.org/fuerte/final/ubuntu precise main" > /etc/apt/sources.list.d/ros1-snapshots.list
 
 # setup environment
 RUN locale-gen en_US.UTF-8

--- a/ros/groovy/ubuntu/precise/platform.yaml
+++ b/ros/groovy/ubuntu/precise/platform.yaml
@@ -11,3 +11,4 @@ platform:
     type: distribution
     version: False
     release: ros
+    ros_version: 1

--- a/ros/groovy/ubuntu/precise/ros/Dockerfile
+++ b/ros/groovy/ubuntu/precise/ros/Dockerfile
@@ -2,14 +2,13 @@
 # generated from docker_images_legacy/create_ros_core_image.Dockerfile.em
 FROM ubuntu:precise
 
-# setup source.list to old-releases
-RUN sed -i -e 's/archive/old-releases/g' /etc/apt/sources.list
+RUN find /etc/apt/ -name *.list -exec sed -i -e 's/archive.ubuntu.com\|security.ubuntu.com/old-releases.ubuntu.com/g' {} \;
 
 # setup keys
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys AD19BAB3CBF125EA
 
 # setup sources.list
-RUN echo "deb http://packages.ros.org/ros/ubuntu precise main" > /etc/apt/sources.list.d/ros-latest.list
+RUN echo "deb http://snapshots.ros.org/groovy/final/ubuntu precise main" > /etc/apt/sources.list.d/ros1-snapshots.list
 
 # setup environment
 RUN locale-gen en_US.UTF-8

--- a/ros/hydro/ubuntu/precise/platform.yaml
+++ b/ros/hydro/ubuntu/precise/platform.yaml
@@ -11,3 +11,4 @@ platform:
     type: distribution
     version: False
     release: ros
+    ros_version: 1

--- a/ros/hydro/ubuntu/precise/ros/Dockerfile
+++ b/ros/hydro/ubuntu/precise/ros/Dockerfile
@@ -2,14 +2,13 @@
 # generated from docker_images_legacy/create_ros_core_image.Dockerfile.em
 FROM ubuntu:precise
 
-# setup source.list to old-releases
-RUN sed -i -e 's/archive/old-releases/g' /etc/apt/sources.list
+RUN find /etc/apt/ -name *.list -exec sed -i -e 's/archive.ubuntu.com\|security.ubuntu.com/old-releases.ubuntu.com/g' {} \;
 
 # setup keys
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys AD19BAB3CBF125EA
 
 # setup sources.list
-RUN echo "deb http://packages.ros.org/ros/ubuntu precise main" > /etc/apt/sources.list.d/ros-latest.list
+RUN echo "deb http://snapshots.ros.org/hydro/final/ubuntu precise main" > /etc/apt/sources.list.d/ros1-snapshots.list
 
 # setup environment
 RUN locale-gen en_US.UTF-8

--- a/ros/indigo/ubuntu/trusty/ros-core/Dockerfile
+++ b/ros/indigo/ubuntu/trusty/ros-core/Dockerfile
@@ -6,14 +6,13 @@ FROM ubuntu:trusty
 RUN apt-get update && apt-get install -q -y \
     dirmngr \
     gnupg2 \
-    lsb-release \
     && rm -rf /var/lib/apt/lists/*
 
 # setup keys
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys AD19BAB3CBF125EA
 
 # setup sources.list
-RUN echo "deb http://packages.ros.org/ros/ubuntu `lsb_release -sc` main" > /etc/apt/sources.list.d/ros-latest.list
+RUN echo "deb http://snapshots.ros.org/indigo/final/ubuntu trusty main" > /etc/apt/sources.list.d/ros1-snapshots.list
 
 # install bootstrap tools
 RUN apt-get update && apt-get install --no-install-recommends -y \

--- a/ros/jade/ubuntu/trusty/ros-core/Dockerfile
+++ b/ros/jade/ubuntu/trusty/ros-core/Dockerfile
@@ -6,14 +6,13 @@ FROM ubuntu:trusty
 RUN apt-get update && apt-get install -q -y \
     dirmngr \
     gnupg2 \
-    lsb-release \
     && rm -rf /var/lib/apt/lists/*
 
 # setup keys
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys AD19BAB3CBF125EA
 
 # setup sources.list
-RUN echo "deb http://packages.ros.org/ros/ubuntu `lsb_release -sc` main" > /etc/apt/sources.list.d/ros-latest.list
+RUN echo "deb http://snapshots.ros.org/jade/final/ubuntu trusty main" > /etc/apt/sources.list.d/ros1-snapshots.list
 
 # install bootstrap tools
 RUN apt-get update && apt-get install --no-install-recommends -y \

--- a/ros/kinetic/debian/jessie/ros-core/Dockerfile
+++ b/ros/kinetic/debian/jessie/ros-core/Dockerfile
@@ -6,14 +6,13 @@ FROM debian:jessie
 RUN apt-get update && apt-get install -q -y \
     dirmngr \
     gnupg2 \
-    lsb-release \
     && rm -rf /var/lib/apt/lists/*
 
 # setup keys
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys AD19BAB3CBF125EA
 
 # setup sources.list
-RUN echo "deb http://packages.ros.org/ros/ubuntu `lsb_release -sc` main" > /etc/apt/sources.list.d/ros-latest.list
+RUN echo "deb http://snapshots.ros.org/kinetic/final/debian jessie main" > /etc/apt/sources.list.d/ros1-snapshots.list
 
 # install bootstrap tools
 RUN apt-get update && apt-get install --no-install-recommends -y \

--- a/ros/kinetic/ubuntu/xenial/ros-core/Dockerfile
+++ b/ros/kinetic/ubuntu/xenial/ros-core/Dockerfile
@@ -6,14 +6,13 @@ FROM ubuntu:xenial
 RUN apt-get update && apt-get install -q -y \
     dirmngr \
     gnupg2 \
-    lsb-release \
     && rm -rf /var/lib/apt/lists/*
 
 # setup keys
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
 
 # setup sources.list
-RUN echo "deb http://packages.ros.org/ros/ubuntu `lsb_release -sc` main" > /etc/apt/sources.list.d/ros-latest.list
+RUN echo "deb http://packages.ros.org/ros/ubuntu xenial main" > /etc/apt/sources.list.d/ros1-latest.list
 
 # install bootstrap tools
 RUN apt-get update && apt-get install --no-install-recommends -y \

--- a/ros/lunar/debian/stretch/ros-core/Dockerfile
+++ b/ros/lunar/debian/stretch/ros-core/Dockerfile
@@ -6,14 +6,13 @@ FROM debian:stretch
 RUN apt-get update && apt-get install -q -y \
     dirmngr \
     gnupg2 \
-    lsb-release \
     && rm -rf /var/lib/apt/lists/*
 
 # setup keys
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys AD19BAB3CBF125EA
 
 # setup sources.list
-RUN echo "deb http://packages.ros.org/ros/ubuntu `lsb_release -sc` main" > /etc/apt/sources.list.d/ros-latest.list
+RUN echo "deb http://snapshots.ros.org/lunar/final/debian stretch main" > /etc/apt/sources.list.d/ros1-snapshots.list
 
 # install bootstrap tools
 RUN apt-get update && apt-get install --no-install-recommends -y \

--- a/ros/lunar/ubuntu/xenial/ros-core/Dockerfile
+++ b/ros/lunar/ubuntu/xenial/ros-core/Dockerfile
@@ -6,14 +6,13 @@ FROM ubuntu:xenial
 RUN apt-get update && apt-get install -q -y \
     dirmngr \
     gnupg2 \
-    lsb-release \
     && rm -rf /var/lib/apt/lists/*
 
 # setup keys
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys AD19BAB3CBF125EA
 
 # setup sources.list
-RUN echo "deb http://packages.ros.org/ros/ubuntu `lsb_release -sc` main" > /etc/apt/sources.list.d/ros-latest.list
+RUN echo "deb http://snapshots.ros.org/lunar/final/ubuntu xenial main" > /etc/apt/sources.list.d/ros1-snapshots.list
 
 # install bootstrap tools
 RUN apt-get update && apt-get install --no-install-recommends -y \

--- a/ros/lunar/ubuntu/zesty/ros-core/Dockerfile
+++ b/ros/lunar/ubuntu/zesty/ros-core/Dockerfile
@@ -1,19 +1,19 @@
 # This is an auto generated Dockerfile for ros:ros-core
 # generated from docker_images/create_ros_core_image.Dockerfile.em
 FROM ubuntu:zesty
+RUN find /etc/apt/ -name *.list -exec sed -i -e 's/archive.ubuntu.com\|security.ubuntu.com/old-releases.ubuntu.com/g' {} \;
 
 # install packages
 RUN apt-get update && apt-get install -q -y \
     dirmngr \
     gnupg2 \
-    lsb-release \
     && rm -rf /var/lib/apt/lists/*
 
 # setup keys
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys AD19BAB3CBF125EA
 
 # setup sources.list
-RUN echo "deb http://packages.ros.org/ros/ubuntu `lsb_release -sc` main" > /etc/apt/sources.list.d/ros-latest.list
+RUN echo "deb http://snapshots.ros.org/lunar/final/ubuntu zesty main" > /etc/apt/sources.list.d/ros1-snapshots.list
 
 # install bootstrap tools
 RUN apt-get update && apt-get install --no-install-recommends -y \

--- a/ros/manifest.yaml
+++ b/ros/manifest.yaml
@@ -40,6 +40,8 @@ release_names:
                         archs:
                             - amd64
                         tag_names:
+                            ros:
+                                aliases:
     cturtle:
         eol: a long time ago
         os_names:
@@ -50,6 +52,8 @@ release_names:
                         archs:
                             - amd64
                         tag_names:
+                            ros:
+                                aliases:
     diamondback:
         eol: in a galaxy far, far away....
         os_names:
@@ -60,6 +64,8 @@ release_names:
                         archs:
                             - amd64
                         tag_names:
+                            ros:
+                                aliases:
     electric:
         eol: came forth a ros distro
         os_names:
@@ -70,6 +76,8 @@ release_names:
                         archs:
                             - amd64
                         tag_names:
+                            ros:
+                                aliases:
     fuerte:
         eol: to resore balance to the overlay
         os_names:
@@ -80,6 +88,8 @@ release_names:
                         archs:
                             - amd64
                         tag_names:
+                            ros:
+                                aliases:
     groovy:
         eol: 2014-07
         os_names:
@@ -90,6 +100,8 @@ release_names:
                         archs:
                             - amd64
                         tag_names:
+                            ros:
+                                aliases:
     hydro:
         eol: 2015-05
         os_names:
@@ -100,6 +112,8 @@ release_names:
                         archs:
                             - amd64
                         tag_names:
+                            ros:
+                                aliases:
     indigo:
         eol: 2019-04
         os_names:
@@ -140,23 +154,23 @@ release_names:
                             - arm32v7
                         tag_names:
                             # EOL
-                            # ros-core:
-                            #     aliases:
-                            #         - "$release_name-ros-core"
-                            #         - "$release_name-ros-core-$os_code_name"
-                            # ros-base:
-                            #     aliases:
-                            #         - "$release_name-ros-base"
-                            #         - "$release_name-ros-base-$os_code_name"
-                            #         - "$release_name"
-                            # robot:
-                            #     aliases:
-                            #         - "$release_name-robot"
-                            #         - "$release_name-robot-$os_code_name"
-                            # perception:
-                            #     aliases:
-                            #         - "$release_name-perception"
-                            #         - "$release_name-perception-$os_code_name"
+                            ros-core:
+                                aliases:
+                                    - "$release_name-ros-core"
+                                    - "$release_name-ros-core-$os_code_name"
+                            ros-base:
+                                aliases:
+                                    - "$release_name-ros-base"
+                                    - "$release_name-ros-base-$os_code_name"
+                                    - "$release_name"
+                            robot:
+                                aliases:
+                                    - "$release_name-robot"
+                                    - "$release_name-robot-$os_code_name"
+                            perception:
+                                aliases:
+                                    - "$release_name-perception"
+                                    - "$release_name-perception-$os_code_name"
     kinetic:
         eol: 2021-04
         os_names:
@@ -195,18 +209,18 @@ release_names:
                             - arm64v8
                         tag_names:
                             # EOL
-                            # ros-core:
-                            #     aliases:
-                            #         - "$release_name-ros-core-$os_code_name"
-                            # ros-base:
-                            #     aliases:
-                            #         - "$release_name-ros-base-$os_code_name"
-                            # robot:
-                            #     aliases:
-                            #         - "$release_name-robot-$os_code_name"
-                            # perception:
-                            #     aliases:
-                            #         - "$release_name-perception-$os_code_name"
+                            ros-core:
+                                aliases:
+                                    - "$release_name-ros-core-$os_code_name"
+                            ros-base:
+                                aliases:
+                                    - "$release_name-ros-base-$os_code_name"
+                            robot:
+                                aliases:
+                                    - "$release_name-robot-$os_code_name"
+                            perception:
+                                aliases:
+                                    - "$release_name-perception-$os_code_name"
     lunar:
         eol: 2019-05
         os_names:
@@ -242,18 +256,18 @@ release_names:
                             - amd64
                         tag_names:
                             # EOL
-                            # ros-core:
-                            #     aliases:
-                            #         - "$release_name-ros-core-$os_code_name"
-                            # ros-base:
-                            #     aliases:
-                            #         - "$release_name-ros-base-$os_code_name"
-                            # robot:
-                            #     aliases:
-                            #         - "$release_name-robot-$os_code_name"
-                            # perception:
-                            #     aliases:
-                            #         - "$release_name-perception-$os_code_name"
+                            ros-core:
+                                aliases:
+                                    - "$release_name-ros-core-$os_code_name"
+                            ros-base:
+                                aliases:
+                                    - "$release_name-ros-base-$os_code_name"
+                            robot:
+                                aliases:
+                                    - "$release_name-robot-$os_code_name"
+                            perception:
+                                aliases:
+                                    - "$release_name-perception-$os_code_name"
             debian:
                 os_code_names:
                     stretch:
@@ -337,15 +351,15 @@ release_names:
                             - arm64v8
                         tag_names:
                             # EOL
-                            # ros-core:
-                            #     aliases:
-                            #         - "$release_name-ros-core"
-                            #         - "$release_name-ros-core-$os_code_name"
-                            # ros-base:
-                            #     aliases:
-                            #         - "$release_name-ros-base"
-                            #         - "$release_name-ros-base-$os_code_name"
-                            #         - "$release_name"
+                            ros-core:
+                                aliases:
+                                    - "$release_name-ros-core"
+                                    - "$release_name-ros-core-$os_code_name"
+                            ros-base:
+                                aliases:
+                                    - "$release_name-ros-base"
+                                    - "$release_name-ros-base-$os_code_name"
+                                    - "$release_name"
     bouncy:
         eol: 2019-07
         os_names:
@@ -492,10 +506,10 @@ hacks:
                     trusty:
                         tag_names:
                             # EOL
-                            # desktop:
-                            #     <<: *DEFAULT_HOOKS
-                            # desktop-full:
-                            #     <<: *DEFAULT_HOOKS
+                            desktop:
+                                <<: *DEFAULT_HOOKS
+                            desktop-full:
+                                <<: *DEFAULT_HOOKS
     kinetic:
         os_names:
             ubuntu:
@@ -533,10 +547,10 @@ hacks:
                     xenial:
                         tag_names:
                             # EOL
-                            # desktop:
-                            #     <<: *DEFAULT_HOOKS
-                            # ros1-bridge:
-                            #     <<: *DEFAULT_HOOKS
+                            desktop:
+                                <<: *DEFAULT_HOOKS
+                            ros1-bridge:
+                                <<: *DEFAULT_HOOKS
     bouncy:
         os_names:
             ubuntu:

--- a/ros/manifest.yaml
+++ b/ros/manifest.yaml
@@ -40,8 +40,6 @@ release_names:
                         archs:
                             - amd64
                         tag_names:
-                            ros:
-                                aliases:
     cturtle:
         eol: a long time ago
         os_names:
@@ -52,8 +50,6 @@ release_names:
                         archs:
                             - amd64
                         tag_names:
-                            ros:
-                                aliases:
     diamondback:
         eol: in a galaxy far, far away....
         os_names:
@@ -64,8 +60,6 @@ release_names:
                         archs:
                             - amd64
                         tag_names:
-                            ros:
-                                aliases:
     electric:
         eol: came forth a ros distro
         os_names:
@@ -76,8 +70,6 @@ release_names:
                         archs:
                             - amd64
                         tag_names:
-                            ros:
-                                aliases:
     fuerte:
         eol: to resore balance to the overlay
         os_names:
@@ -88,8 +80,6 @@ release_names:
                         archs:
                             - amd64
                         tag_names:
-                            ros:
-                                aliases:
     groovy:
         eol: 2014-07
         os_names:
@@ -100,8 +90,6 @@ release_names:
                         archs:
                             - amd64
                         tag_names:
-                            ros:
-                                aliases:
     hydro:
         eol: 2015-05
         os_names:
@@ -112,8 +100,6 @@ release_names:
                         archs:
                             - amd64
                         tag_names:
-                            ros:
-                                aliases:
     indigo:
         eol: 2019-04
         os_names:

--- a/ros/melodic/debian/stretch/ros-core/Dockerfile
+++ b/ros/melodic/debian/stretch/ros-core/Dockerfile
@@ -6,14 +6,13 @@ FROM debian:stretch
 RUN apt-get update && apt-get install -q -y \
     dirmngr \
     gnupg2 \
-    lsb-release \
     && rm -rf /var/lib/apt/lists/*
 
 # setup keys
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
 
 # setup sources.list
-RUN echo "deb http://packages.ros.org/ros/ubuntu `lsb_release -sc` main" > /etc/apt/sources.list.d/ros-latest.list
+RUN echo "deb http://packages.ros.org/ros/ubuntu stretch main" > /etc/apt/sources.list.d/ros1-latest.list
 
 # install bootstrap tools
 RUN apt-get update && apt-get install --no-install-recommends -y \

--- a/ros/melodic/ubuntu/bionic/ros-core/Dockerfile
+++ b/ros/melodic/ubuntu/bionic/ros-core/Dockerfile
@@ -11,14 +11,13 @@ RUN echo 'Etc/UTC' > /etc/timezone && \
 RUN apt-get update && apt-get install -q -y \
     dirmngr \
     gnupg2 \
-    lsb-release \
     && rm -rf /var/lib/apt/lists/*
 
 # setup keys
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
 
 # setup sources.list
-RUN echo "deb http://packages.ros.org/ros/ubuntu `lsb_release -sc` main" > /etc/apt/sources.list.d/ros-latest.list
+RUN echo "deb http://packages.ros.org/ros/ubuntu bionic main" > /etc/apt/sources.list.d/ros1-latest.list
 
 # install bootstrap tools
 RUN apt-get update && apt-get install --no-install-recommends -y \

--- a/ros/ros
+++ b/ros/ros
@@ -9,23 +9,50 @@ GitRepo: https://github.com/osrf/docker_images.git
 
 Tags: indigo-ros-core, indigo-ros-core-trusty
 Architectures: amd64, arm32v7
-GitCommit: 1a1c56d93f309d10c412c6323db5791fc1b23d1b
+GitCommit: 460ddc4707530c2179788e2100d5c624cf2af3d7
 Directory: ros/indigo/ubuntu/trusty/ros-core
 
 Tags: indigo-ros-base, indigo-ros-base-trusty, indigo
 Architectures: amd64, arm32v7
-GitCommit: 1a1c56d93f309d10c412c6323db5791fc1b23d1b
+GitCommit: 460ddc4707530c2179788e2100d5c624cf2af3d7
 Directory: ros/indigo/ubuntu/trusty/ros-base
 
 Tags: indigo-robot, indigo-robot-trusty
 Architectures: amd64, arm32v7
-GitCommit: 1a1c56d93f309d10c412c6323db5791fc1b23d1b
+GitCommit: 460ddc4707530c2179788e2100d5c624cf2af3d7
 Directory: ros/indigo/ubuntu/trusty/robot
 
 Tags: indigo-perception, indigo-perception-trusty
 Architectures: amd64, arm32v7
-GitCommit: 1a1c56d93f309d10c412c6323db5791fc1b23d1b
+GitCommit: 460ddc4707530c2179788e2100d5c624cf2af3d7
 Directory: ros/indigo/ubuntu/trusty/perception
+
+
+################################################################################
+# Release: jade
+
+########################################
+# Distro: ubuntu:trusty
+
+Tags: jade-ros-core, jade-ros-core-trusty
+Architectures: amd64, arm32v7
+GitCommit: 460ddc4707530c2179788e2100d5c624cf2af3d7
+Directory: ros/jade/ubuntu/trusty/ros-core
+
+Tags: jade-ros-base, jade-ros-base-trusty, jade
+Architectures: amd64, arm32v7
+GitCommit: 460ddc4707530c2179788e2100d5c624cf2af3d7
+Directory: ros/jade/ubuntu/trusty/ros-base
+
+Tags: jade-robot, jade-robot-trusty
+Architectures: amd64, arm32v7
+GitCommit: 460ddc4707530c2179788e2100d5c624cf2af3d7
+Directory: ros/jade/ubuntu/trusty/robot
+
+Tags: jade-perception, jade-perception-trusty
+Architectures: amd64, arm32v7
+GitCommit: 460ddc4707530c2179788e2100d5c624cf2af3d7
+Directory: ros/jade/ubuntu/trusty/perception
 
 
 ################################################################################
@@ -36,23 +63,46 @@ Directory: ros/indigo/ubuntu/trusty/perception
 
 Tags: kinetic-ros-core, kinetic-ros-core-xenial
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 1a1c56d93f309d10c412c6323db5791fc1b23d1b
+GitCommit: 460ddc4707530c2179788e2100d5c624cf2af3d7
 Directory: ros/kinetic/ubuntu/xenial/ros-core
 
 Tags: kinetic-ros-base, kinetic-ros-base-xenial, kinetic
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 1a1c56d93f309d10c412c6323db5791fc1b23d1b
+GitCommit: 460ddc4707530c2179788e2100d5c624cf2af3d7
 Directory: ros/kinetic/ubuntu/xenial/ros-base
 
 Tags: kinetic-robot, kinetic-robot-xenial
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 1a1c56d93f309d10c412c6323db5791fc1b23d1b
+GitCommit: 460ddc4707530c2179788e2100d5c624cf2af3d7
 Directory: ros/kinetic/ubuntu/xenial/robot
 
 Tags: kinetic-perception, kinetic-perception-xenial
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 1a1c56d93f309d10c412c6323db5791fc1b23d1b
+GitCommit: 460ddc4707530c2179788e2100d5c624cf2af3d7
 Directory: ros/kinetic/ubuntu/xenial/perception
+
+########################################
+# Distro: debian:jessie
+
+Tags: kinetic-ros-core-jessie
+Architectures: amd64, arm64v8
+GitCommit: 460ddc4707530c2179788e2100d5c624cf2af3d7
+Directory: ros/kinetic/debian/jessie/ros-core
+
+Tags: kinetic-ros-base-jessie
+Architectures: amd64, arm64v8
+GitCommit: 460ddc4707530c2179788e2100d5c624cf2af3d7
+Directory: ros/kinetic/debian/jessie/ros-base
+
+Tags: kinetic-robot-jessie
+Architectures: amd64, arm64v8
+GitCommit: 460ddc4707530c2179788e2100d5c624cf2af3d7
+Directory: ros/kinetic/debian/jessie/robot
+
+Tags: kinetic-perception-jessie
+Architectures: amd64, arm64v8
+GitCommit: 460ddc4707530c2179788e2100d5c624cf2af3d7
+Directory: ros/kinetic/debian/jessie/perception
 
 
 ################################################################################
@@ -63,45 +113,68 @@ Directory: ros/kinetic/ubuntu/xenial/perception
 
 Tags: lunar-ros-core, lunar-ros-core-xenial
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 1a1c56d93f309d10c412c6323db5791fc1b23d1b
+GitCommit: 460ddc4707530c2179788e2100d5c624cf2af3d7
 Directory: ros/lunar/ubuntu/xenial/ros-core
 
 Tags: lunar-ros-base, lunar-ros-base-xenial, lunar
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 1a1c56d93f309d10c412c6323db5791fc1b23d1b
+GitCommit: 460ddc4707530c2179788e2100d5c624cf2af3d7
 Directory: ros/lunar/ubuntu/xenial/ros-base
 
 Tags: lunar-robot, lunar-robot-xenial
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 1a1c56d93f309d10c412c6323db5791fc1b23d1b
+GitCommit: 460ddc4707530c2179788e2100d5c624cf2af3d7
 Directory: ros/lunar/ubuntu/xenial/robot
 
 Tags: lunar-perception, lunar-perception-xenial
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 1a1c56d93f309d10c412c6323db5791fc1b23d1b
+GitCommit: 460ddc4707530c2179788e2100d5c624cf2af3d7
 Directory: ros/lunar/ubuntu/xenial/perception
+
+########################################
+# Distro: ubuntu:zesty
+
+Tags: lunar-ros-core-zesty
+Architectures: amd64
+GitCommit: 460ddc4707530c2179788e2100d5c624cf2af3d7
+Directory: ros/lunar/ubuntu/zesty/ros-core
+
+Tags: lunar-ros-base-zesty
+Architectures: amd64
+GitCommit: 460ddc4707530c2179788e2100d5c624cf2af3d7
+Directory: ros/lunar/ubuntu/zesty/ros-base
+
+Tags: lunar-robot-zesty
+Architectures: amd64
+GitCommit: 460ddc4707530c2179788e2100d5c624cf2af3d7
+Directory: ros/lunar/ubuntu/zesty/robot
+
+Tags: lunar-perception-zesty
+Architectures: amd64
+GitCommit: 460ddc4707530c2179788e2100d5c624cf2af3d7
+Directory: ros/lunar/ubuntu/zesty/perception
 
 ########################################
 # Distro: debian:stretch
 
 Tags: lunar-ros-core-stretch
 Architectures: amd64, arm64v8
-GitCommit: 1a1c56d93f309d10c412c6323db5791fc1b23d1b
+GitCommit: 460ddc4707530c2179788e2100d5c624cf2af3d7
 Directory: ros/lunar/debian/stretch/ros-core
 
 Tags: lunar-ros-base-stretch
 Architectures: amd64, arm64v8
-GitCommit: 1a1c56d93f309d10c412c6323db5791fc1b23d1b
+GitCommit: 460ddc4707530c2179788e2100d5c624cf2af3d7
 Directory: ros/lunar/debian/stretch/ros-base
 
 Tags: lunar-robot-stretch
 Architectures: amd64, arm64v8
-GitCommit: 1a1c56d93f309d10c412c6323db5791fc1b23d1b
+GitCommit: 460ddc4707530c2179788e2100d5c624cf2af3d7
 Directory: ros/lunar/debian/stretch/robot
 
 Tags: lunar-perception-stretch
 Architectures: amd64, arm64v8
-GitCommit: 1a1c56d93f309d10c412c6323db5791fc1b23d1b
+GitCommit: 460ddc4707530c2179788e2100d5c624cf2af3d7
 Directory: ros/lunar/debian/stretch/perception
 
 
@@ -113,22 +186,22 @@ Directory: ros/lunar/debian/stretch/perception
 
 Tags: melodic-ros-core, melodic-ros-core-bionic
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 1a1c56d93f309d10c412c6323db5791fc1b23d1b
+GitCommit: 460ddc4707530c2179788e2100d5c624cf2af3d7
 Directory: ros/melodic/ubuntu/bionic/ros-core
 
 Tags: melodic-ros-base, melodic-ros-base-bionic, melodic, latest
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 1a1c56d93f309d10c412c6323db5791fc1b23d1b
+GitCommit: 460ddc4707530c2179788e2100d5c624cf2af3d7
 Directory: ros/melodic/ubuntu/bionic/ros-base
 
 Tags: melodic-robot, melodic-robot-bionic
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 1a1c56d93f309d10c412c6323db5791fc1b23d1b
+GitCommit: 460ddc4707530c2179788e2100d5c624cf2af3d7
 Directory: ros/melodic/ubuntu/bionic/robot
 
 Tags: melodic-perception, melodic-perception-bionic
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 1a1c56d93f309d10c412c6323db5791fc1b23d1b
+GitCommit: 460ddc4707530c2179788e2100d5c624cf2af3d7
 Directory: ros/melodic/ubuntu/bionic/perception
 
 ########################################
@@ -136,23 +209,40 @@ Directory: ros/melodic/ubuntu/bionic/perception
 
 Tags: melodic-ros-core-stretch
 Architectures: amd64, arm64v8
-GitCommit: 1a1c56d93f309d10c412c6323db5791fc1b23d1b
+GitCommit: 460ddc4707530c2179788e2100d5c624cf2af3d7
 Directory: ros/melodic/debian/stretch/ros-core
 
 Tags: melodic-ros-base-stretch
 Architectures: amd64, arm64v8
-GitCommit: 1a1c56d93f309d10c412c6323db5791fc1b23d1b
+GitCommit: 460ddc4707530c2179788e2100d5c624cf2af3d7
 Directory: ros/melodic/debian/stretch/ros-base
 
 Tags: melodic-robot-stretch
 Architectures: amd64, arm64v8
-GitCommit: 1a1c56d93f309d10c412c6323db5791fc1b23d1b
+GitCommit: 460ddc4707530c2179788e2100d5c624cf2af3d7
 Directory: ros/melodic/debian/stretch/robot
 
 Tags: melodic-perception-stretch
 Architectures: amd64, arm64v8
-GitCommit: 1a1c56d93f309d10c412c6323db5791fc1b23d1b
+GitCommit: 460ddc4707530c2179788e2100d5c624cf2af3d7
 Directory: ros/melodic/debian/stretch/perception
+
+
+################################################################################
+# Release: ardent
+
+########################################
+# Distro: ubuntu:xenial
+
+Tags: ardent-ros-core, ardent-ros-core-xenial
+Architectures: amd64, arm64v8
+GitCommit: 460ddc4707530c2179788e2100d5c624cf2af3d7
+Directory: ros/ardent/ubuntu/xenial/ros-core
+
+Tags: ardent-ros-base, ardent-ros-base-xenial, ardent
+Architectures: amd64, arm64v8
+GitCommit: 460ddc4707530c2179788e2100d5c624cf2af3d7
+Directory: ros/ardent/ubuntu/xenial/ros-base
 
 
 ################################################################################
@@ -163,12 +253,12 @@ Directory: ros/melodic/debian/stretch/perception
 
 Tags: bouncy-ros-core, bouncy-ros-core-bionic
 Architectures: amd64, arm64v8
-GitCommit: 32244a8fafcf7d3c69c48e3a3aa082e4acc1fbf7
+GitCommit: 460ddc4707530c2179788e2100d5c624cf2af3d7
 Directory: ros/bouncy/ubuntu/bionic/ros-core
 
 Tags: bouncy-ros-base, bouncy-ros-base-bionic, bouncy
 Architectures: amd64, arm64v8
-GitCommit: 32244a8fafcf7d3c69c48e3a3aa082e4acc1fbf7
+GitCommit: 460ddc4707530c2179788e2100d5c624cf2af3d7
 Directory: ros/bouncy/ubuntu/bionic/ros-base
 
 
@@ -180,12 +270,12 @@ Directory: ros/bouncy/ubuntu/bionic/ros-base
 
 Tags: crystal-ros-core, crystal-ros-core-bionic
 Architectures: amd64, arm64v8
-GitCommit: ed29a36e105bf35ddf560486f29f286965afe491
+GitCommit: 460ddc4707530c2179788e2100d5c624cf2af3d7
 Directory: ros/crystal/ubuntu/bionic/ros-core
 
 Tags: crystal-ros-base, crystal-ros-base-bionic, crystal
 Architectures: amd64, arm64v8
-GitCommit: ed29a36e105bf35ddf560486f29f286965afe491
+GitCommit: 460ddc4707530c2179788e2100d5c624cf2af3d7
 Directory: ros/crystal/ubuntu/bionic/ros-base
 
 
@@ -197,11 +287,10 @@ Directory: ros/crystal/ubuntu/bionic/ros-base
 
 Tags: dashing-ros-core, dashing-ros-core-bionic
 Architectures: amd64, arm64v8
-GitCommit: bf5aa6ca8ca41a096dd20b7b9e4e18594795bd27
+GitCommit: 460ddc4707530c2179788e2100d5c624cf2af3d7
 Directory: ros/dashing/ubuntu/bionic/ros-core
 
 Tags: dashing-ros-base, dashing-ros-base-bionic, dashing
 Architectures: amd64, arm64v8
-GitCommit: bf5aa6ca8ca41a096dd20b7b9e4e18594795bd27
+GitCommit: 460ddc4707530c2179788e2100d5c624cf2af3d7
 Directory: ros/dashing/ubuntu/bionic/ros-base
-


### PR DESCRIPTION
- Updates the images.yaml.em to reflect ros_version for all images
- Reenable all EOL images in ros manifest 
- Regenerate images using https://github.com/osrf/docker_templates/pull/67:
  - use snapshots repository for EOL distros + associated key
  - update key for packages.for.org

Fixes https://github.com/osrf/docker_images/issues/288
Replaces https://github.com/osrf/docker_images/pull/269
Replaces https://github.com/osrf/docker_images/pull/273

Should be merged and built on dockerhub before addressing https://github.com/osrf/docker_images/issues/282 and https://github.com/osrf/docker_images/pull/268

I successfully built all the images locally

Current blocker for this PR:
The ROS Lunar / Debian Stretch packages are [not available in the snapshot repository](http://snapshots.ros.org/lunar/final/debian/dists/stretch/) (issue raised [here](https://discourse.ros.org/t/announcing-ros-snapshot-repositories/7705/11)). 
@nuclearsandwich @tfoote Do you have an estimate of when these packages will be synced to the snapshots repository?