### PR TITLE
Revert "rever ROS_PACKAGE_PATH hack allowing rosdep to find the ros2 packages"

### DIFF
--- a/ros2/nightly/nightly/Dockerfile
+++ b/ros2/nightly/nightly/Dockerfile
@@ -97,6 +97,10 @@ RUN . /opt/ros/$ROS_DISTRO/setup.sh \
       rti-connext-dds-5.3.1" \
     && rm -rf /var/lib/apt/lists/*
 
+# FIXME Remove this once rosdep detects ROS 2 packages https://github.com/ros-infrastructure/rosdep/issues/660
+# ignore installed rosdep keys
+ENV ROS_PACKAGE_PATH /opt/ros/$ROS_DISTRO/share
+
 # FIXME Remove this once ament_export_interfaces respects COLCON_CURRENT_PREFIX https://github.com/ament/ament_cmake/issues/173
 #Workaround hard coded paths in nightly tarball setup scripts
 ARG UPSTREAM_CI_WS=/home/jenkins-agent/workspace/packaging_linux/ws


### PR DESCRIPTION
Reverts osrf/docker_images#326

Reintroduces the RPP hack because the fix for https://github.com/ros-infrastructure/rosdep/issues/660 is incomplete leading consumers of the image to break.

Current rosdep behavior:
Packages in the ament_prefix_path that do install a package.xml but dont register themselves in the ament index fail to be detected