### PR TITLE
Add arm32 docker builds for dashing

### DIFF
--- a/ros/manifest.yaml
+++ b/ros/manifest.yaml
@@ -403,6 +403,7 @@ release_names:
                         archs:
                             - amd64
                             - arm64v8
+                            - arm32v7
                         tag_names:
                             ros-core:
                                 aliases:


### PR DESCRIPTION
Would be useful to generate arm32 docker containers like we do for ROS1 distros. 

Note - I really don't know if this is the only change required to enable arm32 dashing docker builds. If (significant) additional work is required I'll just open an issue instead and plan for it properly.