### PR TITLE
Limit use of release packages on nightly

### DIFF
--- a/ros2/nightly/images.yaml.em
+++ b/ros2/nightly/images.yaml.em
@@ -31,4 +31,5 @@ images:
             skip_keys:
                 - libopensplice69
                 - rti-connext-dds-5.3.1
+            rosdistro_index_url: https://raw.githubusercontent.com/osrf/docker_images/master/ros2/nightly/nightly/index-v4.yaml
         ros2_binary_url: https://ci.ros2.org/view/packaging/job/packaging_linux/lastSuccessfulBuild/artifact/ws/ros2-package-linux-x86_64.tar.bz2

--- a/ros2/nightly/nightly/Dockerfile
+++ b/ros2/nightly/nightly/Dockerfile
@@ -34,10 +34,6 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 ENV LANG C.UTF-8
 ENV LC_ALL C.UTF-8
 
-# bootstrap rosdep
-RUN rosdep init \
-    && rosdep update
-
 # install python packages
 RUN pip3 install -U \
     argcomplete \
@@ -69,6 +65,10 @@ RUN wget -q $ROS2_BINARY_URL -O - | \
 RUN apt-get update && apt-get install -q -y \
     ros-$ROS_DISTRO-ros-workspace \
     && rm -rf /var/lib/apt/lists/*
+
+# bootstrap rosdep
+ENV ROSDISTRO_INDEX_URL https://raw.githubusercontent.com/osrf/docker_images/master/ros2/nightly/nightly/index-v4.yaml
+RUN rosdep init
 
 # add custom rosdep rule files
 COPY prereqs.yaml /etc/ros/rosdep/

--- a/ros2/nightly/nightly/index-v4.yaml
+++ b/ros2/nightly/nightly/index-v4.yaml
@@ -1,0 +1,7 @@
+%YAML 1.1
+# ROS index file
+# see REP 153: http://ros.org/reps/rep-0153.html
+---
+distributions:
+type: index
+version: 4


### PR DESCRIPTION
By marking all release packages as `hold`
Context: https://github.com/osrf/docker_images/issues/304#issuecomment-520029364