### PR TITLE
Add dependencies for ros1-bridge demos

### DIFF
--- a/ros/.config/ros2/images.yaml.em
+++ b/ros/.config/ros2/images.yaml.em
@@ -38,5 +38,9 @@ images:
             - docker_templates
         ros2_packages:
             - ros1-bridge
+            - demo-nodes-cpp
+            - demo-nodes-py
         ros_packages:
             - ros-comm
+            - roscpp-tutorials
+            - rospy-tutorials

--- a/ros/crystal/ubuntu/bionic/images.yaml.em
+++ b/ros/crystal/ubuntu/bionic/images.yaml.em
@@ -38,5 +38,9 @@ images:
             - docker_templates
         ros2_packages:
             - ros1-bridge
+            - demo-nodes-cpp
+            - demo-nodes-py
         ros_packages:
             - ros-comm
+            - roscpp-tutorials
+            - rospy-tutorials

--- a/ros/crystal/ubuntu/bionic/ros1-bridge/Dockerfile
+++ b/ros/crystal/ubuntu/bionic/ros1-bridge/Dockerfile
@@ -13,11 +13,15 @@ ENV ROS2_DISTRO crystal
 # install ros packages
 RUN apt-get update && apt-get install -y \
     ros-melodic-ros-comm=1.14.3-0* \
+    ros-melodic-roscpp-tutorials=0.9.1-0* \
+    ros-melodic-rospy-tutorials=0.9.1-0* \
     && rm -rf /var/lib/apt/lists/*
 
 # install ros2 packages
 RUN apt-get update && apt-get install -y \
     ros-crystal-ros1-bridge=0.6.2-2* \
+    ros-crystal-demo-nodes-cpp=0.6.2-0* \
+    ros-crystal-demo-nodes-py=0.6.2-0* \
     && rm -rf /var/lib/apt/lists/*
 
 # setup entrypoint

--- a/ros/dashing/ubuntu/bionic/images.yaml.em
+++ b/ros/dashing/ubuntu/bionic/images.yaml.em
@@ -38,5 +38,9 @@ images:
             - docker_templates
         ros2_packages:
             - ros1-bridge
+            - demo-nodes-cpp
+            - demo-nodes-py
         ros_packages:
             - ros-comm
+            - roscpp-tutorials
+            - rospy-tutorials

--- a/ros/dashing/ubuntu/bionic/ros1-bridge/Dockerfile
+++ b/ros/dashing/ubuntu/bionic/ros1-bridge/Dockerfile
@@ -13,11 +13,15 @@ ENV ROS2_DISTRO dashing
 # install ros packages
 RUN apt-get update && apt-get install -y \
     ros-melodic-ros-comm=1.14.3-0* \
+    ros-melodic-roscpp-tutorials=0.9.1-0* \
+    ros-melodic-rospy-tutorials=0.9.1-0* \
     && rm -rf /var/lib/apt/lists/*
 
 # install ros2 packages
 RUN apt-get update && apt-get install -y \
     ros-dashing-ros1-bridge=0.7.3-1* \
+    ros-dashing-demo-nodes-cpp=0.7.9-1* \
+    ros-dashing-demo-nodes-py=0.7.9-1* \
     && rm -rf /var/lib/apt/lists/*
 
 # setup entrypoint

--- a/ros/eloquent/ubuntu/bionic/images.yaml.em
+++ b/ros/eloquent/ubuntu/bionic/images.yaml.em
@@ -38,5 +38,9 @@ images:
             - docker_templates
         ros2_packages:
             - ros1-bridge
+            - demo-nodes-cpp
+            - demo-nodes-py
         ros_packages:
             - ros-comm
+            - roscpp-tutorials
+            - rospy-tutorials

--- a/ros/eloquent/ubuntu/bionic/ros1-bridge/Dockerfile
+++ b/ros/eloquent/ubuntu/bionic/ros1-bridge/Dockerfile
@@ -13,11 +13,15 @@ ENV ROS2_DISTRO eloquent
 # install ros packages
 RUN apt-get update && apt-get install -y \
     ros-melodic-ros-comm=1.14.3-0* \
+    ros-melodic-roscpp-tutorials=0.9.1-0* \
+    ros-melodic-rospy-tutorials=0.9.1-0* \
     && rm -rf /var/lib/apt/lists/*
 
 # install ros2 packages
 RUN apt-get update && apt-get install -y \
     ros-eloquent-ros1-bridge=0.8.1-3* \
+    ros-eloquent-demo-nodes-cpp=0.8.4-1* \
+    ros-eloquent-demo-nodes-py=0.8.4-1* \
     && rm -rf /var/lib/apt/lists/*
 
 # setup entrypoint


### PR DESCRIPTION
This is a follow up of https://github.com/ros2/ros1_bridge/issues/228

The bride images should provide the packages providing talker and listener in their ROS 1 and 2 form for basic testing / tutorial to be possible out of the box