### PR TITLE
Opensplice cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,9 @@ List of tags available at https://hub.docker.com/r/osrf/ros2/tags
 
 - `nightly`
   - _Description:_
-    - includes pre-installed environment from nightly job on the build farm
+    - includes pre-installed environment from nightly job on the ci.ros2.org and pre-installed DDS implementations:
+      - Fast-RTPS (default)
+      - CycloneDDS
     - closely mimics the Official Library images as be interchangeable
   - _Purpose:_
     - intended for CI and testing against the latest nightly builds
@@ -115,8 +117,7 @@ List of tags available at https://hub.docker.com/r/osrf/ros2/tags
 - `nightly-rmw`
   - _Description:_
     - builds `FROM` `nightly` and installs open source libraries
-    - including non default vendors:
-      - Opensplice
+    - currently identical to `nightly`
   - _Purpose:_
     - intended for CI and testing against more rmw implementations
 - `nightly-rmw-nonfree`

--- a/ros2/nightly/images.yaml.em
+++ b/ros2/nightly/images.yaml.em
@@ -35,7 +35,6 @@ images:
               - prereqs.yaml
             path: /opt/ros/$ROS_DISTRO/share
             skip_keys:
-                - libopensplice69
                 - rti-connext-dds-5.3.1
         ros2_binary_url: https://ci.ros2.org/view/packaging/job/packaging_linux/lastSuccessfulBuild/artifact/ws/ros2-package-linux-x86_64.tar.bz2
     nightly-rmw:

--- a/ros2/nightly/nightly/Dockerfile
+++ b/ros2/nightly/nightly/Dockerfile
@@ -95,7 +95,6 @@ RUN . /opt/ros/$ROS_DISTRO/setup.sh \
     --from-paths /opt/ros/$ROS_DISTRO/share \
     --ignore-src \
     --skip-keys " \
-      libopensplice69 \
       rti-connext-dds-5.3.1" \
     && rm -rf /var/lib/apt/lists/*
 

--- a/ros2/source/images.yaml.em
+++ b/ros2/source/images.yaml.em
@@ -47,7 +47,7 @@ images:
             install:
                 - --from-paths src
                 - --ignore-src
-                - --skip-keys "console_bridge fastcdr fastrtps libopensplice67 libopensplice69 rti-connext-dds-5.3.1 urdfdom_headers"
+                - --skip-keys "console_bridge fastcdr fastrtps libopensplice69 rti-connext-dds-5.3.1 urdfdom_headers"
         vcs:
             imports:
                 repos:

--- a/ros2/source/source/Dockerfile
+++ b/ros2/source/source/Dockerfile
@@ -25,7 +25,7 @@ RUN wget https://raw.githubusercontent.com/ros2/ros2/$ROS_DISTRO-release/ros2.re
 RUN apt-get update && rosdep install -y \
     --from-paths src \
     --ignore-src \
-    --skip-keys "console_bridge fastcdr fastrtps libopensplice67 libopensplice69 rti-connext-dds-5.3.1 urdfdom_headers" \
+    --skip-keys "console_bridge fastcdr fastrtps libopensplice69 rti-connext-dds-5.3.1 urdfdom_headers" \
     && rm -rf /var/lib/apt/lists/*
 
 # build source


### PR DESCRIPTION
Remove references to libopensplice67 that is not used by any currently active ROS distro
Remove `libopensplice69` from nightly as recent and future nightlies don't include Opensplice anymore
Modifies README to reflect current state of images

Keeps `libopensplice69` in source image to be able to build still active ROS Distros Dashing and Eloquent