### PR TITLE
Crystal snapshots

### DIFF
--- a/ros/crystal/ubuntu/bionic/ros-core/Dockerfile
+++ b/ros/crystal/ubuntu/bionic/ros-core/Dockerfile
@@ -15,10 +15,10 @@ RUN apt-get update && apt-get install -q -y \
     && rm -rf /var/lib/apt/lists/*
 
 # setup keys
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 4B63CF8FDE49746E98FA01DDAD19BAB3CBF125EA
 
 # setup sources.list
-RUN echo "deb http://packages.ros.org/ros2/ubuntu bionic main" > /etc/apt/sources.list.d/ros2-latest.list
+RUN echo "deb http://snapshots.ros.org/crystal/final/ubuntu bionic main" > /etc/apt/sources.list.d/ros2-snapshots.list
 
 # install bootstrap tools
 RUN apt-get update && apt-get install --no-install-recommends -y \
@@ -35,7 +35,7 @@ ENV LC_ALL C.UTF-8
 
 # bootstrap rosdep
 RUN rosdep init \
-    && rosdep update
+    && rosdep update --include-eol-distros
 
 # setup colcon mixin and metadata
 RUN colcon mixin add default \

--- a/ros/ros
+++ b/ros/ros
@@ -86,12 +86,12 @@ Directory: ros/melodic/debian/stretch/perception
 
 Tags: crystal-ros-core, crystal-ros-core-bionic
 Architectures: amd64, arm64v8
-GitCommit: 0fee1e693074e55b383d71a294323cb8b3145904
+GitCommit: 557e1a220d460b83402b7ed44b5cfcfb7e39524e
 Directory: ros/crystal/ubuntu/bionic/ros-core
 
 Tags: crystal-ros-base, crystal-ros-base-bionic, crystal
 Architectures: amd64, arm64v8
-GitCommit: 0fee1e693074e55b383d71a294323cb8b3145904
+GitCommit: 557e1a220d460b83402b7ed44b5cfcfb7e39524e
 Directory: ros/crystal/ubuntu/bionic/ros-base
 
 


### PR DESCRIPTION
Based on https://github.com/osrf/docker_templates/pull/77

Crystal is now EOL, this make the image use the snapshots repositories for the last build of the image on dockerhub before retiring them