### PR TITLE
install libssl-dev in nightly images

### DIFF
--- a/ros2/nightly/images.yaml.em
+++ b/ros2/nightly/images.yaml.em
@@ -11,6 +11,7 @@ images:
             - docker_templates
         upstream_packages:
             - bash-completion
+            - libssl-dev
         env_before:
           LANG:   "C.UTF-8"
           LC_ALL: "C.UTF-8"

--- a/ros2/nightly/nightly/Dockerfile
+++ b/ros2/nightly/nightly/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update && apt-get install -q -y \
     dirmngr \
     git \
     gnupg2 \
+    libssl-dev \
     lsb-release \
     python3-pip \
     wget \


### PR DESCRIPTION
Fast-RTPS exports a dependency on OpenSSL, so we need the dev
package to be able to build packages on top.

Signed-off-by: Mikael Arguedas <mikael.arguedas@gmail.com>