### PR TITLE
Add rosdep update options for EOLs

### DIFF
--- a/ros/indigo/ubuntu/trusty/ros-core/Dockerfile
+++ b/ros/indigo/ubuntu/trusty/ros-core/Dockerfile
@@ -27,7 +27,7 @@ ENV LC_ALL C.UTF-8
 
 # bootstrap rosdep
 RUN rosdep init \
-    && rosdep update
+    && rosdep update --include-eol-distros
 
 # install ros packages
 ENV ROS_DISTRO indigo

--- a/ros/jade/ubuntu/trusty/ros-core/Dockerfile
+++ b/ros/jade/ubuntu/trusty/ros-core/Dockerfile
@@ -27,7 +27,7 @@ ENV LC_ALL C.UTF-8
 
 # bootstrap rosdep
 RUN rosdep init \
-    && rosdep update
+    && rosdep update --include-eol-distros
 
 # install ros packages
 ENV ROS_DISTRO jade


### PR DESCRIPTION
rosdep update command require additional option "--include-eol-distros" for eol packages like trusy.
This option was merged by this pull request (https://github.com/ros-infrastructure/rosdep/commit/ae0e89aa7feea3e73c9c3c94ff0f08522e6782b8) .

Please feel free to comment what to improve, I may have done something wrong as this is my first pull request.