### PR TITLE
Remove bouncy from manifest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ env:
   # ros2
   - HUB_REPO=ros   HUB_RELEASE=dashing  HUB_OS_NAME=ubuntu HUB_OS_CODE_NAME=bionic
   - HUB_REPO=ros   HUB_RELEASE=crystal  HUB_OS_NAME=ubuntu HUB_OS_CODE_NAME=bionic
-  - HUB_REPO=ros   HUB_RELEASE=bouncy   HUB_OS_NAME=ubuntu HUB_OS_CODE_NAME=bionic
   # ros
   - HUB_REPO=ros    HUB_RELEASE=melodic HUB_OS_NAME=ubuntu HUB_OS_CODE_NAME=bionic
   - HUB_REPO=ros    HUB_RELEASE=melodic HUB_OS_NAME=debian HUB_OS_CODE_NAME=stretch

--- a/ros/manifest.yaml
+++ b/ros/manifest.yaml
@@ -361,15 +361,16 @@ release_names:
                             - amd64
                             - arm64v8
                         tag_names:
-                            ros-core:
-                                aliases:
-                                    - "$release_name-ros-core"
-                                    - "$release_name-ros-core-$os_code_name"
-                            ros-base:
-                                aliases:
-                                    - "$release_name-ros-base"
-                                    - "$release_name-ros-base-$os_code_name"
-                                    - "$release_name"
+                            # EOL
+                            # ros-core:
+                            #     aliases:
+                            #         - "$release_name-ros-core"
+                            #         - "$release_name-ros-core-$os_code_name"
+                            # ros-base:
+                            #     aliases:
+                            #         - "$release_name-ros-base"
+                            #         - "$release_name-ros-base-$os_code_name"
+                            #         - "$release_name"
     crystal:
         eol: 2019-12
         os_names:
@@ -548,10 +549,11 @@ hacks:
                 os_code_names:
                     bionic:
                         tag_names:
-                            desktop:
-                                <<: *DEFAULT_HOOKS
-                            ros1-bridge:
-                                <<: *DEFAULT_HOOKS
+                            # EOL
+                            # desktop:
+                            #     <<: *DEFAULT_HOOKS
+                            # ros1-bridge:
+                            #     <<: *DEFAULT_HOOKS
     crystal:
         os_names:
             ubuntu:

--- a/ros/ros
+++ b/ros/ros
@@ -79,23 +79,6 @@ Directory: ros/melodic/debian/stretch/perception
 
 
 ################################################################################
-# Release: bouncy
-
-########################################
-# Distro: ubuntu:bionic
-
-Tags: bouncy-ros-core, bouncy-ros-core-bionic
-Architectures: amd64, arm64v8
-GitCommit: e44dfd3b21824309285eeccce66af8b8ed4c29f6
-Directory: ros/bouncy/ubuntu/bionic/ros-core
-
-Tags: bouncy-ros-base, bouncy-ros-base-bionic, bouncy
-Architectures: amd64, arm64v8
-GitCommit: e44dfd3b21824309285eeccce66af8b8ed4c29f6
-Directory: ros/bouncy/ubuntu/bionic/ros-base
-
-
-################################################################################
 # Release: crystal
 
 ########################################
@@ -120,11 +103,11 @@ Directory: ros/crystal/ubuntu/bionic/ros-base
 
 Tags: dashing-ros-core, dashing-ros-core-bionic
 Architectures: amd64, arm64v8
-GitCommit: 460ddc4707530c2179788e2100d5c624cf2af3d7
+GitCommit: 30a5aa5b57ff1df58515bebdb44ac2c8e553df28
 Directory: ros/dashing/ubuntu/bionic/ros-core
 
 Tags: dashing-ros-base, dashing-ros-base-bionic, dashing
 Architectures: amd64, arm64v8
-GitCommit: 460ddc4707530c2179788e2100d5c624cf2af3d7
+GitCommit: 30a5aa5b57ff1df58515bebdb44ac2c8e553df28
 Directory: ros/dashing/ubuntu/bionic/ros-base
 


### PR DESCRIPTION
Bouncy imagesrbuilt successfully targetting the snapshots repositories. They can now be removed from the manifest