### PR TITLE
switch devel and nightly images to focal

### DIFF
--- a/ros2/nightly/nightly/Dockerfile
+++ b/ros2/nightly/nightly/Dockerfile
@@ -1,6 +1,6 @@
 # This is an auto generated Dockerfile for ros:nightly
 # generated from docker_images_ros2/nightly/create_ros_image.Dockerfile.em
-FROM ubuntu:bionic
+FROM ubuntu:focal
 
 # setup timezone
 RUN echo 'Etc/UTC' > /etc/timezone && \

--- a/ros2/nightly/platform.yaml
+++ b/ros2/nightly/platform.yaml
@@ -4,7 +4,6 @@
 platform:
     os_name: ubuntu
     os_code_name: focal
-    rosdistro_name: noetic
     ros2distro_name: foxy
     user_name: ros
     maintainer_name:

--- a/ros2/nightly/platform.yaml
+++ b/ros2/nightly/platform.yaml
@@ -3,8 +3,8 @@
 ---
 platform:
     os_name: ubuntu
-    os_code_name: bionic
-    rosdistro_name: melodic
+    os_code_name: focal
+    rosdistro_name: noetic
     ros2distro_name: foxy
     user_name: ros
     maintainer_name:

--- a/ros2/source/devel/Dockerfile
+++ b/ros2/source/devel/Dockerfile
@@ -1,6 +1,6 @@
 # This is an auto generated Dockerfile for ros2:devel
 # generated from docker_images_ros2/devel/create_ros_image.Dockerfile.em
-ARG FROM_IMAGE=ubuntu:bionic
+ARG FROM_IMAGE=ubuntu:focal
 FROM $FROM_IMAGE
 
 # setup timezone

--- a/ros2/source/platform.yaml
+++ b/ros2/source/platform.yaml
@@ -3,8 +3,8 @@
 ---
 platform:
     os_name: ubuntu
-    os_code_name: bionic
-    rosdistro_name: melodic
+    os_code_name: focal
+    rosdistro_name: noetic
     user_name: ros2
     maintainer_name:
     arch: amd64

--- a/ros2/source/platform.yaml
+++ b/ros2/source/platform.yaml
@@ -4,7 +4,6 @@
 platform:
     os_name: ubuntu
     os_code_name: focal
-    rosdistro_name: noetic
     user_name: ros2
     maintainer_name:
     arch: amd64


### PR DESCRIPTION
~~**DO NOT MERGE** until ros2 nightly archives are based on ubuntu focal~~

This does not update the source image. That one cannot be updated until the official foxy release or until a foxy-release tag is created on ros2/ros2 repository.

Question: should the `ros2:nightly` base image be made configurable via build arg like `ros2:devel`?
The only advantage is to be able to support various archive types. But at that point it's likely that some other change in the dockerfile would be necessary so making it a build arg doesn't bring that much