### PR TITLE
remove remnant cyclonedds key ignore

### DIFF
--- a/ros2/nightly/images.yaml.em
+++ b/ros2/nightly/images.yaml.em
@@ -35,7 +35,6 @@ images:
               - prereqs.yaml
             path: /opt/ros/$ROS_DISTRO/share
             skip_keys:
-                - cyclonedds
                 - libopensplice69
                 - rti-connext-dds-5.3.1
         ros2_binary_url: https://ci.ros2.org/view/packaging/job/packaging_linux/lastSuccessfulBuild/artifact/ws/ros2-package-linux-x86_64.tar.bz2

--- a/ros2/nightly/nightly/Dockerfile
+++ b/ros2/nightly/nightly/Dockerfile
@@ -95,7 +95,6 @@ RUN . /opt/ros/$ROS_DISTRO/setup.sh \
     --from-paths /opt/ros/$ROS_DISTRO/share \
     --ignore-src \
     --skip-keys " \
-      cyclonedds \
       libopensplice69 \
       rti-connext-dds-5.3.1" \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
it was forgotten in https://github.com/osrf/docker_images/pull/336