### PR TITLE
Use cron jobs from Circleci to trigger Docker Hub builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,8 @@ commands:
             curl --request POST \
               --header "Content-Type: application/json" \
               --data << parameters.data >> \
-              --url << parameters.url >>
+              --url << parameters.url >> \
+            > /dev/null
           when: always
 
 executors:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ commands:
               --header "Content-Type: application/json" \
               --data << parameters.data >> \
               --url << parameters.url >> \
-            > /dev/null
+            > /dev/null && true
           when: always
 
 executors:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,12 +22,12 @@ references:
     trigger_docker_hub:
       url: $DOCKER_TRIGGER_URL_ROS2
       data: >-
-        `{"docker_tag": devel}`
+        '{"docker_tag": devel}'
   trigger_osrf_ros2_nightly: &trigger_osrf_ros2_nightly
     trigger_docker_hub:
       url: $DOCKER_TRIGGER_URL_ROS2
       data: >-
-        `{"docker_tag": nightly}`
+        '{"docker_tag": nightly}'
 
 commands:
   <<: *common_commands

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,41 +1,34 @@
 version: 2.1
 
 references:
-  common_commands: &common_commands
-    trigger_docker_hub:
-      description: "Trigger Docker Hub"
-      parameters:
-        data:
-          type: string
-        url:
-          type: string
-      steps:
-        - run:
-            name: Trigger Docker Hub
-            command: |
-              curl --request POST \
-                --header "Content-Type: application/json" \
-                --data << parameters.data >> \
-                --url << parameters.url >>
-            when: always
-  trigger_osrf_ros2_devel: &trigger_osrf_ros2_devel
-    trigger_docker_hub:
-      url: $DOCKER_TRIGGER_URL_ROS2
-      data: >-
-        '{"docker_tag": devel}'
   trigger_osrf_ros2_nightly: &trigger_osrf_ros2_nightly
     trigger_docker_hub:
-      url: $DOCKER_TRIGGER_URL_ROS2
+      url: ${DOCKER_TRIGGER_URL_ROS2}
       data: >-
-        '{"docker_tag": nightly}'
+        '{"docker_tag": "nightly"}'
+  trigger_osrf_ros2_devel: &trigger_osrf_ros2_devel
+    trigger_docker_hub:
+      url: ${DOCKER_TRIGGER_URL_ROS2}
+      data: >-
+        '{"docker_tag": "devel"}'
 
 commands:
-  <<: *common_commands
-  trigger_osrf_ros2:
-    description: "Trigger osrf/ros2"
+  trigger_docker_hub:
+    description: "Trigger Docker Hub"
+    parameters:
+      data:
+        type: string
+      url:
+        type: string
     steps:
-      - *trigger_osrf_ros2_devel
-      - *trigger_osrf_ros2_nightly
+      - run:
+          name: Trigger Docker Hub
+          command: |
+            curl --request POST \
+              --header "Content-Type: application/json" \
+              --data << parameters.data >> \
+              --url << parameters.url >>
+          when: always
 
 executors:
   docker_exec:
@@ -43,10 +36,19 @@ executors:
       - image: circleci/python
 
 jobs:
-  osrf_ros2: &osrf_ros2
+  osrf_ros2:
     executor: docker_exec
     steps:
-      - trigger_osrf_ros2
+      - *trigger_osrf_ros2_nightly
+      - *trigger_osrf_ros2_devel
+  osrf_ros2_nightly:
+    executor: docker_exec
+    steps:
+      - *trigger_osrf_ros2_nightly
+  osrf_ros2_devel:
+    executor: docker_exec
+    steps:
+      - *trigger_osrf_ros2_devel
 
 workflows:
   version: 2
@@ -59,11 +61,22 @@ workflows:
               only: master
   nightly:
     jobs:
-      - osrf_ros2:
+      - osrf_ros2_nightly:
           context: dockerhub
     triggers:
       - schedule:
           cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - master
+  daily:
+    jobs:
+      - osrf_ros2_devel:
+          context: dockerhub
+    triggers:
+      - schedule:
+          cron: "0 12 * * *"
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,12 +21,12 @@ references:
   trigger_osrf_ros2_devel: &trigger_osrf_ros2_devel
     trigger_docker_hub:
       url: $DOCKER_TRIGGER_URL_ROS2
-      data: |
+      data: >-
         `{"docker_tag": devel}`
   trigger_osrf_ros2_nightly: &trigger_osrf_ros2_nightly
     trigger_docker_hub:
       url: $DOCKER_TRIGGER_URL_ROS2
-      data: |
+      data: >-
         `{"docker_tag": nightly}`
 
 commands:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ references:
             name: Trigger Docker Hub
             command: |
               curl --request POST \
-                --header "Content-Type:application/json" \
+                --header "Content-Type: application/json" \
                 --data << parameters.data >> \
                 --url << parameters.url >>
             when: always

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,63 @@
+version: 2.1
+
+references:
+  common_commands: &common_commands
+    trigger_docker_hub:
+      description: "Trigger Docker Hub"
+      parameters:
+        data:
+          type: string
+        url:
+          type: string
+      steps:
+        - run:
+            name: Trigger Docker Hub
+            command: |
+              curl --request POST \
+                --header "Content-Type:application/json" \
+                --data << parameters.data >> \
+                --url << parameters.url >>
+            when: always
+  trigger_osrf_ros2_devel: &trigger_osrf_ros2_devel
+    trigger_docker_hub:
+      url: $DOCKER_TRIGGER_URL_ROS2
+      data: |
+        `{"docker_tag": devel}`
+  trigger_osrf_ros2_nightly: &trigger_osrf_ros2_nightly
+    trigger_docker_hub:
+      url: $DOCKER_TRIGGER_URL_ROS2
+      data: |
+        `{"docker_tag": nightly}`
+
+commands:
+  <<: *common_commands
+  trigger_osrf_ros2:
+    description: "Trigger osrf/ros2"
+    steps:
+      - *trigger_osrf_ros2_devel
+      - *trigger_osrf_ros2_nightly
+
+executors:
+  docker_exec:
+    docker:
+      - image: ubuntu
+
+jobs:
+  osrf_ros2: &osrf_ros2
+    executor: docker_exec
+    steps:
+      - trigger_osrf_ros2
+
+workflows:
+  version: 2
+  nightly:
+    jobs:
+      - osrf_ros2:
+          context: dockerhub
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,6 +50,13 @@ jobs:
 
 workflows:
   version: 2
+  deploy:
+    jobs:
+      - osrf_ros2:
+          context: dockerhub
+          filters:
+            branches:
+              only: master
   nightly:
     jobs:
       - osrf_ros2:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ commands:
 executors:
   docker_exec:
     docker:
-      - image: ubuntu
+      - image: circleci/python
 
 jobs:
   osrf_ros2: &osrf_ros2


### PR DESCRIPTION
It seems like the server hosting the cron jobs for triggering Docker Hub builds keeps going AWOL.
I'd like to add some reliability and transparency to this task so we can keep tabs on it here in the repo.

This simply add a CircleCI config to trigger the osrf/ros2 night tags every night,
and the devel tag every day, as to spread out the build queue on docker hub.
It also triggers to build both if any changes are made to the repo.

![image](https://user-images.githubusercontent.com/2293573/63739770-5cfd9f00-c843-11e9-8faf-a08c08165b77.png)
