### PR TITLE
Ros2 nightly eloquent

### DIFF
--- a/ros2/nightly/Makefile
+++ b/ros2/nightly/Makefile
@@ -10,16 +10,16 @@ help:
 	@echo ""
 
 build:
-	@docker build --tag=ros2:nightly             nightly/.
-	@docker build --tag=ros2:nightly-rmw         nightly-rmw/.
-	@docker build --tag=ros2:nightly-rmw-nonfree nightly-rmw-nonfree/.
+	@docker build --tag=osrf/ros2:nightly             nightly/.
+	@docker build --tag=osrf/ros2:nightly-rmw         nightly-rmw/.
+	@docker build --tag=osrf/ros2:nightly-rmw-nonfree nightly-rmw-nonfree/.
 
 pull:
-	@docker pull ros2:nightly
-	@docker pull ros2:nightly-rmw
-	@docker pull ros2:nightly-rmw-nonfree
+	@docker pull osrf/ros2:nightly
+	@docker pull osrf/ros2:nightly-rmw
+	@docker pull osrf/ros2:nightly-rmw-nonfree
 
 clean:
-	@docker rmi -f ros2:nightly
-	@docker rmi -f ros2:nightly-rmw
-	@docker rmi -f ros2:nightly-rmw-nonfree
+	@docker rmi -f osrf/ros2:nightly
+	@docker rmi -f osrf/ros2:nightly-rmw
+	@docker rmi -f osrf/ros2:nightly-rmw-nonfree

--- a/ros2/nightly/nightly/Dockerfile
+++ b/ros2/nightly/nightly/Dockerfile
@@ -55,7 +55,7 @@ RUN pip3 install -U \
 RUN pip3 freeze | grep pytest \
     && python3 -m pytest --version
 # install ros2 packages
-ENV ROS_DISTRO dashing
+ENV ROS_DISTRO eloquent
 RUN mkdir -p /opt/ros/$ROS_DISTRO
 ARG ROS2_BINARY_URL=https://ci.ros2.org/view/packaging/job/packaging_linux/lastSuccessfulBuild/artifact/ws/ros2-package-linux-x86_64.tar.bz2
 RUN wget -q $ROS2_BINARY_URL -O - | \


### PR DESCRIPTION
Update distro env to eloquent.
Installing ros-dashing-ros-workspace from testing is broken as it points to `/opt/ros/eloquent`.
Installing ros-eloquent-ros-workspace resolves this.