### PR TITLE
remove ros_workspace, use COLCON_CURRENT_PREFIX

### DIFF
--- a/ros2/nightly/images.yaml.em
+++ b/ros2/nightly/images.yaml.em
@@ -15,6 +15,7 @@ images:
           LANG:   "C.UTF-8"
           LC_ALL: "C.UTF-8"
           ROSDISTRO_INDEX_URL: "https://raw.githubusercontent.com/osrf/docker_images/master/ros2/nightly/nightly/index-v4.yaml"
+          COLCON_CURRENT_PREFIX: "/opt/ros/$ROS_DISTRO"
         env_after:
           ROS_PACKAGE_PATH: "/opt/ros/$ROS_DISTRO/share"
         pip3_install:

--- a/ros2/nightly/images.yaml.em
+++ b/ros2/nightly/images.yaml.em
@@ -15,7 +15,6 @@ images:
           LANG:   "C.UTF-8"
           LC_ALL: "C.UTF-8"
           ROSDISTRO_INDEX_URL: "https://raw.githubusercontent.com/osrf/docker_images/master/ros2/nightly/nightly/index-v4.yaml"
-          COLCON_CURRENT_PREFIX: "/opt/ros/$ROS_DISTRO"
         env_after:
           ROS_PACKAGE_PATH: "/opt/ros/$ROS_DISTRO/share"
         pip3_install:

--- a/ros2/nightly/nightly/Dockerfile
+++ b/ros2/nightly/nightly/Dockerfile
@@ -64,6 +64,9 @@ RUN mkdir -p /opt/ros/$ROS_DISTRO
 ARG ROS2_BINARY_URL=https://ci.ros2.org/view/packaging/job/packaging_linux/lastSuccessfulBuild/artifact/ws/ros2-package-linux-x86_64.tar.bz2
 RUN wget -q $ROS2_BINARY_URL -O - | \
     tar -xj --strip-components=1 -C /opt/ros/$ROS_DISTRO
+
+# Overwriting _colcon_prefix_chain_sh_COLCON_CURRENT_PREFIX to point to the new install location
+# Necessary because the default value is an absolute path valid only on the build machine
 RUN sed -i "s|^\(_colcon_prefix_chain_sh_COLCON_CURRENT_PREFIX\s*=\s*\).*$|\1/opt/ros/$ROS_DISTRO|" \
       /opt/ros/$ROS_DISTRO/setup.sh
 

--- a/ros2/nightly/nightly/Dockerfile
+++ b/ros2/nightly/nightly/Dockerfile
@@ -39,7 +39,6 @@ ENV ROS_DISTRO foxy
 ENV LANG C.UTF-8
 ENV LC_ALL C.UTF-8
 ENV ROSDISTRO_INDEX_URL https://raw.githubusercontent.com/osrf/docker_images/master/ros2/nightly/nightly/index-v4.yaml
-ENV COLCON_CURRENT_PREFIX /opt/ros/$ROS_DISTRO
 
 # install python packages
 RUN pip3 install -U \
@@ -65,6 +64,8 @@ RUN mkdir -p /opt/ros/$ROS_DISTRO
 ARG ROS2_BINARY_URL=https://ci.ros2.org/view/packaging/job/packaging_linux/lastSuccessfulBuild/artifact/ws/ros2-package-linux-x86_64.tar.bz2
 RUN wget -q $ROS2_BINARY_URL -O - | \
     tar -xj --strip-components=1 -C /opt/ros/$ROS_DISTRO
+RUN sed -i "s|^\(_colcon_prefix_chain_sh_COLCON_CURRENT_PREFIX\s*=\s*\).*$|\1/opt/ros/$ROS_DISTRO|" \
+      /opt/ros/$ROS_DISTRO/setup.sh
 
 # setup colcon mixin and metadata
 RUN colcon mixin add default \

--- a/ros2/nightly/nightly/Dockerfile
+++ b/ros2/nightly/nightly/Dockerfile
@@ -35,9 +35,11 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     && rm -rf /var/lib/apt/lists/*
 
 # setup environment
+ENV ROS_DISTRO foxy
 ENV LANG C.UTF-8
 ENV LC_ALL C.UTF-8
 ENV ROSDISTRO_INDEX_URL https://raw.githubusercontent.com/osrf/docker_images/master/ros2/nightly/nightly/index-v4.yaml
+ENV COLCON_CURRENT_PREFIX /opt/ros/$ROS_DISTRO
 
 # install python packages
 RUN pip3 install -U \
@@ -59,21 +61,10 @@ RUN pip3 freeze | grep pytest \
     && python3 -m pytest --version
 
 # install ros2 packages
-ENV ROS_DISTRO foxy
 RUN mkdir -p /opt/ros/$ROS_DISTRO
 ARG ROS2_BINARY_URL=https://ci.ros2.org/view/packaging/job/packaging_linux/lastSuccessfulBuild/artifact/ws/ros2-package-linux-x86_64.tar.bz2
 RUN wget -q $ROS2_BINARY_URL -O - | \
     tar -xj --strip-components=1 -C /opt/ros/$ROS_DISTRO
-
-# Overwrite setup scripts with ones that point to /opt/ros/$ROS_DISTRO
-RUN mkdir -p /tmp/dir/build \
- && cd /tmp/dir \
- && git clone --depth 1 https://github.com/ros2/ros_workspace.git -b latest \
- && cd /tmp/dir/build \
- && COLCON_CURRENT_PREFIX=/opt/ros/$ROS_DISTRO . /opt/ros/$ROS_DISTRO/local_setup.sh \
- && cmake -DCMAKE_INSTALL_PREFIX=/opt/ros/$ROS_DISTRO ../ros_workspace \
- && make install \
- && rm -r /tmp/dir
 
 # setup colcon mixin and metadata
 RUN colcon mixin add default \


### PR DESCRIPTION
Sourcing of ROS 1 underlay has been removed from the setup files in the archives: https://github.com/ros2/ci/pull/356

So the setup files can be sourced by simply defining `COLCON_CURRENT_PREFIX` in the image.