### PR TITLE
Remove EOL distros from manifest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,7 @@ env:
   # ros
   - HUB_REPO=ros    HUB_RELEASE=melodic HUB_OS_NAME=ubuntu HUB_OS_CODE_NAME=bionic
   - HUB_REPO=ros    HUB_RELEASE=melodic HUB_OS_NAME=debian HUB_OS_CODE_NAME=stretch
-  - HUB_REPO=ros    HUB_RELEASE=lunar   HUB_OS_NAME=ubuntu HUB_OS_CODE_NAME=xenial
-  - HUB_REPO=ros    HUB_RELEASE=lunar   HUB_OS_NAME=debian HUB_OS_CODE_NAME=stretch
   - HUB_REPO=ros    HUB_RELEASE=kinetic HUB_OS_NAME=ubuntu HUB_OS_CODE_NAME=xenial
-  - HUB_REPO=ros    HUB_RELEASE=indigo  HUB_OS_NAME=ubuntu HUB_OS_CODE_NAME=trusty
   # gazebo
   - HUB_REPO=gazebo HUB_RELEASE=10      HUB_OS_NAME=ubuntu HUB_OS_CODE_NAME=bionic
   - HUB_REPO=gazebo HUB_RELEASE=9       HUB_OS_NAME=ubuntu HUB_OS_CODE_NAME=bionic

--- a/ros/bouncy/ubuntu/bionic/ros-core/Dockerfile
+++ b/ros/bouncy/ubuntu/bionic/ros-core/Dockerfile
@@ -15,10 +15,10 @@ RUN apt-get update && apt-get install -q -y \
     && rm -rf /var/lib/apt/lists/*
 
 # setup keys
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 4B63CF8FDE49746E98FA01DDAD19BAB3CBF125EA
 
 # setup sources.list
-RUN echo "deb http://packages.ros.org/ros2/ubuntu bionic main" > /etc/apt/sources.list.d/ros2-latest.list
+RUN echo "deb http://snapshots.ros.org/bouncy/final/ubuntu bionic main" > /etc/apt/sources.list.d/ros2-snapshots.list
 
 # install bootstrap tools
 RUN apt-get update && apt-get install --no-install-recommends -y \

--- a/ros/manifest.yaml
+++ b/ros/manifest.yaml
@@ -111,23 +111,24 @@ release_names:
                             - amd64
                             - arm32v7
                         tag_names:
-                            ros-core:
-                                aliases:
-                                    - "$release_name-ros-core"
-                                    - "$release_name-ros-core-$os_code_name"
-                            ros-base:
-                                aliases:
-                                    - "$release_name-ros-base"
-                                    - "$release_name-ros-base-$os_code_name"
-                                    - "$release_name"
-                            robot:
-                                aliases:
-                                    - "$release_name-robot"
-                                    - "$release_name-robot-$os_code_name"
-                            perception:
-                                aliases:
-                                    - "$release_name-perception"
-                                    - "$release_name-perception-$os_code_name"
+                            # EOL
+                            # ros-core:
+                            #     aliases:
+                            #         - "$release_name-ros-core"
+                            #         - "$release_name-ros-core-$os_code_name"
+                            # ros-base:
+                            #     aliases:
+                            #         - "$release_name-ros-base"
+                            #         - "$release_name-ros-base-$os_code_name"
+                            #         - "$release_name"
+                            # robot:
+                            #     aliases:
+                            #         - "$release_name-robot"
+                            #         - "$release_name-robot-$os_code_name"
+                            # perception:
+                            #     aliases:
+                            #         - "$release_name-perception"
+                            #         - "$release_name-perception-$os_code_name"
     jade:
         eol: 2017-04
         os_names:
@@ -140,23 +141,23 @@ release_names:
                             - arm32v7
                         tag_names:
                             # EOL
-                            ros-core:
-                                aliases:
-                                    - "$release_name-ros-core"
-                                    - "$release_name-ros-core-$os_code_name"
-                            ros-base:
-                                aliases:
-                                    - "$release_name-ros-base"
-                                    - "$release_name-ros-base-$os_code_name"
-                                    - "$release_name"
-                            robot:
-                                aliases:
-                                    - "$release_name-robot"
-                                    - "$release_name-robot-$os_code_name"
-                            perception:
-                                aliases:
-                                    - "$release_name-perception"
-                                    - "$release_name-perception-$os_code_name"
+                            # ros-core:
+                            #     aliases:
+                            #         - "$release_name-ros-core"
+                            #         - "$release_name-ros-core-$os_code_name"
+                            # ros-base:
+                            #     aliases:
+                            #         - "$release_name-ros-base"
+                            #         - "$release_name-ros-base-$os_code_name"
+                            #         - "$release_name"
+                            # robot:
+                            #     aliases:
+                            #         - "$release_name-robot"
+                            #         - "$release_name-robot-$os_code_name"
+                            # perception:
+                            #     aliases:
+                            #         - "$release_name-perception"
+                            #         - "$release_name-perception-$os_code_name"
     kinetic:
         eol: 2021-04
         os_names:
@@ -195,18 +196,18 @@ release_names:
                             # EOL - arm64v8
                         tag_names:
                             # EOL
-                            ros-core:
-                                aliases:
-                                    - "$release_name-ros-core-$os_code_name"
-                            ros-base:
-                                aliases:
-                                    - "$release_name-ros-base-$os_code_name"
-                            robot:
-                                aliases:
-                                    - "$release_name-robot-$os_code_name"
-                            perception:
-                                aliases:
-                                    - "$release_name-perception-$os_code_name"
+                            # ros-core:
+                            #     aliases:
+                            #         - "$release_name-ros-core-$os_code_name"
+                            # ros-base:
+                            #     aliases:
+                            #         - "$release_name-ros-base-$os_code_name"
+                            # robot:
+                            #     aliases:
+                            #         - "$release_name-robot-$os_code_name"
+                            # perception:
+                            #     aliases:
+                            #         - "$release_name-perception-$os_code_name"
     lunar:
         eol: 2019-05
         os_names:
@@ -219,41 +220,42 @@ release_names:
                             - arm32v7
                             - arm64v8
                         tag_names:
-                            ros-core:
-                                aliases:
-                                    - "$release_name-ros-core"
-                                    - "$release_name-ros-core-$os_code_name"
-                            ros-base:
-                                aliases:
-                                    - "$release_name-ros-base"
-                                    - "$release_name-ros-base-$os_code_name"
-                                    - "$release_name"
-                            robot:
-                                aliases:
-                                    - "$release_name-robot"
-                                    - "$release_name-robot-$os_code_name"
-                            perception:
-                                aliases:
-                                    - "$release_name-perception"
-                                    - "$release_name-perception-$os_code_name"
+                            # EOL
+                            # ros-core:
+                            #     aliases:
+                            #         - "$release_name-ros-core"
+                            #         - "$release_name-ros-core-$os_code_name"
+                            # ros-base:
+                            #     aliases:
+                            #         - "$release_name-ros-base"
+                            #         - "$release_name-ros-base-$os_code_name"
+                            #         - "$release_name"
+                            # robot:
+                            #     aliases:
+                            #         - "$release_name-robot"
+                            #         - "$release_name-robot-$os_code_name"
+                            # perception:
+                            #     aliases:
+                            #         - "$release_name-perception"
+                            #         - "$release_name-perception-$os_code_name"
                     zesty:
                         <<: *DEFAULT_ROS1
                         archs:
                             - amd64
                         tag_names:
                             # EOL
-                            ros-core:
-                                aliases:
-                                    - "$release_name-ros-core-$os_code_name"
-                            ros-base:
-                                aliases:
-                                    - "$release_name-ros-base-$os_code_name"
-                            robot:
-                                aliases:
-                                    - "$release_name-robot-$os_code_name"
-                            perception:
-                                aliases:
-                                    - "$release_name-perception-$os_code_name"
+                            # ros-core:
+                            #     aliases:
+                            #         - "$release_name-ros-core-$os_code_name"
+                            # ros-base:
+                            #     aliases:
+                            #         - "$release_name-ros-base-$os_code_name"
+                            # robot:
+                            #     aliases:
+                            #         - "$release_name-robot-$os_code_name"
+                            # perception:
+                            #     aliases:
+                            #         - "$release_name-perception-$os_code_name"
             debian:
                 os_code_names:
                     stretch:
@@ -262,18 +264,19 @@ release_names:
                             - amd64
                             - arm64v8
                         tag_names:
-                            ros-core:
-                                aliases:
-                                    - "$release_name-ros-core-$os_code_name"
-                            ros-base:
-                                aliases:
-                                    - "$release_name-ros-base-$os_code_name"
-                            robot:
-                                aliases:
-                                    - "$release_name-robot-$os_code_name"
-                            perception:
-                                aliases:
-                                    - "$release_name-perception-$os_code_name"
+                            # EOL
+                            # ros-core:
+                            #     aliases:
+                            #         - "$release_name-ros-core-$os_code_name"
+                            # ros-base:
+                            #     aliases:
+                            #         - "$release_name-ros-base-$os_code_name"
+                            # robot:
+                            #     aliases:
+                            #         - "$release_name-robot-$os_code_name"
+                            # perception:
+                            #     aliases:
+                            #         - "$release_name-perception-$os_code_name"
     melodic:
         eol: 2023-05
         os_names:
@@ -337,15 +340,15 @@ release_names:
                             - arm64v8
                         tag_names:
                             # EOL
-                            ros-core:
-                                aliases:
-                                    - "$release_name-ros-core"
-                                    - "$release_name-ros-core-$os_code_name"
-                            ros-base:
-                                aliases:
-                                    - "$release_name-ros-base"
-                                    - "$release_name-ros-base-$os_code_name"
-                                    - "$release_name"
+                            # ros-core:
+                            #     aliases:
+                            #         - "$release_name-ros-core"
+                            #         - "$release_name-ros-core-$os_code_name"
+                            # ros-base:
+                            #     aliases:
+                            #         - "$release_name-ros-base"
+                            #         - "$release_name-ros-base-$os_code_name"
+                            #         - "$release_name"
     bouncy:
         eol: 2019-07
         os_names:
@@ -481,10 +484,11 @@ hacks:
                 os_code_names:
                     trusty:
                         tag_names:
-                            desktop:
-                                <<: *DEFAULT_HOOKS
-                            desktop-full:
-                                <<: *DEFAULT_HOOKS
+                            # EOL
+                            # desktop:
+                            #     <<: *DEFAULT_HOOKS
+                            # desktop-full:
+                            #     <<: *DEFAULT_HOOKS
     jade:
         os_names:
             ubuntu:
@@ -492,10 +496,10 @@ hacks:
                     trusty:
                         tag_names:
                             # EOL
-                            desktop:
-                                <<: *DEFAULT_HOOKS
-                            desktop-full:
-                                <<: *DEFAULT_HOOKS
+                            # desktop:
+                            #     <<: *DEFAULT_HOOKS
+                            # desktop-full:
+                            #     <<: *DEFAULT_HOOKS
     kinetic:
         os_names:
             ubuntu:
@@ -512,10 +516,11 @@ hacks:
                 os_code_names:
                     xenial:
                         tag_names:
-                            desktop:
-                                <<: *DEFAULT_HOOKS
-                            desktop-full:
-                                <<: *DEFAULT_HOOKS
+                            # EOL
+                            # desktop:
+                            #     <<: *DEFAULT_HOOKS
+                            # desktop-full:
+                            #     <<: *DEFAULT_HOOKS
     melodic:
         os_names:
             ubuntu:
@@ -533,10 +538,10 @@ hacks:
                     xenial:
                         tag_names:
                             # EOL
-                            desktop:
-                                <<: *DEFAULT_HOOKS
-                            ros1-bridge:
-                                <<: *DEFAULT_HOOKS
+                            # desktop:
+                            #     <<: *DEFAULT_HOOKS
+                            # ros1-bridge:
+                            #     <<: *DEFAULT_HOOKS
     bouncy:
         os_names:
             ubuntu:

--- a/ros/ros
+++ b/ros/ros
@@ -86,12 +86,12 @@ Directory: ros/melodic/debian/stretch/perception
 
 Tags: bouncy-ros-core, bouncy-ros-core-bionic
 Architectures: amd64, arm64v8
-GitCommit: 460ddc4707530c2179788e2100d5c624cf2af3d7
+GitCommit: e44dfd3b21824309285eeccce66af8b8ed4c29f6
 Directory: ros/bouncy/ubuntu/bionic/ros-core
 
 Tags: bouncy-ros-base, bouncy-ros-base-bionic, bouncy
 Architectures: amd64, arm64v8
-GitCommit: 460ddc4707530c2179788e2100d5c624cf2af3d7
+GitCommit: e44dfd3b21824309285eeccce66af8b8ed4c29f6
 Directory: ros/bouncy/ubuntu/bionic/ros-base
 
 

--- a/ros/ros
+++ b/ros/ros
@@ -2,60 +2,6 @@ Maintainers: Tully Foote <tfoote+buildfarm@osrfoundation.org> (@tfoote)
 GitRepo: https://github.com/osrf/docker_images.git
 
 ################################################################################
-# Release: indigo
-
-########################################
-# Distro: ubuntu:trusty
-
-Tags: indigo-ros-core, indigo-ros-core-trusty
-Architectures: amd64, arm32v7
-GitCommit: 7b6d0959808500b3531e8a5448756fc95dbb2d12
-Directory: ros/indigo/ubuntu/trusty/ros-core
-
-Tags: indigo-ros-base, indigo-ros-base-trusty, indigo
-Architectures: amd64, arm32v7
-GitCommit: 7b6d0959808500b3531e8a5448756fc95dbb2d12
-Directory: ros/indigo/ubuntu/trusty/ros-base
-
-Tags: indigo-robot, indigo-robot-trusty
-Architectures: amd64, arm32v7
-GitCommit: 7b6d0959808500b3531e8a5448756fc95dbb2d12
-Directory: ros/indigo/ubuntu/trusty/robot
-
-Tags: indigo-perception, indigo-perception-trusty
-Architectures: amd64, arm32v7
-GitCommit: 7b6d0959808500b3531e8a5448756fc95dbb2d12
-Directory: ros/indigo/ubuntu/trusty/perception
-
-
-################################################################################
-# Release: jade
-
-########################################
-# Distro: ubuntu:trusty
-
-Tags: jade-ros-core, jade-ros-core-trusty
-Architectures: amd64, arm32v7
-GitCommit: 7b6d0959808500b3531e8a5448756fc95dbb2d12
-Directory: ros/jade/ubuntu/trusty/ros-core
-
-Tags: jade-ros-base, jade-ros-base-trusty, jade
-Architectures: amd64, arm32v7
-GitCommit: 7b6d0959808500b3531e8a5448756fc95dbb2d12
-Directory: ros/jade/ubuntu/trusty/ros-base
-
-Tags: jade-robot, jade-robot-trusty
-Architectures: amd64, arm32v7
-GitCommit: 7b6d0959808500b3531e8a5448756fc95dbb2d12
-Directory: ros/jade/ubuntu/trusty/robot
-
-Tags: jade-perception, jade-perception-trusty
-Architectures: amd64, arm32v7
-GitCommit: 7b6d0959808500b3531e8a5448756fc95dbb2d12
-Directory: ros/jade/ubuntu/trusty/perception
-
-
-################################################################################
 # Release: kinetic
 
 ########################################
@@ -80,102 +26,6 @@ Tags: kinetic-perception, kinetic-perception-xenial
 Architectures: amd64, arm32v7, arm64v8
 GitCommit: 460ddc4707530c2179788e2100d5c624cf2af3d7
 Directory: ros/kinetic/ubuntu/xenial/perception
-
-########################################
-# Distro: debian:jessie
-
-Tags: kinetic-ros-core-jessie
-Architectures: amd64
-GitCommit: 7b6d0959808500b3531e8a5448756fc95dbb2d12
-Directory: ros/kinetic/debian/jessie/ros-core
-
-Tags: kinetic-ros-base-jessie
-Architectures: amd64
-GitCommit: 7b6d0959808500b3531e8a5448756fc95dbb2d12
-Directory: ros/kinetic/debian/jessie/ros-base
-
-Tags: kinetic-robot-jessie
-Architectures: amd64
-GitCommit: 7b6d0959808500b3531e8a5448756fc95dbb2d12
-Directory: ros/kinetic/debian/jessie/robot
-
-Tags: kinetic-perception-jessie
-Architectures: amd64
-GitCommit: 7b6d0959808500b3531e8a5448756fc95dbb2d12
-Directory: ros/kinetic/debian/jessie/perception
-
-
-################################################################################
-# Release: lunar
-
-########################################
-# Distro: ubuntu:xenial
-
-Tags: lunar-ros-core, lunar-ros-core-xenial
-Architectures: amd64, arm32v7, arm64v8
-GitCommit: 7b6d0959808500b3531e8a5448756fc95dbb2d12
-Directory: ros/lunar/ubuntu/xenial/ros-core
-
-Tags: lunar-ros-base, lunar-ros-base-xenial, lunar
-Architectures: amd64, arm32v7, arm64v8
-GitCommit: 7b6d0959808500b3531e8a5448756fc95dbb2d12
-Directory: ros/lunar/ubuntu/xenial/ros-base
-
-Tags: lunar-robot, lunar-robot-xenial
-Architectures: amd64, arm32v7, arm64v8
-GitCommit: 7b6d0959808500b3531e8a5448756fc95dbb2d12
-Directory: ros/lunar/ubuntu/xenial/robot
-
-Tags: lunar-perception, lunar-perception-xenial
-Architectures: amd64, arm32v7, arm64v8
-GitCommit: 7b6d0959808500b3531e8a5448756fc95dbb2d12
-Directory: ros/lunar/ubuntu/xenial/perception
-
-########################################
-# Distro: ubuntu:zesty
-
-Tags: lunar-ros-core-zesty
-Architectures: amd64
-GitCommit: 7b6d0959808500b3531e8a5448756fc95dbb2d12
-Directory: ros/lunar/ubuntu/zesty/ros-core
-
-Tags: lunar-ros-base-zesty
-Architectures: amd64
-GitCommit: 7b6d0959808500b3531e8a5448756fc95dbb2d12
-Directory: ros/lunar/ubuntu/zesty/ros-base
-
-Tags: lunar-robot-zesty
-Architectures: amd64
-GitCommit: 7b6d0959808500b3531e8a5448756fc95dbb2d12
-Directory: ros/lunar/ubuntu/zesty/robot
-
-Tags: lunar-perception-zesty
-Architectures: amd64
-GitCommit: 7b6d0959808500b3531e8a5448756fc95dbb2d12
-Directory: ros/lunar/ubuntu/zesty/perception
-
-########################################
-# Distro: debian:stretch
-
-Tags: lunar-ros-core-stretch
-Architectures: amd64, arm64v8
-GitCommit: 7b6d0959808500b3531e8a5448756fc95dbb2d12
-Directory: ros/lunar/debian/stretch/ros-core
-
-Tags: lunar-ros-base-stretch
-Architectures: amd64, arm64v8
-GitCommit: 7b6d0959808500b3531e8a5448756fc95dbb2d12
-Directory: ros/lunar/debian/stretch/ros-base
-
-Tags: lunar-robot-stretch
-Architectures: amd64, arm64v8
-GitCommit: 7b6d0959808500b3531e8a5448756fc95dbb2d12
-Directory: ros/lunar/debian/stretch/robot
-
-Tags: lunar-perception-stretch
-Architectures: amd64, arm64v8
-GitCommit: 7b6d0959808500b3531e8a5448756fc95dbb2d12
-Directory: ros/lunar/debian/stretch/perception
 
 
 ################################################################################
@@ -229,23 +79,6 @@ Directory: ros/melodic/debian/stretch/perception
 
 
 ################################################################################
-# Release: ardent
-
-########################################
-# Distro: ubuntu:xenial
-
-Tags: ardent-ros-core, ardent-ros-core-xenial
-Architectures: amd64, arm64v8
-GitCommit: 7b6d0959808500b3531e8a5448756fc95dbb2d12
-Directory: ros/ardent/ubuntu/xenial/ros-core
-
-Tags: ardent-ros-base, ardent-ros-base-xenial, ardent
-Architectures: amd64, arm64v8
-GitCommit: 7b6d0959808500b3531e8a5448756fc95dbb2d12
-Directory: ros/ardent/ubuntu/xenial/ros-base
-
-
-################################################################################
 # Release: bouncy
 
 ########################################
@@ -294,3 +127,4 @@ Tags: dashing-ros-base, dashing-ros-base-bionic, dashing
 Architectures: amd64, arm64v8
 GitCommit: 460ddc4707530c2179788e2100d5c624cf2af3d7
 Directory: ros/dashing/ubuntu/bionic/ros-base
+


### PR DESCRIPTION
Replaces https://github.com/osrf/docker_images/pull/268/files
Fixes https://github.com/osrf/docker_images/issues/282

Should wait for all final images to be rebuilt on dockerhub before submitting upstream.

@nuclearsandwich Is Bouncy officially EOL?