### PR TITLE
WIP add Ignition

### DIFF
--- a/.github/workflows/ignition_ci.yaml
+++ b/.github/workflows/ignition_ci.yaml
@@ -1,0 +1,41 @@
+name: CI Gazebo images
+
+on:
+  pull_request:
+    paths:
+    - 'ignition/blueprint/**'
+    - 'ignition/citadel/**'
+    - 'ignition/ignition'
+  push:
+    paths:
+    - 'ignition/blueprint/**'
+    - 'ignition/citadel/**'
+    - 'ignition/ignition'
+  schedule:
+    # Trigger daily to check for upstream changes
+    - cron: '0 0 * * *'
+jobs:
+  check_images:
+    strategy:
+      fail-fast: false
+      matrix:
+        env:
+          - {HUB_REPO: ignition, HUB_RELEASE: citadel, HUB_OS_NAME: ubuntu, HUB_OS_CODE_NAME: bionic}
+    runs-on: ubuntu-latest
+    env:
+      GITHUBEMAIL: ${{ secrets.GITHUBEMAIL }}
+      GITHUBTOKEN: ${{ secrets.GITHUBTOKEN }}
+      GITHUBUSER: ${{ secrets.GITHUBUSER }}
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-python@v1
+        with:
+          python-version: 3.x
+      - name: Install requirements
+        run: |
+             python -m pip install --upgrade pip
+             pip install -r docker/requirements.txt
+             pip install -r .ci/requirements.txt
+      - name: Check and build Gazebo image
+        env: ${{matrix.env}}
+        run: .ci/ci_script.py

--- a/.github/workflows/ignition_ci.yaml
+++ b/.github/workflows/ignition_ci.yaml
@@ -1,4 +1,4 @@
-name: CI Gazebo images
+name: CI Ignition images
 
 on:
   pull_request:
@@ -37,6 +37,6 @@ jobs:
              python -m pip install --upgrade pip
              pip install -r docker/requirements.txt
              pip install -r .ci/requirements.txt
-      - name: Check and build Gazebo image
+      - name: Check and build Ignition image
         env: ${{matrix.env}}
         run: .ci/ci_script.py

--- a/.github/workflows/ignition_ci.yaml
+++ b/.github/workflows/ignition_ci.yaml
@@ -20,6 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         env:
+          - {HUB_REPO: ignition, HUB_RELEASE: blueprint, HUB_OS_NAME: ubuntu, HUB_OS_CODE_NAME: bionic}
           - {HUB_REPO: ignition, HUB_RELEASE: citadel, HUB_OS_NAME: ubuntu, HUB_OS_CODE_NAME: bionic}
     runs-on: ubuntu-latest
     env:

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This repo hosts Dockerfiles and scaffolding for images in the Official Library a
 [Official docker library](https://github.com/osrf/docker_images/blob/master/README.md#official-library)<br/>
 [Official ROS (1 and 2) images](https://github.com/osrf/docker_images/blob/master/README.md#ros--)<br/>
 [Official Gazebo images](https://github.com/osrf/docker_images/blob/master/README.md#gazebo--)<br/>
+[Official Ignition images](https://github.com/osrf/docker_images/blob/master/README.md#ignition--)<br/>
 [OSRF ROS (1 and 2) overlay images](https://github.com/osrf/docker_images/blob/master/README.md#ros---1)<br/>
 [OSRF ROS 2 development images](https://github.com/osrf/docker_images/blob/master/README.md#ros2--)<br/>
 [OSRF Gazebo overlay images](https://github.com/osrf/docker_images/blob/master/README.md#gazebo---1)<br/>
@@ -16,6 +17,7 @@ This repo hosts Dockerfiles and scaffolding for images in the Official Library a
 | ROS | [![Build Status](https://github.com/osrf/docker_images/workflows/CI%20ROS%20images/badge.svg?branch=master)](https://github.com/osrf/docker_images/actions?query=workflow%3A%22CI+ROS+images%22+event%3Aschedule)
 | ROS 2 | [![Build Status](https://github.com/osrf/docker_images/workflows/CI%20ROS%202%20images/badge.svg?branch=master)](https://github.com/osrf/docker_images)
 | Gazebo | [![Build Status](https://github.com/osrf/docker_images/workflows/CI%20Gazebo%20images/badge.svg?branch=master)](https://github.com/osrf/docker_images/actions?query=workflow%3A%22CI+Gazebo+images%22+event%3Aschedule)
+| Ignition | [![Build Status](https://github.com/osrf/docker_images/workflows/CI%20Ignition%20images/badge.svg?branch=master)](https://github.com/osrf/docker_images/actions?query=workflow%3A%22CI+Ignition+images%22+event%3Aschedule)
 
 ---
 
@@ -63,6 +65,26 @@ For complete listing of tag, view the Repo Info link below.
 | [arm64v8](https://hub.docker.com/r/arm64v8/gazebo/tags) | [![Build Status](https://doi-janky.infosiftr.net/buildStatus/icon?job=multiarch/arm64v8/gazebo)](https://doi-janky.infosiftr.net/job/multiarch/job/arm64v8/job/gazebo/) |
 -->
 
+### [Ignition ![Docker Pulls](https://img.shields.io/docker/pulls/_/ignition.svg?label=pulls) ![Docker Stars](https://img.shields.io/docker/stars/_/ignition.svg?label=stars)](https://hub.docker.com/_/ignition)
+
+This repo contains images available for Ignition.
+For more documentation on using these images, view the Docker Hub repo link above.
+Images are tagged by releases version, meta package, as well as code name for supported OS base images.
+For complete listing of tag, view the Repo Info link below.
+
+#### [Repo Info](https://github.com/docker-library/repo-info/tree/master/repos/ignition)
+
+[![Compare Images](https://images.microbadger.com/badges/image/library/ignition.svg)](https://microbadger.com/#/images/library/ignition)
+
+#### Architectures
+
+| Type | Status |
+|---|---|
+| [amd64](https://hub.docker.com/r/amd64/ignition/tags) | [![Build Status](https://doi-janky.infosiftr.net/buildStatus/icon?job=multiarch/amd64/ignition)](https://doi-janky.infosiftr.net/job/multiarch/job/amd64/job/ignition/) |
+<!--
+| [arm32v7](https://hub.docker.com/r/arm32v7/ignition/tags) | [![Build Status](https://doi-janky.infosiftr.net/buildStatus/icon?job=multiarch/arm32v7/ignition)](https://doi-janky.infosiftr.net/job/multiarch/job/arm32v7/job/ignition/) |
+| [arm64v8](https://hub.docker.com/r/arm64v8/ignition/tags) | [![Build Status](https://doi-janky.infosiftr.net/buildStatus/icon?job=multiarch/arm64v8/ignition)](https://doi-janky.infosiftr.net/job/multiarch/job/arm64v8/job/ignition/) |
+-->
 ---
 
 ## [OSRF Profile](https://hub.docker.com/u/osrf/)

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -9,7 +9,7 @@ pyyaml
 ###### Requirements with Repo Specifiers ######
 #   See https://pip.readthedocs.io/en/stable/reference/pip_install/#git
 git+git://github.com/ros-infrastructure/ros_buildfarm.git@master#egg=ros_buildfarm
-git+git://github.com/osrf/docker_templates.git@master#egg=docker_templates
+git+git://github.com/osrf/docker_templates.git@ignition#egg=docker_templates
 
 ###### Requirements with Version Specifiers ######
 #   See https://www.python.org/dev/peps/pep-0440/#version-specifiers

--- a/ignition/.config/Makefile.em
+++ b/ignition/.config/Makefile.em
@@ -1,0 +1,19 @@
+all: help
+
+help:
+	@echo ""
+	@echo "-- Help Menu"
+	@echo ""
+	@echo "   1. make build            - build all images"
+	@echo "   2. make pull             - pull all images"
+	@echo "   3. make clean            - remove all images"
+	@echo ""
+
+build:
+	@docker build --tag=ignition:$release_name-$os_code_name	ignition/.
+
+pull:
+	@docker pull ignition:$release_name-$os_code_name
+
+clean:
+	@docker rmi -f ignition:$release_name-$os_code_name

--- a/ignition/.config/images.yaml.em
+++ b/ignition/.config/images.yaml.em
@@ -1,0 +1,13 @@
+%YAML 1.1
+# Ignition Dockerfile database
+---
+images:
+    ignition:
+        base_image: @(os_name):@(os_code_name)
+        maintainer_name: @(maintainer_name)
+        template_name: docker_images/create_ignition_image.Dockerfile.em
+        # entrypoint_name: docker_images/no_entrypoint.sh
+        template_packages:
+            - docker_templates
+        ignition_packages:
+            - ignition-@(ignition_version)

--- a/ignition/.config/platform.yaml.em
+++ b/ignition/.config/platform.yaml.em
@@ -1,0 +1,13 @@
+%YAML 1.1
+# Ignition Dockerfile database
+---
+platform:
+    os_name: $os_name
+    os_code_name: $os_code_name
+    ignition_version: $release_name
+    user_name: ignition
+    maintainer_name:
+    arch: amd64
+    type: distribution
+    version:
+    release: stable

--- a/ignition/blueprint/ubuntu/bionic/Makefile
+++ b/ignition/blueprint/ubuntu/bionic/Makefile
@@ -1,0 +1,19 @@
+all: help
+
+help:
+	@echo ""
+	@echo "-- Help Menu"
+	@echo ""
+	@echo "   1. make build            - build all images"
+	@echo "   2. make pull             - pull all images"
+	@echo "   3. make clean            - remove all images"
+	@echo ""
+
+build:
+	@docker build --tag=ignition:blueprint-bionic	ignition/.
+
+pull:
+	@docker pull ignition:blueprint-bionic
+
+clean:
+	@docker rmi -f ignition:blueprint-bionic

--- a/ignition/blueprint/ubuntu/bionic/ignition/Dockerfile
+++ b/ignition/blueprint/ubuntu/bionic/ignition/Dockerfile
@@ -1,0 +1,32 @@
+# This is an auto generated Dockerfile for ignition:ignition
+# generated from docker_images/create_ignition_image.Dockerfile.em
+FROM ubuntu:bionic
+
+# setup timezone
+RUN echo 'Etc/UTC' > /etc/timezone && \
+    ln -s /usr/share/zoneinfo/Etc/UTC /etc/localtime && \
+    apt-get update && apt-get install -q -y tzdata && rm -rf /var/lib/apt/lists/*
+
+# install packages
+RUN apt-get update && apt-get install -q -y \
+    dirmngr \
+    gnupg2 \
+    lsb-release \
+    && rm -rf /var/lib/apt/lists/*
+
+# setup keys
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys D2486D2DD83DB69272AFE98867170598AF249743
+
+# setup sources.list
+RUN . /etc/os-release \
+    && echo "deb http://packages.osrfoundation.org/gazebo/$ID-stable `lsb_release -sc` main" > /etc/apt/sources.list.d/gazebo-latest.list
+
+# install ignition packages
+RUN apt-get update && apt-get install -q -y \
+    ignition-blueprint=1.0.0-1* \
+    && rm -rf /var/lib/apt/lists/*
+
+# setup environment
+EXPOSE 11345
+
+CMD ["ign", "gazebo", "-s"]

--- a/ignition/blueprint/ubuntu/bionic/images.yaml.em
+++ b/ignition/blueprint/ubuntu/bionic/images.yaml.em
@@ -1,0 +1,13 @@
+%YAML 1.1
+# Ignition Dockerfile database
+---
+images:
+    ignition:
+        base_image: @(os_name):@(os_code_name)
+        maintainer_name: @(maintainer_name)
+        template_name: docker_images/create_ignition_image.Dockerfile.em
+        # entrypoint_name: docker_images/no_entrypoint.sh
+        template_packages:
+            - docker_templates
+        ignition_packages:
+            - ignition-@(ignition_version)

--- a/ignition/blueprint/ubuntu/bionic/platform.yaml
+++ b/ignition/blueprint/ubuntu/bionic/platform.yaml
@@ -1,0 +1,13 @@
+%YAML 1.1
+# Ignition Dockerfile database
+---
+platform:
+    os_name: ubuntu
+    os_code_name: bionic
+    ignition_version: blueprint
+    user_name: ignition
+    maintainer_name:
+    arch: amd64
+    type: distribution
+    version:
+    release: stable

--- a/ignition/citadel/ubuntu/bionic/Makefile
+++ b/ignition/citadel/ubuntu/bionic/Makefile
@@ -1,0 +1,19 @@
+all: help
+
+help:
+	@echo ""
+	@echo "-- Help Menu"
+	@echo ""
+	@echo "   1. make build            - build all images"
+	@echo "   2. make pull             - pull all images"
+	@echo "   3. make clean            - remove all images"
+	@echo ""
+
+build:
+	@docker build --tag=ignition:citadel-bionic	ignition/.
+
+pull:
+	@docker pull ignition:citadel-bionic
+
+clean:
+	@docker rmi -f ignition:citadel-bionic

--- a/ignition/citadel/ubuntu/bionic/ignition/Dockerfile
+++ b/ignition/citadel/ubuntu/bionic/ignition/Dockerfile
@@ -1,0 +1,32 @@
+# This is an auto generated Dockerfile for ignition:ignition
+# generated from docker_images/create_ignition_image.Dockerfile.em
+FROM ubuntu:bionic
+
+# setup timezone
+RUN echo 'Etc/UTC' > /etc/timezone && \
+    ln -s /usr/share/zoneinfo/Etc/UTC /etc/localtime && \
+    apt-get update && apt-get install -q -y tzdata && rm -rf /var/lib/apt/lists/*
+
+# install packages
+RUN apt-get update && apt-get install -q -y \
+    dirmngr \
+    gnupg2 \
+    lsb-release \
+    && rm -rf /var/lib/apt/lists/*
+
+# setup keys
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys D2486D2DD83DB69272AFE98867170598AF249743
+
+# setup sources.list
+RUN . /etc/os-release \
+    && echo "deb http://packages.osrfoundation.org/gazebo/$ID-stable `lsb_release -sc` main" > /etc/apt/sources.list.d/gazebo-latest.list
+
+# install ignition packages
+RUN apt-get update && apt-get install -q -y \
+    ignition-citadel=1.0.0-1* \
+    && rm -rf /var/lib/apt/lists/*
+
+# setup environment
+EXPOSE 11345
+
+CMD ["ign", "gazebo", "-s"]

--- a/ignition/citadel/ubuntu/bionic/images.yaml.em
+++ b/ignition/citadel/ubuntu/bionic/images.yaml.em
@@ -1,0 +1,13 @@
+%YAML 1.1
+# Ignition Dockerfile database
+---
+images:
+    ignition:
+        base_image: @(os_name):@(os_code_name)
+        maintainer_name: @(maintainer_name)
+        template_name: docker_images/create_ignition_image.Dockerfile.em
+        # entrypoint_name: docker_images/no_entrypoint.sh
+        template_packages:
+            - docker_templates
+        ignition_packages:
+            - ignition-@(ignition_version)

--- a/ignition/citadel/ubuntu/bionic/platform.yaml
+++ b/ignition/citadel/ubuntu/bionic/platform.yaml
@@ -1,0 +1,13 @@
+%YAML 1.1
+# Ignition Dockerfile database
+---
+platform:
+    os_name: ubuntu
+    os_code_name: bionic
+    ignition_version: citadel
+    user_name: ignition
+    maintainer_name:
+    arch: amd64
+    type: distribution
+    version:
+    release: stable

--- a/ignition/create_dockerfiles.py
+++ b/ignition/create_dockerfiles.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import yaml
+
+try:
+    from cStringIO import StringIO
+except ImportError:
+    from io import StringIO
+from em import Interpreter
+
+from docker_templates.argparse import DockerfileArgParser
+from docker_templates.create import create_files
+from docker_templates.collections import OrderedLoad
+from docker_templates.packages import expandPackages
+
+def main(argv=sys.argv[1:]):
+    """Create Dockerfiles for images from platform and image yaml data"""
+
+    # Create the top-level parser
+    parser = DockerfileArgParser(
+        description="Generate the 'Dockerfile's for the base docker images")
+    parser.set()
+    args = parser.parse(argv)
+
+    # Read platform params
+    with open(args.platform, 'r') as f:
+        # use safe_load instead load
+        platform = yaml.safe_load(f)['platform']
+
+    # Read image params using platform params
+    images_yaml = StringIO()
+    try:
+        interpreter = Interpreter(output=images_yaml)
+        interpreter.file(open(args.images, 'r'), locals=platform)
+        images_yaml = images_yaml.getvalue()
+    except Exception as e:
+        print("Error processing %s" % args.images)
+        raise
+    finally:
+        interpreter.shutdown()
+        interpreter = None
+    # Use ordered dict
+    images = OrderedLoad(images_yaml, yaml.SafeLoader)['images']
+
+    # For each image tag
+    for image in images:
+
+        # Get data for image
+        data = dict(images[image])
+        data['tag_name'] = image
+
+        # Add platform params
+        data.update(platform)
+
+        # Apply package distro/version formatting
+        expandPackages(data)
+
+        # Get path to save Docker file
+        dockerfile_dir = os.path.join(args.output, image)
+        if not os.path.exists(dockerfile_dir):
+            os.makedirs(dockerfile_dir)
+        data['dockerfile_dir'] = dockerfile_dir
+
+        # generate Dockerfile
+        create_files(data)
+
+if __name__ == '__main__':
+    main()

--- a/ignition/create_dockerfolders.py
+++ b/ignition/create_dockerfolders.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+
+import sys
+import yaml
+
+import create_dockerfiles
+
+from docker_templates.argparse import DockerfolderArgParser
+from docker_templates.collections import OrderedLoad
+from docker_templates.folders import populate_paths
+
+
+def main(argv=sys.argv[1:]):
+    """Create Dockerfolders for images from manifest yaml data"""
+
+    # Create the top-level parser
+    parser = DockerfolderArgParser(
+        description="Generate the Dockerfolders for the base docker images")
+    parser.set()
+    args = parser.parse(argv)
+
+    # Read manifest params
+    with open(args.manifest, 'r') as f:
+        manifest = OrderedLoad(f, yaml.SafeLoader)
+
+    # Populate all paths from the manifest
+    populate_paths(manifest, args, create_dockerfiles)
+
+
+if __name__ == '__main__':
+    main()

--- a/ignition/create_dockerlibrary.py
+++ b/ignition/create_dockerlibrary.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+
+import git
+import os
+import sys
+import yaml
+
+import ros_buildfarm.templates
+
+from docker_templates.argparse import DockerlibraryArgParser
+from docker_templates.collections import OrderedLoad
+from docker_templates.create import expand_template_prefix_path, create_dockerlibrary
+from docker_templates.library import parse_manifest
+
+default_template_prefix_path = ros_buildfarm.templates.template_prefix_path
+PWD = os.path.dirname(os.path.abspath(__file__))
+
+
+def main(argv=sys.argv[1:]):
+    """Create Dockerlibrary for images from manifest yaml data"""
+
+    # Create the top-level parser
+    parser = DockerlibraryArgParser(
+        description="Generate the 'Dockerlibrary for the base docker images")
+    parser.set()
+    args = parser.parse(argv)
+
+    # Read manifest params
+    with open(args.manifest, 'r') as f:
+        manifest = OrderedLoad(f, yaml.SafeLoader)
+
+    # Create a git diff for the current repo
+    repo = git.Repo(os.path.join(PWD, '..'))  # , odbt=git.GitCmdObjectDB)
+
+    # Parse the manifest
+    repo_name = os.path.basename(PWD)
+    manifest = parse_manifest(manifest, repo, repo_name)
+
+    # Flattin manifest data
+    data = {**manifest, **manifest['meta']}
+
+    # Create Docker Library
+    template_name = data['template_name']
+    template_packages = data['template_packages']
+    expand_template_prefix_path(template_packages)
+    create_dockerlibrary(template_name, data, args.output)
+
+
+if __name__ == '__main__':
+    main()

--- a/ignition/ignition
+++ b/ignition/ignition
@@ -1,0 +1,14 @@
+Maintainers: Tully Foote <tfoote+buildfarm@osrfoundation.org> (@tfoote)
+GitRepo: https://github.com/osrf/docker_images.git
+
+################################################################################
+# Release: citadel
+
+########################################
+# Distro: ubuntu:bionic
+
+Tags: citadel-bionic
+Architectures: amd64
+GitCommit: 6b0f5c0ec8df509c23a939ac09701c59ac98f5b8
+Directory: ignition/citadel/ubuntu/bionic/ignition
+

--- a/ignition/ignition
+++ b/ignition/ignition
@@ -2,6 +2,18 @@ Maintainers: Tully Foote <tfoote+buildfarm@osrfoundation.org> (@tfoote)
 GitRepo: https://github.com/osrf/docker_images.git
 
 ################################################################################
+# Release: blueprint
+
+########################################
+# Distro: ubuntu:bionic
+
+Tags: blueprint-bionic
+Architectures: amd64
+GitCommit: 258016edbb73ee817a57e8fd5efa84d429fe8151
+Directory: ignition/blueprint/ubuntu/bionic/ignition
+
+
+################################################################################
 # Release: citadel
 
 ########################################

--- a/ignition/manifest.yaml
+++ b/ignition/manifest.yaml
@@ -1,0 +1,37 @@
+%YAML 1.1
+# Ignition Dockerfolder manifest
+---
+defaults:
+
+    default_hooks: &DEFAULT_HOOKS
+        hook_names:
+            post_push: .hooks/post_push.em
+
+    default: &DEFAULT
+        templates: &DEFAULT_TEMPLATES
+            images: .config/images.yaml.em
+            makefile: .config/Makefile.em
+            platform: .config/platform.yaml.em
+
+release_names:
+    'citadel':
+        eol: 2025-01-01
+        os_names:
+            ubuntu:
+                os_code_names:
+                    bionic:
+                        <<: *DEFAULT
+                        archs:
+                            - amd64
+                        tag_names:
+                            citadel:
+                                aliases:
+                                    - "$release_name-$os_code_name"
+
+meta:
+    maintainers:
+        - Tully Foote <tfoote+buildfarm@osrfoundation.org> (@tfoote)
+    template_name: docker_library/ignition.em
+    template_packages:
+        - docker_templates
+    repo_url: https://github.com/osrf/docker_images.git

--- a/ignition/manifest.yaml
+++ b/ignition/manifest.yaml
@@ -14,8 +14,21 @@ defaults:
             platform: .config/platform.yaml.em
 
 release_names:
+    'blueprint':
+        eol: 2020-09-01
+        os_names:
+            ubuntu:
+                os_code_names:
+                    bionic:
+                        <<: *DEFAULT
+                        archs:
+                            - amd64
+                        tag_names:
+                            ignition:
+                                aliases:
+                                    - "$release_name-$os_code_name"
     'citadel':
-        eol: 2025-01-01
+        eol: 2024-12-01
         os_names:
             ubuntu:
                 os_code_names:

--- a/ignition/manifest.yaml
+++ b/ignition/manifest.yaml
@@ -24,7 +24,7 @@ release_names:
                         archs:
                             - amd64
                         tag_names:
-                            citadel:
+                            ignition:
                                 aliases:
                                     - "$release_name-$os_code_name"
 


### PR DESCRIPTION
This PR along with https://github.com/osrf/docker_templates/pull/84 provide boilerplate to generate ignition docker files and dockerfiles for Ignition blueprint and citadel.
To be done before merging:
- addressing al open questions below
- opening PRs for repository and doc creation on dockerhub
- removing debug commits like https://github.com/osrf/docker_images/commit/8f11889e8990840d7b10056bf54cbb7af044ecfc

Open questions / remarks (ping @j-rivero @chapulina @ruffsl) :
- This PR includes an image for Blueprint: should we keep it or just provide images for the newer and LTS Citadel?
- Currently the container starts with `ign gazebo -s`:
  - this is headless so makes sense for an official image
  - doesnt run any actual simulation: ignition doesnt start with a default world (?)
  - do we want to launch an empty world instead ?
- hardcoded `gazebo` in the package URL `http://packages.osrfoundation.org/gazebo/$ID-stable`, will this be changed/mirrored to `ignition` or should we [hard code it](https://github.com/osrf/docker_templates/pull/84/files#diff-44d6052fa67c49b9e85f8f8276b5f64bR34) in [the templates](https://github.com/osrf/docker_templates/pull/84/files#diff-920ba209a0d7229a3390d3f41ea5c6fcR39) ?
- dependencies:
  - `ignition-citadel`and more precisely `libignition-launch2-dev` depends on both `ignition-gazebo2` and `libignition-gazebo3-dev` ?! Is it normal to depend on 2 different versions of Gazebo?
  - `ignition-citadel` depends on `libboost-all-dev` and a ton of `libignition-*-dev` packages. Is there another package I should install to have only the runtime libraries in the docker image? (The current `ignition-citadel` image is 1.46GB which is huge)