### PR TITLE
Add Gazebo11

### DIFF
--- a/.github/workflows/gazebo_ci.yaml
+++ b/.github/workflows/gazebo_ci.yaml
@@ -20,6 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         env:
+          - {HUB_REPO: gazebo, HUB_RELEASE: 11, HUB_OS_NAME: ubuntu, HUB_OS_CODE_NAME: bionic}
           - {HUB_REPO: gazebo, HUB_RELEASE: 10, HUB_OS_NAME: ubuntu, HUB_OS_CODE_NAME: bionic}
           - {HUB_REPO: gazebo, HUB_RELEASE: 9, HUB_OS_NAME: debian, HUB_OS_CODE_NAME: stretch}
           - {HUB_REPO: gazebo, HUB_RELEASE: 9, HUB_OS_NAME: ubuntu, HUB_OS_CODE_NAME: bionic}

--- a/.github/workflows/gazebo_ci.yaml
+++ b/.github/workflows/gazebo_ci.yaml
@@ -3,11 +3,13 @@ name: CI Gazebo images
 on:
   pull_request:
     paths:
+    - 'gazebo/11/**'
     - 'gazebo/10/**'
     - 'gazebo/9/**'
     - 'gazebo/7/**'
   push:
     paths:
+    - 'gazebo/11/**'
     - 'gazebo/10/**'
     - 'gazebo/9/**'
     - 'gazebo/7/**'

--- a/.travis.yml.unused
+++ b/.travis.yml.unused
@@ -18,6 +18,7 @@ env:
   - HUB_REPO=ros    HUB_RELEASE=melodic HUB_OS_NAME=debian HUB_OS_CODE_NAME=stretch
   - HUB_REPO=ros    HUB_RELEASE=kinetic HUB_OS_NAME=ubuntu HUB_OS_CODE_NAME=xenial
   # gazebo
+  - HUB_REPO=gazebo HUB_RELEASE=11      HUB_OS_NAME=ubuntu HUB_OS_CODE_NAME=bionic
   - HUB_REPO=gazebo HUB_RELEASE=10      HUB_OS_NAME=ubuntu HUB_OS_CODE_NAME=bionic
   - HUB_REPO=gazebo HUB_RELEASE=9       HUB_OS_NAME=ubuntu HUB_OS_CODE_NAME=bionic
   - HUB_REPO=gazebo HUB_RELEASE=9       HUB_OS_NAME=debian HUB_OS_CODE_NAME=stretch

--- a/gazebo/11/ubuntu/bionic/Makefile
+++ b/gazebo/11/ubuntu/bionic/Makefile
@@ -1,0 +1,28 @@
+all: help
+
+help:
+	@echo ""
+	@echo "-- Help Menu"
+	@echo ""
+	@echo "   1. make build            - build all images"
+	@echo "   2. make pull             - pull all images"
+	@echo "   3. make clean            - remove all images"
+	@echo ""
+
+build:
+	@docker build --tag=gazebo:gzserver11-bionic	gzserver11/.
+	@docker build --tag=gazebo:libgazebo11-bionic	libgazebo11/.
+	# @docker build --tag=gazebo:gzclient11-bionic	gzclient11/.
+	# @docker build --tag=gazebo:gzweb11-bionic			gzweb11/.
+
+pull:
+	@docker pull gazebo:libgazebo11-bionic
+	@docker pull gazebo:gzserver11-bionic
+	# @docker pull gazebo:gzclient11-bionic
+	# @docker pull gazebo:gzweb11-bionic
+
+clean:
+	@docker rmi -f gazebo:libgazebo11-bionic
+	@docker rmi -f gazebo:gzserver11-bionic
+	# @docker rmi -f gazebo:gzclient11-bionic
+	# @docker rmi -f gazebo:gzweb11-bionic

--- a/gazebo/11/ubuntu/bionic/gzclient11/Dockerfile
+++ b/gazebo/11/ubuntu/bionic/gzclient11/Dockerfile
@@ -1,0 +1,16 @@
+# This is an auto generated Dockerfile for gazebo:gzclient11
+# generated from docker_images/create_gzclient_image.Dockerfile.em
+FROM gazebo:gzserver11-bionic
+
+# install packages
+RUN apt-get update && apt-get install -q -y \
+    binutils \
+    mesa-utils \
+    module-init-tools \
+    x-window-system \
+    && rm -rf /var/lib/apt/lists/*
+
+# install gazebo packages
+RUN apt-get update && apt-get install -q -y \
+    gazebo11=11.0.0-1* \
+    && rm -rf /var/lib/apt/lists/*

--- a/gazebo/11/ubuntu/bionic/gzserver11/Dockerfile
+++ b/gazebo/11/ubuntu/bionic/gzserver11/Dockerfile
@@ -1,0 +1,36 @@
+# This is an auto generated Dockerfile for gazebo:gzserver11
+# generated from docker_images/create_gzserver_image.Dockerfile.em
+FROM ubuntu:bionic
+
+# setup timezone
+RUN echo 'Etc/UTC' > /etc/timezone && \
+    ln -s /usr/share/zoneinfo/Etc/UTC /etc/localtime && \
+    apt-get update && apt-get install -q -y tzdata && rm -rf /var/lib/apt/lists/*
+
+# install packages
+RUN apt-get update && apt-get install -q -y \
+    dirmngr \
+    gnupg2 \
+    lsb-release \
+    && rm -rf /var/lib/apt/lists/*
+
+# setup keys
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys D2486D2DD83DB69272AFE98867170598AF249743
+
+# setup sources.list
+RUN . /etc/os-release \
+    && echo "deb http://packages.osrfoundation.org/gazebo/$ID-stable `lsb_release -sc` main" > /etc/apt/sources.list.d/gazebo-latest.list
+
+# install gazebo packages
+RUN apt-get update && apt-get install -q -y \
+    gazebo11=11.0.0-1* \
+    && rm -rf /var/lib/apt/lists/*
+
+# setup environment
+EXPOSE 11345
+
+# setup entrypoint
+COPY ./gzserver_entrypoint.sh /
+
+ENTRYPOINT ["/gzserver_entrypoint.sh"]
+CMD ["gzserver"]

--- a/gazebo/11/ubuntu/bionic/gzserver11/gzserver_entrypoint.sh
+++ b/gazebo/11/ubuntu/bionic/gzserver11/gzserver_entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+# setup gazebo environment
+source "/usr/share/gazebo/setup.sh"
+exec "$@"

--- a/gazebo/11/ubuntu/bionic/gzweb11/Dockerfile
+++ b/gazebo/11/ubuntu/bionic/gzweb11/Dockerfile
@@ -1,0 +1,42 @@
+# This is an auto generated Dockerfile for gazebo:gzweb11
+# generated from docker_images/create_gzweb_image.Dockerfile.em
+FROM gazebo:libgazebo11-bionic
+
+# install packages
+RUN apt-get update && apt-get install -q -y \
+    build-essential \
+    cmake \
+    imagemagick \
+    libboost-all-dev \
+    libgts-dev \
+    libjansson-dev \
+    libtinyxml-dev \
+    mercurial \
+    nodejs \
+    nodejs-legacy \
+    npm \
+    pkg-config \
+    psmisc \
+    xvfb \
+    && rm -rf /var/lib/apt/lists/*
+
+# install gazebo packages
+RUN apt-get update && apt-get install -q -y \
+    libgazebo11-dev=11.0.0-1* \
+    && rm -rf /var/lib/apt/lists/*
+
+# clone gzweb
+ENV GZWEB_WS /root/gzweb
+RUN hg clone https://bitbucket.org/osrf/gzweb $GZWEB_WS
+WORKDIR $GZWEB_WS
+
+# build gzweb
+RUN hg up default \
+    && xvfb-run -s "-screen 0 1280x1024x24" ./deploy.sh -m -t
+
+# setup environment
+EXPOSE 8080
+EXPOSE 7681
+
+# run gzserver and gzweb
+CMD gzserver --verbose & npm start

--- a/gazebo/11/ubuntu/bionic/images.yaml.em
+++ b/gazebo/11/ubuntu/bionic/images.yaml.em
@@ -1,0 +1,57 @@
+%YAML 1.1
+# Gazebo Dockerfile database
+---
+images:
+    gzserver@(gazebo_version):
+        base_image: @(os_name):@(os_code_name)
+        maintainer_name: @(maintainer_name)
+        template_name: docker_images/create_gzserver_image.Dockerfile.em
+        entrypoint_name: docker_images/gzserver_entrypoint.sh
+        template_packages:
+            - docker_templates
+        gazebo_packages:
+            - gazebo@(gazebo_version)
+    libgazebo@(gazebo_version):
+        base_image: @(user_name):gzserver@(gazebo_version)-@(os_code_name)
+        maintainer_name: @(maintainer_name)
+        template_name: docker_images/create_gzclient_image.Dockerfile.em
+        template_packages:
+            - docker_templates
+        gazebo_packages:
+            - libgazebo@(gazebo_version)-dev
+    gzweb@(gazebo_version):
+        base_image: @(user_name):libgazebo@(gazebo_version)-@(os_code_name)
+        maintainer_name: @(maintainer_name)
+        template_name: docker_images/create_gzweb_image.Dockerfile.em
+        template_packages:
+            - docker_templates
+        upstream_packages:
+            - build-essential
+            - cmake
+            - imagemagick
+            - libboost-all-dev
+            - libgts-dev
+            - libjansson-dev
+            - libtinyxml-dev
+            - mercurial
+            - nodejs
+            - nodejs-legacy
+            - npm
+            - pkg-config
+            - psmisc
+            - xvfb
+        gazebo_packages:
+            - libgazebo@(gazebo_version)-dev
+    gzclient@(gazebo_version):
+        base_image: @(user_name):gzserver@(gazebo_version)-@(os_code_name)
+        maintainer_name: @(maintainer_name)
+        template_name: docker_images/create_gzclient_image.Dockerfile.em
+        template_packages:
+            - docker_templates
+        upstream_packages:
+            - binutils
+            - mesa-utils
+            - module-init-tools
+            - x-window-system
+        gazebo_packages:
+            - gazebo@(gazebo_version)

--- a/gazebo/11/ubuntu/bionic/libgazebo11/Dockerfile
+++ b/gazebo/11/ubuntu/bionic/libgazebo11/Dockerfile
@@ -1,0 +1,7 @@
+# This is an auto generated Dockerfile for gazebo:libgazebo11
+# generated from docker_images/create_gzclient_image.Dockerfile.em
+FROM gazebo:gzserver11-bionic
+# install gazebo packages
+RUN apt-get update && apt-get install -q -y \
+    libgazebo11-dev=11.0.0-1* \
+    && rm -rf /var/lib/apt/lists/*

--- a/gazebo/11/ubuntu/bionic/platform.yaml
+++ b/gazebo/11/ubuntu/bionic/platform.yaml
@@ -1,0 +1,13 @@
+%YAML 1.1
+# Gazebo Dockerfile database
+---
+platform:
+    os_name: ubuntu
+    os_code_name: bionic
+    gazebo_version: 11
+    user_name: gazebo
+    maintainer_name:
+    arch: amd64
+    type: distribution
+    version:
+    release: stable

--- a/gazebo/gazebo
+++ b/gazebo/gazebo
@@ -72,8 +72,25 @@ Architectures: amd64
 GitCommit: f1b7ad09fa3bc6b88621c5f4ff2da9669c9ccb3e
 Directory: gazebo/10/ubuntu/bionic/gzserver10
 
-Tags: libgazebo10, libgazebo10-bionic, latest
+Tags: libgazebo10, libgazebo10-bionic
 Architectures: amd64
 GitCommit: f1b7ad09fa3bc6b88621c5f4ff2da9669c9ccb3e
 Directory: gazebo/10/ubuntu/bionic/libgazebo10
+
+
+################################################################################
+# Release: 11
+
+########################################
+# Distro: ubuntu:bionic
+
+Tags: gzserver11, gzserver11-bionic
+Architectures: amd64
+GitCommit: bd0ef992496452d93ea929ea5921b123acdab58c
+Directory: gazebo/11/ubuntu/bionic/gzserver11
+
+Tags: libgazebo11, libgazebo11-bionic, latest
+Architectures: amd64
+GitCommit: bd0ef992496452d93ea929ea5921b123acdab58c
+Directory: gazebo/11/ubuntu/bionic/libgazebo11
 

--- a/gazebo/manifest.yaml
+++ b/gazebo/manifest.yaml
@@ -165,6 +165,24 @@ release_names:
                                 aliases:
                                     - "libgazebo$release_name"
                                     - "libgazebo$release_name-$os_code_name"
+    '11':
+        eol: 2025-01-30
+        os_names:
+            ubuntu:
+                os_code_names:
+                    bionic:
+                        <<: *DEFAULT
+                        archs:
+                            - amd64
+                        tag_names:
+                            gzserver11:
+                                aliases:
+                                    - "gzserver$release_name"
+                                    - "gzserver$release_name-$os_code_name"
+                            libgazebo11:
+                                aliases:
+                                    - "libgazebo$release_name"
+                                    - "libgazebo$release_name-$os_code_name"
                                     - latest
 
 meta:


### PR DESCRIPTION
Add gazebo 11 dockerfiles.

Currently this targets only Ubuntu Bionic and only amd64 architecture.

@chapulina @j-rivero Do you know if there other OSes and / or architectures that Gazebo11 is targeting / released for ?