### PR TITLE
revert no-install-recommends on ros2 daily images

### DIFF
--- a/ros2/nightly/nightly/Dockerfile
+++ b/ros2/nightly/nightly/Dockerfile
@@ -5,12 +5,10 @@ FROM ubuntu:focal
 # setup timezone
 RUN echo 'Etc/UTC' > /etc/timezone && \
     ln -s /usr/share/zoneinfo/Etc/UTC /etc/localtime && \
-    apt-get update && \
-    apt-get install -q -y --no-install-recommends tzdata && \
-    rm -rf /var/lib/apt/lists/*
+    apt-get update && apt-get install -q -y tzdata && rm -rf /var/lib/apt/lists/*
 
 # install packages
-RUN apt-get update && apt-get install -q -y --no-install-recommends \
+RUN apt-get update && apt-get install -q -y \
     bash-completion \
     cmake \
     dirmngr \
@@ -29,7 +27,6 @@ RUN echo "deb http://packages.ros.org/ros2-testing/ubuntu `lsb_release -sc` main
 
 # install bootstrap tools
 RUN apt-get update && apt-get install --no-install-recommends -y \
-    build-essential \
     git \
     python3-colcon-common-extensions \
     python3-colcon-mixin \

--- a/ros2/source/devel/Dockerfile
+++ b/ros2/source/devel/Dockerfile
@@ -6,12 +6,10 @@ FROM $FROM_IMAGE
 # setup timezone
 RUN echo 'Etc/UTC' > /etc/timezone && \
     ln -s /usr/share/zoneinfo/Etc/UTC /etc/localtime && \
-    apt-get update && \
-    apt-get install -q -y --no-install-recommends tzdata && \
-    rm -rf /var/lib/apt/lists/*
+    apt-get update && apt-get install -q -y tzdata && rm -rf /var/lib/apt/lists/*
 
 # install packages
-RUN apt-get update && apt-get install -q -y --no-install-recommends \
+RUN apt-get update && apt-get install -q -y \
     bash-completion \
     dirmngr \
     gnupg2 \
@@ -31,7 +29,6 @@ ENV LC_ALL C.UTF-8
 
 # install bootstrap tools
 RUN apt-get update && apt-get install --no-install-recommends -y \
-    build-essential \
     git \
     python3-colcon-common-extensions \
     python3-colcon-mixin \

--- a/ros2/source/source/Dockerfile
+++ b/ros2/source/source/Dockerfile
@@ -5,7 +5,7 @@ ARG FROM_IMAGE=osrf/ros2:devel
 FROM $FROM_IMAGE
 
 # install packages
-RUN apt-get update && apt-get install -q -y --no-install-recommends \
+RUN apt-get update && apt-get install -q -y \
     libasio-dev \
     libtinyxml2-dev \
     wget \


### PR DESCRIPTION
This reverts temporarily the part of https://github.com/osrf/docker_images/pull/357 applying to the ros2 devel, source and nightly images.

Currently some overlays would fail to build because of
https://github.com/ros-infrastructure/rosdep/issues/752

(Will fail CI because not matching the templates anymore)

Signed-off-by: Mikael Arguedas <mikael.arguedas@gmail.com>