### PR TITLE
Added noetic dockerfiles for ubuntu focal

### DIFF
--- a/ros/noetic/ubuntu/focal/Makefile
+++ b/ros/noetic/ubuntu/focal/Makefile
@@ -1,0 +1,28 @@
+all: help
+
+help:
+	@echo ""
+	@echo "-- Help Menu"
+	@echo ""
+	@echo "   1. make build            - build all images"
+	@echo "   2. make pull             - pull all images"
+	@echo "   3. make clean            - remove all images"
+	@echo ""
+
+build:
+	@docker build --tag=ros:noetic-ros-core-focal          ros-core/.
+	@docker build --tag=ros:noetic-ros-base-focal          ros-base/.
+	@docker build --tag=ros:noetic-robot-focal             robot/.
+	@docker build --tag=ros:noetic-perception-focal        perception/.
+
+pull:
+	@docker pull ros:noetic-ros-core-focal
+	@docker pull ros:noetic-ros-base-focal
+	@docker pull ros:noetic-robot-focal
+	@docker pull ros:noetic-perception-focal
+
+clean:
+	@docker rmi -f ros:noetic-ros-core-focal
+	@docker rmi -f ros:noetic-ros-base-focal
+	@docker rmi -f ros:noetic-robot-focal
+	@docker rmi -f ros:noetic-perception-focal

--- a/ros/noetic/ubuntu/focal/images.yaml.em
+++ b/ros/noetic/ubuntu/focal/images.yaml.em
@@ -1,0 +1,37 @@
+%YAML 1.1
+# ROS Dockerfile database
+---
+images:
+    ros-core:
+        base_image: @(os_name):@(os_code_name)
+        maintainer_name: @(maintainer_name)
+        template_name: docker_images/create_ros_core_image.Dockerfile.em
+        entrypoint_name: docker_images/ros_entrypoint.sh
+        template_packages:
+            - docker_templates
+        ros_packages:
+            - ros-core
+      ros-base:
+          base_image: @(user_name):@(rosdistro_name)-ros-core-@(os_code_name)
+          maintainer_name: @(maintainer_name)
+          template_name: docker_images/create_ros_image.Dockerfile.em
+          template_packages:
+              - docker_templates
+          ros_packages:
+              - ros-base
+      robot:
+          base_image: @(user_name):@(rosdistro_name)-ros-base-@(os_code_name)
+          maintainer_name: @(maintainer_name)
+          template_name: docker_images/create_ros_image.Dockerfile.em
+          template_packages:
+              - docker_templates
+          ros_packages:
+              - robot
+      perception:
+          base_image: @(user_name):@(rosdistro_name)-ros-base-@(os_code_name)
+          maintainer_name: @(maintainer_name)
+          template_name: docker_images/create_ros_image.Dockerfile.em
+          template_packages:
+              - docker_templates
+          ros_packages:
+              - perception

--- a/ros/noetic/ubuntu/focal/perception/Dockerfile
+++ b/ros/noetic/ubuntu/focal/perception/Dockerfile
@@ -1,0 +1,8 @@
+# This is an auto generated Dockerfile for ros:perception
+# generated from docker_images/create_ros_image.Dockerfile.em
+FROM ros:noetic-ros-base-focal
+
+# install ros packages
+RUN apt-get update && apt-get install -y \
+    ros-noetic-perception \
+    && rm -rf /var/lib/apt/lists/*

--- a/ros/noetic/ubuntu/focal/platform.yaml
+++ b/ros/noetic/ubuntu/focal/platform.yaml
@@ -1,0 +1,14 @@
+%YAML 1.1
+# ROS Dockerfile database
+---
+platform:
+    os_name: ubuntu
+    os_code_name: focal
+    rosdistro_name: noetic
+    user_name: ros
+    maintainer_name:
+    arch: amd64
+    type: distribution
+    version:
+    release: ros
+    ros_version: 1

--- a/ros/noetic/ubuntu/focal/robot/Dockerfile
+++ b/ros/noetic/ubuntu/focal/robot/Dockerfile
@@ -1,0 +1,8 @@
+# This is an auto generated Dockerfile for ros:robot
+# generated from docker_images/create_ros_image.Dockerfile.em
+FROM ros:noetic-ros-base-focal
+
+# install ros packages
+RUN apt-get update && apt-get install -y \
+    ros-focal-robot \
+    && rm -rf /var/lib/apt/lists/*

--- a/ros/noetic/ubuntu/focal/ros-base/Dockerfile
+++ b/ros/noetic/ubuntu/focal/ros-base/Dockerfile
@@ -1,0 +1,8 @@
+# This is an auto generated Dockerfile for ros:ros-base
+# generated from docker_images/create_ros_image.Dockerfile.em
+FROM ros:noetic-ros-core-focal
+
+# install ros packages
+RUN apt-get update && apt-get install -y \
+    ros-noetic-ros-base \
+    && rm -rf /var/lib/apt/lists/*

--- a/ros/noetic/ubuntu/focal/ros-core/Dockerfile
+++ b/ros/noetic/ubuntu/focal/ros-core/Dockerfile
@@ -1,0 +1,48 @@
+# This is an auto generated Dockerfile for ros:ros-core
+# generated from docker_images/create_ros_core_image.Dockerfile.em
+FROM ubuntu:focal
+
+# setup timezone
+RUN echo 'Etc/UTC' > /etc/timezone && \
+    ln -s /usr/share/zoneinfo/Etc/UTC /etc/localtime && \
+    apt-get update && apt-get install -q -y tzdata && rm -rf /var/lib/apt/lists/*
+
+# install packages
+RUN apt-get update && apt-get install -q -y \
+    dirmngr \
+    gnupg2 \
+    && rm -rf /var/lib/apt/lists/*
+
+# setup keys
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
+
+# setup sources.list
+RUN echo "deb http://repositories.ros.org/ubuntu/testing focal main" > /etc/apt/sources.list.d/ros1-latest.list
+RUN echo "deb http://packages.ros.org/ros/ubuntu bionic main" > /etc/apt/sources.list.d/ros1-latest.list
+
+# install bootstrap tools
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    python3-rosdep \
+    python3-rosinstall \
+    python3-vcstools \
+    && rm -rf /var/lib/apt/lists/*
+
+# setup environment
+ENV LANG C.UTF-8
+ENV LC_ALL C.UTF-8
+
+ENV ROS_DISTRO noetic
+# bootstrap rosdep
+RUN rosdep init && \
+  rosdep update --rosdistro $ROS_DISTRO
+
+# install ros packages
+RUN apt-get update && apt-get install -y \
+    ros-noetic-ros-core \
+    && rm -rf /var/lib/apt/lists/*
+
+# setup entrypoint
+COPY ./ros_entrypoint.sh /
+
+ENTRYPOINT ["/ros_entrypoint.sh"]
+CMD ["bash"]

--- a/ros/noetic/ubuntu/focal/ros-core/ros_entrypoint.sh
+++ b/ros/noetic/ubuntu/focal/ros-core/ros_entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+# setup ros environment
+source "/opt/ros/$ROS_DISTRO/setup.bash"
+exec "$@"


### PR DESCRIPTION
we need to create the noetic dockerfiles to support some CI jobs (for example in the perception pipeline: https://github.com/ros-perception/image_pipeline/pull/507).

Meta packages such as: `ros-noetic-ros-core`, `ros-noetic-ros-base`, etc are not created yet. Fow now it's not possible to build these dockerfiles.

Signed-off-by: ahcorde <ahcorde@gmail.com>