### PR TITLE
Use kmod to fix gzclient images

### DIFF
--- a/gazebo/.config/images.yaml.em
+++ b/gazebo/.config/images.yaml.em
@@ -50,8 +50,8 @@ images:
             - docker_templates
         upstream_packages:
             - binutils
+            - kmod
             - mesa-utils
-            - module-init-tools
             - x-window-system
         gazebo_packages:
             - gazebo@(gazebo_version)

--- a/gazebo/10/ubuntu/bionic/gzclient10/Dockerfile
+++ b/gazebo/10/ubuntu/bionic/gzclient10/Dockerfile
@@ -5,8 +5,8 @@ FROM gazebo:gzserver10-bionic
 # install packages
 RUN apt-get update && apt-get install -q -y \
     binutils \
+    kmod \
     mesa-utils \
-    module-init-tools \
     x-window-system \
     && rm -rf /var/lib/apt/lists/*
 

--- a/gazebo/10/ubuntu/bionic/images.yaml.em
+++ b/gazebo/10/ubuntu/bionic/images.yaml.em
@@ -50,8 +50,8 @@ images:
             - docker_templates
         upstream_packages:
             - binutils
+            - kmod
             - mesa-utils
-            - module-init-tools
             - x-window-system
         gazebo_packages:
             - gazebo@(gazebo_version)

--- a/gazebo/7/ubuntu/xenial/gzclient7/Dockerfile
+++ b/gazebo/7/ubuntu/xenial/gzclient7/Dockerfile
@@ -5,8 +5,8 @@ FROM gazebo:gzserver7-xenial
 # install packages
 RUN apt-get update && apt-get install -q -y \
     binutils \
+    kmod \
     mesa-utils \
-    module-init-tools \
     x-window-system \
     && rm -rf /var/lib/apt/lists/*
 

--- a/gazebo/7/ubuntu/xenial/images.yaml.em
+++ b/gazebo/7/ubuntu/xenial/images.yaml.em
@@ -50,8 +50,8 @@ images:
             - docker_templates
         upstream_packages:
             - binutils
+            - kmod
             - mesa-utils
-            - module-init-tools
             - x-window-system
         gazebo_packages:
             - gazebo@(gazebo_version)

--- a/gazebo/9/debian/stretch/Makefile
+++ b/gazebo/9/debian/stretch/Makefile
@@ -12,7 +12,7 @@ help:
 build:
 	@docker build --tag=gazebo:gzserver9-stretch	gzserver9/.
 	@docker build --tag=gazebo:libgazebo9-stretch	libgazebo9/.
-	# @docker build --tag=gazebo:gzclient9-stretch	gzclient9/.
+	@docker build --tag=gazebo:gzclient9-stretch	gzclient9/.
 	# @docker build --tag=gazebo:gzweb9-stretch			gzweb9/.
 
 pull:

--- a/gazebo/9/debian/stretch/gzclient9/Dockerfile
+++ b/gazebo/9/debian/stretch/gzclient9/Dockerfile
@@ -5,8 +5,8 @@ FROM gazebo:gzserver9-stretch
 # install packages
 RUN apt-get update && apt-get install -q -y \
     binutils \
+    kmod \
     mesa-utils \
-    module-init-tools \
     x-window-system \
     && rm -rf /var/lib/apt/lists/*
 

--- a/gazebo/9/debian/stretch/images.yaml.em
+++ b/gazebo/9/debian/stretch/images.yaml.em
@@ -50,8 +50,8 @@ images:
             - docker_templates
         upstream_packages:
             - binutils
+            - kmod
             - mesa-utils
-            - module-init-tools
             - x-window-system
         gazebo_packages:
             - gazebo@(gazebo_version)

--- a/gazebo/9/ubuntu/bionic/gzclient9/Dockerfile
+++ b/gazebo/9/ubuntu/bionic/gzclient9/Dockerfile
@@ -5,8 +5,8 @@ FROM gazebo:gzserver9-bionic
 # install packages
 RUN apt-get update && apt-get install -q -y \
     binutils \
+    kmod \
     mesa-utils \
-    module-init-tools \
     x-window-system \
     && rm -rf /var/lib/apt/lists/*
 

--- a/gazebo/9/ubuntu/bionic/images.yaml.em
+++ b/gazebo/9/ubuntu/bionic/images.yaml.em
@@ -50,8 +50,8 @@ images:
             - docker_templates
         upstream_packages:
             - binutils
+            - kmod
             - mesa-utils
-            - module-init-tools
             - x-window-system
         gazebo_packages:
             - gazebo@(gazebo_version)

--- a/gazebo/9/ubuntu/xenial/gzclient9/Dockerfile
+++ b/gazebo/9/ubuntu/xenial/gzclient9/Dockerfile
@@ -5,8 +5,8 @@ FROM gazebo:gzserver9-xenial
 # install packages
 RUN apt-get update && apt-get install -q -y \
     binutils \
+    kmod \
     mesa-utils \
-    module-init-tools \
     x-window-system \
     && rm -rf /var/lib/apt/lists/*
 

--- a/gazebo/9/ubuntu/xenial/images.yaml.em
+++ b/gazebo/9/ubuntu/xenial/images.yaml.em
@@ -50,8 +50,8 @@ images:
             - docker_templates
         upstream_packages:
             - binutils
+            - kmod
             - mesa-utils
-            - module-init-tools
             - x-window-system
         gazebo_packages:
             - gazebo@(gazebo_version)


### PR DESCRIPTION
This fixes the build on gzclient images on Debian.

We may want to revisit the entrypoint / command of these images because currently they just run `gzserver` as their parents. I'm tempted to just make these call `gazebo` and keep the entrypoint of the base image