### PR TITLE
dashing patch 2

### DIFF
--- a/ros/dashing/ubuntu/bionic/ros1-bridge/Dockerfile
+++ b/ros/dashing/ubuntu/bionic/ros1-bridge/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update && apt-get install -y \
 
 # install ros2 packages
 RUN apt-get update && apt-get install -y \
-    ros-dashing-ros1-bridge=0.7.2-4* \
+    ros-dashing-ros1-bridge=0.7.3-1* \
     && rm -rf /var/lib/apt/lists/*
 
 # setup entrypoint


### PR DESCRIPTION
Did not update the docker library as the `ros1_bridge` image is not hosted on the official library

Signed-off-by: Mikael Arguedas <mikael.arguedas@gmail.com>