### PR TITLE
CRON job to trigger daily build of ros2 images

### DIFF
--- a/.github/workflows/cron.yaml
+++ b/.github/workflows/cron.yaml
@@ -15,7 +15,7 @@ jobs:
     - uses: actions/checkout@v1
     - name: Call devel webhook
       run: |
-        curl -H "Content-Type: application/json" --data '{"docker_tag": "${{env.dockerTag}}"}'  -X POST ${{ secrets.DOCKER_POST_PUSH_TRIGGER }}
+        curl -H "Content-Type: application/json" --data '{"docker_tag": "${{env.dockerTag}}"}'  -X POST ${{ secrets.DOCKER_ROS2_POST_PUSH_TRIGGER }}
   nightly_build:
     name: Trigger nightly image
     env:
@@ -25,4 +25,4 @@ jobs:
     - uses: actions/checkout@v1
     - name: Call nightly webhook
       run: |
-        curl -H "Content-Type: application/json" --data '{"docker_tag": "${{env.dockerTag}}"}'  -X POST ${{ secrets.DOCKER_POST_PUSH_TRIGGER }}
+        curl -H "Content-Type: application/json" --data '{"docker_tag": "${{env.dockerTag}}"}'  -X POST ${{ secrets.DOCKER_ROS2_POST_PUSH_TRIGGER }}

--- a/.github/workflows/cron.yaml
+++ b/.github/workflows/cron.yaml
@@ -1,0 +1,28 @@
+---
+name: Trigger nightly images
+
+on:
+  schedule:
+    # nightly packaging job usually finish around 14 UTC
+    - cron:  '0 15 * * *'
+jobs:
+  source_build:
+    name: Trigger devel image
+    env:
+      dockerTag: ${{ 'devel' }}
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Call devel webhook
+      run: |
+        curl -H "Content-Type: application/json" --data '{"docker_tag": "${{env.dockerTag}}"}'  -X POST ${{ secrets.DOCKER_POST_PUSH_TRIGGER }}
+  nightly_build:
+    name: Trigger nightly image
+    env:
+      dockerTag: ${{ 'nightly' }}
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Call nightly webhook
+      run: |
+        curl -H "Content-Type: application/json" --data '{"docker_tag": "${{env.dockerTag}}"}'  -X POST ${{ secrets.DOCKER_POST_PUSH_TRIGGER }}

--- a/.github/workflows/trigger_devel.yaml
+++ b/.github/workflows/trigger_devel.yaml
@@ -1,0 +1,17 @@
+---
+name: CRON Trigger devel images
+
+on:
+  schedule:
+    - cron:  '0 3 * * *'
+jobs:
+  source_build:
+    name: Trigger devel image
+    env:
+      dockerTag: ${{ 'devel' }}
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Call devel webhook
+      run: |
+        curl -H "Content-Type: application/json" --data '{"docker_tag": "${{env.dockerTag}}"}'  -X POST ${{ secrets.DOCKER_ROS2_POST_PUSH_TRIGGER }}

--- a/.github/workflows/trigger_devel.yaml
+++ b/.github/workflows/trigger_devel.yaml
@@ -3,7 +3,12 @@ name: CRON Trigger devel images
 
 on:
   schedule:
-    - cron:  '0 3 * * *'
+  - cron:  '0 3 * * *'
+  push:
+    branches:
+    - master
+    paths:
+      'ros2/source/**'
 jobs:
   source_build:
     name: Trigger devel image

--- a/.github/workflows/trigger_nightly.yaml
+++ b/.github/workflows/trigger_nightly.yaml
@@ -3,8 +3,13 @@ name: CRON Trigger nightly images
 
 on:
   schedule:
-    # nightly packaging job usually finish around 14 UTC
-    - cron:  '0 15 * * *'
+  # nightly packaging job usually finish around 14 UTC
+  - cron:  '0 15 * * *'
+  push:
+    branches:
+    - master
+    paths:
+      'ros2/nightly/**'
 jobs:
   nightly_build:
     name: Trigger nightly image

--- a/.github/workflows/trigger_nightly.yaml
+++ b/.github/workflows/trigger_nightly.yaml
@@ -1,21 +1,11 @@
 ---
-name: Trigger nightly images
+name: CRON Trigger nightly images
 
 on:
   schedule:
     # nightly packaging job usually finish around 14 UTC
     - cron:  '0 15 * * *'
 jobs:
-  source_build:
-    name: Trigger devel image
-    env:
-      dockerTag: ${{ 'devel' }}
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v1
-    - name: Call devel webhook
-      run: |
-        curl -H "Content-Type: application/json" --data '{"docker_tag": "${{env.dockerTag}}"}'  -X POST ${{ secrets.DOCKER_ROS2_POST_PUSH_TRIGGER }}
   nightly_build:
     name: Trigger nightly image
     env:


### PR DESCRIPTION
ros2 images have not been rebuilt since Dec 4th (20 days ago).
It was suggested in the past to have a cron job to trigger these builds daily to not rely on the currently flaky setup. The PR for it has been blocked for a while https://github.com/osrf/docker_images/pull/312

This PR implements a cron job using Github Actions thus allowing us to use it without extra permissions given to a third party app.

How it compares to https://github.com/osrf/docker_images/pull/312:

- the secrets have to be defined in this repo. They are encrypted by github and filtered out of the logs
  - cons:
    - any matching string in the logs will be redacted, so it could actually leak password if the same string is printed to the logs from code (though unlikely). I believe the logs are not public, so leaking is prevented
    - Logs are not public?
- the images are built in the actions and not on dockerhub:
  - pro:
    - we get notified on build failure
    - the job starts instantly
  - cons:
    - slower (maybe?) as pulling, building and pushing will require some bandwidth and latency is likely lower on dockerhub
    - I'm discovering github actions and hopefully things can be optimized and improved later on

Leaving this in draft for a couple days the time it proves to run reliably at https://github.com/mikaelarguedas/docker_images/actions