### PR TITLE
remove COLCON_IGNORE at root of AMENT_PREFIX_PATH

### DIFF
--- a/ros2/nightly/nightly/Dockerfile
+++ b/ros2/nightly/nightly/Dockerfile
@@ -62,7 +62,8 @@ ENV ROS_DISTRO foxy
 RUN mkdir -p /opt/ros/$ROS_DISTRO
 ARG ROS2_BINARY_URL=https://ci.ros2.org/view/packaging/job/packaging_linux/lastSuccessfulBuild/artifact/ws/ros2-package-linux-x86_64.tar.bz2
 RUN wget -q $ROS2_BINARY_URL -O - | \
-    tar -xj --strip-components=1 -C /opt/ros/$ROS_DISTRO
+    tar -xj --strip-components=1 -C /opt/ros/$ROS_DISTRO \
+    && rm -f /opt/ros/$ROS_DISTRO/COLCON_IGNORE
 
 # Overwrite setup scripts with ones that point to /opt/ros/$ROS_DISTRO
 RUN mkdir -p /tmp/dir/build \


### PR DESCRIPTION
This way if a consumer points the `ROS_PACKAGE_PATH` to `/opt/ros/$ROS_DISTRO` catkin_pkg can find packages.

pros: 
- brings us closer to the official docker images that don't have colcon files in their install space
- supports applications like industrial_ci that currently set the ROS_PACKAGE_PATH themselves

con:
- (more feature than a bug) crawling can happen if the `ROS_PACKAGE_PATH` is overriden, just like anywhere else on the system

Relates to https://github.com/ros-industrial/industrial_ci/pull/454#discussion_r360396351