### PR TITLE
Remove unnecessary argcomplete from pip

### DIFF
--- a/ros/.config/ros2/images.yaml.em
+++ b/ros/.config/ros2/images.yaml.em
@@ -7,8 +7,6 @@ images:
         maintainer_name: @(maintainer_name)
         template_name: docker_images_ros2/create_ros_core_image.Dockerfile.em
         entrypoint_name: docker_images_ros2/ros_entrypoint.sh
-        pip3_install:
-            - argcomplete
         template_packages:
             - docker_templates
         ros2_packages:

--- a/ros/dashing/ubuntu/bionic/images.yaml.em
+++ b/ros/dashing/ubuntu/bionic/images.yaml.em
@@ -7,8 +7,6 @@ images:
         maintainer_name: @(maintainer_name)
         template_name: docker_images_ros2/create_ros_core_image.Dockerfile.em
         entrypoint_name: docker_images_ros2/ros_entrypoint.sh
-        pip3_install:
-            - argcomplete
         template_packages:
             - docker_templates
         ros2_packages:

--- a/ros/dashing/ubuntu/bionic/ros-core/Dockerfile
+++ b/ros/dashing/ubuntu/bionic/ros-core/Dockerfile
@@ -11,7 +11,6 @@ RUN echo 'Etc/UTC' > /etc/timezone && \
 RUN apt-get update && apt-get install -q -y \
     dirmngr \
     gnupg2 \
-    python3-pip \
     && rm -rf /var/lib/apt/lists/*
 
 # setup keys
@@ -45,10 +44,6 @@ RUN colcon mixin add default \
     colcon metadata add default \
       https://raw.githubusercontent.com/colcon/colcon-metadata-repository/master/index.yaml && \
     colcon metadata update
-
-# install python packages
-RUN pip3 install -U \
-    argcomplete
 
 # install ros2 packages
 RUN apt-get update && apt-get install -y \

--- a/ros/eloquent/ubuntu/bionic/images.yaml.em
+++ b/ros/eloquent/ubuntu/bionic/images.yaml.em
@@ -7,8 +7,6 @@ images:
         maintainer_name: @(maintainer_name)
         template_name: docker_images_ros2/create_ros_core_image.Dockerfile.em
         entrypoint_name: docker_images_ros2/ros_entrypoint.sh
-        pip3_install:
-            - argcomplete
         template_packages:
             - docker_templates
         ros2_packages:

--- a/ros/eloquent/ubuntu/bionic/ros-core/Dockerfile
+++ b/ros/eloquent/ubuntu/bionic/ros-core/Dockerfile
@@ -11,7 +11,6 @@ RUN echo 'Etc/UTC' > /etc/timezone && \
 RUN apt-get update && apt-get install -q -y \
     dirmngr \
     gnupg2 \
-    python3-pip \
     && rm -rf /var/lib/apt/lists/*
 
 # setup keys
@@ -45,10 +44,6 @@ RUN colcon mixin add default \
     colcon metadata add default \
       https://raw.githubusercontent.com/colcon/colcon-metadata-repository/master/index.yaml && \
     colcon metadata update
-
-# install python packages
-RUN pip3 install -U \
-    argcomplete
 
 # install ros2 packages
 RUN apt-get update && apt-get install -y \

--- a/ros/ros
+++ b/ros/ros
@@ -86,7 +86,7 @@ Directory: ros/melodic/debian/stretch/perception
 
 Tags: dashing-ros-core, dashing-ros-core-bionic
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: b075c7dbe56055d862f331f19e1e74ba653e181a
+GitCommit: 92054cbbf05c4d00028cb089ce8c6dcb60f42d01
 Directory: ros/dashing/ubuntu/bionic/ros-core
 
 Tags: dashing-ros-base, dashing-ros-base-bionic, dashing
@@ -103,7 +103,7 @@ Directory: ros/dashing/ubuntu/bionic/ros-base
 
 Tags: eloquent-ros-core, eloquent-ros-core-bionic
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: b075c7dbe56055d862f331f19e1e74ba653e181a
+GitCommit: 92054cbbf05c4d00028cb089ce8c6dcb60f42d01
 Directory: ros/eloquent/ubuntu/bionic/ros-core
 
 Tags: eloquent-ros-base, eloquent-ros-base-bionic, eloquent


### PR DESCRIPTION
Version of argcomplete in ubuntu repository in bionic is 1.8.1 that is high enough for the use in colcon/ros2cli. No need to install it from pip anymore.

