### PR TITLE
commit docker library only if there are changes

### DIFF
--- a/.ci/ci_script.py
+++ b/.ci/ci_script.py
@@ -195,11 +195,14 @@ def main(argv=sys.argv[1:]):
                 '--manifest', manifest,
                 '--output', output))
 
-            # Commit changes to Docker Library
-            repo.git.add(all=True)
-            message = "Updating Docker Library\n" + \
-                "This is an automated CI commit"
-            repo.git.commit(m=message)
+            # Check for changes to the Docker Library
+            library_diff = repo.index.diff(None, create_patch=True)
+            if library_diff != []:
+                # Commit changes to Docker Library
+                repo.git.add(all=True)
+                message = "Updating Docker Library\n" + \
+                    "This is an automated CI commit"
+                repo.git.commit(m=message)
 
             # Create new branch from current head
             pr_branch_head = repo.create_head(pr_branch_name)  # noqa


### PR DESCRIPTION
[CI failed last night](https://github.com/osrf/docker_images/runs/518016036) because some dockerfiles needed to be updated (ros1-bridge) but as the bridge image is not part of the official docker library there was nothing to commit library-wise.

This handles the case where the diff on the lib is null and make the bot open the PR with only the Dockerfile changes if library not impacted.

Example of test job printing: "Would create a PR titled ..." instead of actually opening the PR https://github.com/osrf/docker_images/runs/519280424