### PR TITLE
omit arm64v8 that's not supported by dockerhub anymore

### DIFF
--- a/ros/manifest.yaml
+++ b/ros/manifest.yaml
@@ -192,7 +192,7 @@ release_names:
                         <<: *DEFAULT_ROS1
                         archs:
                             - amd64
-                            - arm64v8
+                            # EOL - arm64v8
                         tag_names:
                             # EOL
                             ros-core:

--- a/ros/ros
+++ b/ros/ros
@@ -85,22 +85,22 @@ Directory: ros/kinetic/ubuntu/xenial/perception
 # Distro: debian:jessie
 
 Tags: kinetic-ros-core-jessie
-Architectures: amd64, arm64v8
+Architectures: amd64
 GitCommit: 7b6d0959808500b3531e8a5448756fc95dbb2d12
 Directory: ros/kinetic/debian/jessie/ros-core
 
 Tags: kinetic-ros-base-jessie
-Architectures: amd64, arm64v8
+Architectures: amd64
 GitCommit: 7b6d0959808500b3531e8a5448756fc95dbb2d12
 Directory: ros/kinetic/debian/jessie/ros-base
 
 Tags: kinetic-robot-jessie
-Architectures: amd64, arm64v8
+Architectures: amd64
 GitCommit: 7b6d0959808500b3531e8a5448756fc95dbb2d12
 Directory: ros/kinetic/debian/jessie/robot
 
 Tags: kinetic-perception-jessie
-Architectures: amd64, arm64v8
+Architectures: amd64
 GitCommit: 7b6d0959808500b3531e8a5448756fc95dbb2d12
 Directory: ros/kinetic/debian/jessie/perception
 


### PR DESCRIPTION
Signed-off-by: Mikael Arguedas <mikael.arguedas@gmail.com>