### PR TITLE
Gazebo tag fix

### DIFF
--- a/gazebo/gazebo
+++ b/gazebo/gazebo
@@ -84,12 +84,12 @@ Directory: gazebo/10/ubuntu/bionic/libgazebo10
 ########################################
 # Distro: ubuntu:bionic
 
-Tags: gzserver11, gzserver11-bionic
+Tags: gzserver11-bionic
 Architectures: amd64
 GitCommit: 6f18102d57b424ce454f61e4ac432e3d6d71f670
 Directory: gazebo/11/ubuntu/bionic/gzserver11
 
-Tags: libgazebo11, libgazebo11-bionic
+Tags: libgazebo11-bionic
 Architectures: amd64
 GitCommit: 6f18102d57b424ce454f61e4ac432e3d6d71f670
 Directory: gazebo/11/ubuntu/bionic/libgazebo11

--- a/gazebo/manifest.yaml
+++ b/gazebo/manifest.yaml
@@ -177,11 +177,9 @@ release_names:
                         tag_names:
                             gzserver11:
                                 aliases:
-                                    - "gzserver$release_name"
                                     - "gzserver$release_name-$os_code_name"
                             libgazebo11:
                                 aliases:
-                                    - "libgazebo$release_name"
                                     - "libgazebo$release_name-$os_code_name"
                     focal:
                         <<: *DEFAULT


### PR DESCRIPTION
In #402 the `latest` tag was moved accordingly but the  `gzserver11`, `libgazebo11` were defined for both bionic and focal.

Here we remove the `bionic` ones for that these tags point to `focal` like `latest` does