### PR TITLE
dont pass distro to rosdep when using empty index

### DIFF
--- a/ros2/nightly/nightly-rmw-nonfree/Dockerfile
+++ b/ros2/nightly/nightly-rmw-nonfree/Dockerfile
@@ -5,7 +5,7 @@ FROM osrf/ros2:nightly-rmw
 ENV RTI_NC_LICENSE_ACCEPTED yes
 
 # bootstrap rosdep
-RUN rosdep update --rosdistro $ROS_DISTRO
+RUN rosdep update
 
 # install dependencies
 RUN . /opt/ros/$ROS_DISTRO/setup.sh \

--- a/ros2/nightly/nightly-rmw/Dockerfile
+++ b/ros2/nightly/nightly-rmw/Dockerfile
@@ -3,7 +3,7 @@
 FROM osrf/ros2:nightly
 
 # bootstrap rosdep
-RUN rosdep update --rosdistro $ROS_DISTRO
+RUN rosdep update
 
 # install dependencies
 RUN . /opt/ros/$ROS_DISTRO/setup.sh \

--- a/ros2/nightly/nightly/Dockerfile
+++ b/ros2/nightly/nightly/Dockerfile
@@ -89,7 +89,7 @@ COPY prereqs.yaml /etc/ros/rosdep/
 RUN echo "yaml file:///etc/ros/rosdep/prereqs.yaml" | \
     cat - /etc/ros/rosdep/sources.list.d/20-default.list > temp && \
     mv temp /etc/ros/rosdep/sources.list.d/20-default.list
-RUN rosdep update --rosdistro $ROS_DISTRO
+RUN rosdep update
 
 # install dependencies
 RUN . /opt/ros/$ROS_DISTRO/setup.sh \


### PR DESCRIPTION
This fixes the build of nightly images.

Context at https://github.com/osrf/docker_templates/pull/85#issue-400115397