### PR TITLE
Foxy images

### DIFF
--- a/ros/foxy/ubuntu/focal/Makefile
+++ b/ros/foxy/ubuntu/focal/Makefile
@@ -1,0 +1,28 @@
+all: help
+
+help:
+	@echo ""
+	@echo "-- Help Menu"
+	@echo ""
+	@echo "   1. make build            - build all images"
+	@echo "   2. make pull             - pull all images"
+	@echo "   3. make clean            - remove all images"
+	@echo ""
+
+build:
+	@docker build --tag=ros:foxy-ros-core-focal			ros-core/.
+	@docker build --tag=ros:foxy-ros-base-focal			ros-base/.
+	# @docker build --tag=osrf/ros:foxy-desktop-focal			desktop/.
+	# @docker build --tag=osrf/ros:foxy-ros1-bridge-focal			ros1-bridge/.
+
+pull:
+	@docker pull ros:foxy-ros-core-focal
+	@docker pull ros:foxy-ros-base-focal
+	# @docker pull osrf/ros:foxy-desktop-focal
+	# @docker pull osrf/ros:foxy-ros1-bridge-focal
+
+clean:
+	@docker rmi -f ros:foxy-ros-core-focal
+	@docker rmi -f ros:foxy-ros-base-focal
+	# @docker rmi -f osrf/ros:foxy-desktop-focal
+	# @docker rmi -f osrf/ros:foxy-ros1-bridge-focal

--- a/ros/foxy/ubuntu/focal/desktop/Dockerfile
+++ b/ros/foxy/ubuntu/focal/desktop/Dockerfile
@@ -1,0 +1,9 @@
+# This is an auto generated Dockerfile for ros:desktop
+# generated from docker_images_ros2/create_ros_image.Dockerfile.em
+FROM ros:foxy-ros-base-focal
+
+# install ros2 packages
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ros-foxy-desktop=0.9.1-1* \
+    && rm -rf /var/lib/apt/lists/*
+

--- a/ros/foxy/ubuntu/focal/desktop/hooks/post_push
+++ b/ros/foxy/ubuntu/focal/desktop/hooks/post_push
@@ -1,0 +1,14 @@
+#!/bin/bash
+# http://windsock.io/automated-docker-image-builds-with-multiple-tags/
+
+set -e
+
+# Parse image name for repo name
+tagStart=$(expr index "$IMAGE_NAME" :)
+repoName=${IMAGE_NAME:0:tagStart-1}
+
+# Tag and push image for each additional tag
+for tag in foxy-desktop; do
+    docker tag $IMAGE_NAME ${repoName}:${tag}
+    docker push ${repoName}:${tag}
+done

--- a/ros/foxy/ubuntu/focal/images.yaml.em
+++ b/ros/foxy/ubuntu/focal/images.yaml.em
@@ -1,0 +1,45 @@
+%YAML 1.1
+# ROS2 Dockerfile database
+---
+images:
+    ros-core:
+        base_image: @(os_name):@(os_code_name)
+        maintainer_name: @(maintainer_name)
+        template_name: docker_images_ros2/create_ros_core_image.Dockerfile.em
+        entrypoint_name: docker_images_ros2/ros_entrypoint.sh
+        template_packages:
+            - docker_templates
+        ros2_packages:
+            - ros-core
+    ros-base:
+        base_image: @(user_name):@(ros2distro_name)-ros-core-@(os_code_name)
+        maintainer_name: @(maintainer_name)
+        template_name: docker_images_ros2/create_ros_image.Dockerfile.em
+        template_packages:
+            - docker_templates
+        ros2_packages:
+            - ros-base
+        bootstrap_ros_tools:
+    desktop:
+        base_image: @(user_name):@(ros2distro_name)-ros-base-@(os_code_name)
+        maintainer_name: @(maintainer_name)
+        template_name: docker_images_ros2/create_ros_image.Dockerfile.em
+        template_packages:
+            - docker_templates
+        ros2_packages:
+            - desktop
+    ros1-bridge:
+        base_image: @(user_name):@(ros2distro_name)-ros-base-@(os_code_name)
+        maintainer_name: @(maintainer_name)
+        template_name: docker_images_ros2/ros1_bridge/create_ros_ros1_bridge_image.Dockerfile.em
+        entrypoint_name: docker_images_ros2/ros1_bridge/ros_entrypoint.sh
+        template_packages:
+            - docker_templates
+        ros2_packages:
+            - ros1-bridge
+            - demo-nodes-cpp
+            - demo-nodes-py
+        ros_packages:
+            - ros-comm
+            - roscpp-tutorials
+            - rospy-tutorials

--- a/ros/foxy/ubuntu/focal/platform.yaml
+++ b/ros/foxy/ubuntu/focal/platform.yaml
@@ -1,0 +1,14 @@
+%YAML 1.1
+# ROS2 Dockerfile database
+---
+platform:
+    os_name: ubuntu
+    os_code_name: focal
+    rosdistro_name: noetic
+    ros2distro_name: foxy
+    user_name: ros
+    maintainer_name:
+    arch: amd64
+    type: distribution
+    version:
+    ros_version: 2

--- a/ros/foxy/ubuntu/focal/ros-base/Dockerfile
+++ b/ros/foxy/ubuntu/focal/ros-base/Dockerfile
@@ -1,0 +1,31 @@
+# This is an auto generated Dockerfile for ros:ros-base
+# generated from docker_images_ros2/create_ros_image.Dockerfile.em
+FROM ros:foxy-ros-core-focal
+
+# install bootstrap tools
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    build-essential \
+    git \
+    python3-colcon-common-extensions \
+    python3-colcon-mixin \
+    python3-rosdep \
+    python3-vcstool \
+    && rm -rf /var/lib/apt/lists/*
+
+# bootstrap rosdep
+RUN rosdep init && \
+  rosdep update --rosdistro $ROS_DISTRO
+
+# setup colcon mixin and metadata
+RUN colcon mixin add default \
+      https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml && \
+    colcon mixin update && \
+    colcon metadata add default \
+      https://raw.githubusercontent.com/colcon/colcon-metadata-repository/master/index.yaml && \
+    colcon metadata update
+
+# install ros2 packages
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ros-foxy-ros-base=0.9.1-1* \
+    && rm -rf /var/lib/apt/lists/*
+

--- a/ros/foxy/ubuntu/focal/ros-core/Dockerfile
+++ b/ros/foxy/ubuntu/focal/ros-core/Dockerfile
@@ -1,0 +1,39 @@
+# This is an auto generated Dockerfile for ros:ros-core
+# generated from docker_images_ros2/create_ros_core_image.Dockerfile.em
+FROM ubuntu:focal
+
+# setup timezone
+RUN echo 'Etc/UTC' > /etc/timezone && \
+    ln -s /usr/share/zoneinfo/Etc/UTC /etc/localtime && \
+    apt-get update && \
+    apt-get install -q -y --no-install-recommends tzdata && \
+    rm -rf /var/lib/apt/lists/*
+
+# install packages
+RUN apt-get update && apt-get install -q -y --no-install-recommends \
+    dirmngr \
+    gnupg2 \
+    && rm -rf /var/lib/apt/lists/*
+
+# setup keys
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
+
+# setup sources.list
+RUN echo "deb http://packages.ros.org/ros2/ubuntu focal main" > /etc/apt/sources.list.d/ros2-latest.list
+
+# setup environment
+ENV LANG C.UTF-8
+ENV LC_ALL C.UTF-8
+
+ENV ROS_DISTRO foxy
+
+# install ros2 packages
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ros-foxy-ros-core=0.9.1-1* \
+    && rm -rf /var/lib/apt/lists/*
+
+# setup entrypoint
+COPY ./ros_entrypoint.sh /
+
+ENTRYPOINT ["/ros_entrypoint.sh"]
+CMD ["bash"]

--- a/ros/foxy/ubuntu/focal/ros-core/ros_entrypoint.sh
+++ b/ros/foxy/ubuntu/focal/ros-core/ros_entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+# setup ros2 environment
+source "/opt/ros/$ROS_DISTRO/setup.bash"
+exec "$@"

--- a/ros/foxy/ubuntu/focal/ros1-bridge/Dockerfile
+++ b/ros/foxy/ubuntu/focal/ros1-bridge/Dockerfile
@@ -1,0 +1,29 @@
+# This is an auto generated Dockerfile for ros:ros1-bridge
+# generated from docker_images_ros2/ros1_bridge/create_ros_ros1_bridge_image.Dockerfile.em
+FROM ros:foxy-ros-base-focal
+
+# setup keys
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
+
+# setup sources.list
+RUN echo "deb http://packages.ros.org/ros/ubuntu focal main" > /etc/apt/sources.list.d/ros1-latest.list
+
+ENV ROS1_DISTRO noetic
+ENV ROS2_DISTRO foxy
+# install ros packages
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ros-noetic-ros-comm=1.15.7-1* \
+    ros-noetic-roscpp-tutorials=0.10.1-1* \
+    ros-noetic-rospy-tutorials=0.10.1-1* \
+    && rm -rf /var/lib/apt/lists/*
+
+# install ros2 packages
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ros-foxy-ros1-bridge=0.9.2-1* \
+    ros-foxy-demo-nodes-cpp=0.9.3-1* \
+    ros-foxy-demo-nodes-py=0.9.3-1* \
+    && rm -rf /var/lib/apt/lists/*
+
+# setup entrypoint
+COPY ./ros_entrypoint.sh /
+

--- a/ros/foxy/ubuntu/focal/ros1-bridge/hooks/post_push
+++ b/ros/foxy/ubuntu/focal/ros1-bridge/hooks/post_push
@@ -1,0 +1,14 @@
+#!/bin/bash
+# http://windsock.io/automated-docker-image-builds-with-multiple-tags/
+
+set -e
+
+# Parse image name for repo name
+tagStart=$(expr index "$IMAGE_NAME" :)
+repoName=${IMAGE_NAME:0:tagStart-1}
+
+# Tag and push image for each additional tag
+for tag in foxy-ros1-bridge; do
+    docker tag $IMAGE_NAME ${repoName}:${tag}
+    docker push ${repoName}:${tag}
+done

--- a/ros/foxy/ubuntu/focal/ros1-bridge/ros_entrypoint.sh
+++ b/ros/foxy/ubuntu/focal/ros1-bridge/ros_entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+# unsetting ROS_DISTRO to silence ROS_DISTRO override warning
+unset ROS_DISTRO
+# setup ros1 environment
+source "/opt/ros/$ROS1_DISTRO/setup.bash"
+
+# unsetting ROS_DISTRO to silence ROS_DISTRO override warning
+unset ROS_DISTRO
+# setup ros2 environment
+source "/opt/ros/$ROS2_DISTRO/setup.bash"
+
+exec "$@"

--- a/ros/manifest.yaml
+++ b/ros/manifest.yaml
@@ -298,7 +298,6 @@ release_names:
                                     - "$release_name-ros-base"
                                     - "$release_name-ros-base-$os_code_name"
                                     - "$release_name"
-                                    - latest
                             robot:
                                 aliases:
                                     - "$release_name-robot"
@@ -486,6 +485,29 @@ release_names:
                                     - "$release_name-ros-base"
                                     - "$release_name-ros-base-$os_code_name"
                                     - "$release_name"
+    foxy:
+        eol: 2025-05
+        os_names:
+            ubuntu:
+                os_code_names:
+                    focal:
+                        rosdistro_name: noetic
+                        <<: *DEFAULT_ROS2
+                        archs:
+                            - amd64
+                            - arm32v7
+                            - arm64v8
+                        tag_names:
+                            ros-core:
+                                aliases:
+                                    - "$release_name-ros-core"
+                                    - "$release_name-ros-core-$os_code_name"
+                            ros-base:
+                                aliases:
+                                    - "$release_name-ros-base"
+                                    - "$release_name-ros-base-$os_code_name"
+                                    - "$release_name"
+                                    - latest
 meta:
     maintainers:
         - Tully Foote <tfoote+buildfarm@osrfoundation.org> (@tfoote)
@@ -663,6 +685,16 @@ hacks:
             ubuntu:
                 os_code_names:
                     bionic:
+                        tag_names:
+                            desktop:
+                                <<: *DEFAULT_HOOKS
+                            ros1-bridge:
+                                <<: *DEFAULT_HOOKS
+    foxy:
+        os_names:
+            ubuntu:
+                os_code_names:
+                    focal:
                         tag_names:
                             desktop:
                                 <<: *DEFAULT_HOOKS

--- a/ros/manifest.yaml
+++ b/ros/manifest.yaml
@@ -495,7 +495,6 @@ release_names:
                         <<: *DEFAULT_ROS2
                         archs:
                             - amd64
-                            - arm32v7
                             - arm64v8
                         tag_names:
                             ros-core:

--- a/ros/ros
+++ b/ros/ros
@@ -39,7 +39,7 @@ Architectures: amd64, arm32v7, arm64v8
 GitCommit: 0b33e61b5bbed5b93b9fba2d5bae5db604ff9b58
 Directory: ros/melodic/ubuntu/bionic/ros-core
 
-Tags: melodic-ros-base, melodic-ros-base-bionic, melodic, latest
+Tags: melodic-ros-base, melodic-ros-base-bionic, melodic
 Architectures: amd64, arm32v7, arm64v8
 GitCommit: 0b33e61b5bbed5b93b9fba2d5bae5db604ff9b58
 Directory: ros/melodic/ubuntu/bionic/ros-base
@@ -160,4 +160,21 @@ Tags: eloquent-ros-base, eloquent-ros-base-bionic, eloquent
 Architectures: amd64, arm32v7, arm64v8
 GitCommit: 0b33e61b5bbed5b93b9fba2d5bae5db604ff9b58
 Directory: ros/eloquent/ubuntu/bionic/ros-base
+
+
+################################################################################
+# Release: foxy
+
+########################################
+# Distro: ubuntu:focal
+
+Tags: foxy-ros-core, foxy-ros-core-focal
+Architectures: amd64, arm64v8
+GitCommit: 03c81bdfa9d3b185ac009d9a8ecea26ccd85e179
+Directory: ros/foxy/ubuntu/focal/ros-core
+
+Tags: foxy-ros-base, foxy-ros-base-focal, foxy, latest
+Architectures: amd64, arm64v8
+GitCommit: 03c81bdfa9d3b185ac009d9a8ecea26ccd85e179
+Directory: ros/foxy/ubuntu/focal/ros-base
 


### PR DESCRIPTION
Opening for visibility, this is on hold until the beta releases of Noetic and Foxy are out. From there we'll need to generate the dockerfiles associated to this manifest change

Note: this point the `ros:latest` tag to Foxy according to https://github.com/osrf/docker_images/issues/286. Documentation will need to be updated accordingly

Edit: Noetic images have been released in a separate PR https://github.com/osrf/docker_images/pull/405