### PR TITLE
rever ROS_PACKAGE_PATH hack allowing rosdep to find the ros2 packages

### DIFF
--- a/ros2/nightly/nightly/Dockerfile
+++ b/ros2/nightly/nightly/Dockerfile
@@ -97,10 +97,6 @@ RUN . /opt/ros/$ROS_DISTRO/setup.sh \
       rti-connext-dds-5.3.1" \
     && rm -rf /var/lib/apt/lists/*
 
-# FIXME Remove this once rosdep detects ROS 2 packages https://github.com/ros-infrastructure/rosdep/issues/660
-# ignore installed rosdep keys
-ENV ROS_PACKAGE_PATH /opt/ros/$ROS_DISTRO/share
-
 # FIXME Remove this once ament_export_interfaces respects COLCON_CURRENT_PREFIX https://github.com/ament/ament_cmake/issues/173
 #Workaround hard coded paths in nightly tarball setup scripts
 ARG UPSTREAM_CI_WS=/home/jenkins-agent/workspace/packaging_linux/ws


### PR DESCRIPTION
Now that https://github.com/ros-infrastructure/rosdep/pull/699 has been merged and released

Signed-off-by: Mikael Arguedas <mikael.arguedas@gmail.com>