### PR TITLE
Create Noetic dockerfiles

### DIFF
--- a/.github/workflows/ros_ci.yaml
+++ b/.github/workflows/ros_ci.yaml
@@ -8,6 +8,7 @@ on:
     - '.github/workflows/ros_ci.yaml'
     - 'ros/eloquent/**'
     - 'ros/dashing/**'
+    - 'ros/noetic/**'
     - 'ros/melodic/**'
     - 'ros/kinetic/**'
   push:
@@ -16,6 +17,7 @@ on:
     - '.github/workflows/ros_ci.yaml'
     - 'ros/eloquent/**'
     - 'ros/dashing/**'
+    - 'ros/noetic/**'
     - 'ros/melodic/**'
     - 'ros/kinetic/**'
   schedule:
@@ -29,6 +31,8 @@ jobs:
         env:
           - {HUB_REPO: ros, HUB_RELEASE: eloquent, HUB_OS_NAME: ubuntu, HUB_OS_CODE_NAME: bionic}
           - {HUB_REPO: ros, HUB_RELEASE: dashing, HUB_OS_NAME: ubuntu, HUB_OS_CODE_NAME: bionic}
+          - {HUB_REPO: ros, HUB_RELEASE: noetic, HUB_OS_NAME: ubuntu, HUB_OS_CODE_NAME: focal}
+          - {HUB_REPO: ros, HUB_RELEASE: noetic, HUB_OS_NAME: debian, HUB_OS_CODE_NAME: buster}
           - {HUB_REPO: ros, HUB_RELEASE: melodic, HUB_OS_NAME: ubuntu, HUB_OS_CODE_NAME: bionic}
           - {HUB_REPO: ros, HUB_RELEASE: melodic, HUB_OS_NAME: debian, HUB_OS_CODE_NAME: stretch}
           - {HUB_REPO: ros, HUB_RELEASE: kinetic, HUB_OS_NAME: ubuntu, HUB_OS_CODE_NAME: xenial}

--- a/.github/workflows/ros_ci.yaml
+++ b/.github/workflows/ros_ci.yaml
@@ -8,7 +8,7 @@ on:
     - '.github/workflows/ros_ci.yaml'
     - 'ros/eloquent/**'
     - 'ros/dashing/**'
-    - 'ros/noetic/**'
+    # - 'ros/noetic/**'
     - 'ros/melodic/**'
     - 'ros/kinetic/**'
   push:
@@ -17,7 +17,7 @@ on:
     - '.github/workflows/ros_ci.yaml'
     - 'ros/eloquent/**'
     - 'ros/dashing/**'
-    - 'ros/noetic/**'
+    # - 'ros/noetic/**'
     - 'ros/melodic/**'
     - 'ros/kinetic/**'
   schedule:
@@ -31,8 +31,8 @@ jobs:
         env:
           - {HUB_REPO: ros, HUB_RELEASE: eloquent, HUB_OS_NAME: ubuntu, HUB_OS_CODE_NAME: bionic}
           - {HUB_REPO: ros, HUB_RELEASE: dashing, HUB_OS_NAME: ubuntu, HUB_OS_CODE_NAME: bionic}
-          - {HUB_REPO: ros, HUB_RELEASE: noetic, HUB_OS_NAME: ubuntu, HUB_OS_CODE_NAME: focal}
-          - {HUB_REPO: ros, HUB_RELEASE: noetic, HUB_OS_NAME: debian, HUB_OS_CODE_NAME: buster}
+          # - {HUB_REPO: ros, HUB_RELEASE: noetic, HUB_OS_NAME: ubuntu, HUB_OS_CODE_NAME: focal}
+          # - {HUB_REPO: ros, HUB_RELEASE: noetic, HUB_OS_NAME: debian, HUB_OS_CODE_NAME: buster}
           - {HUB_REPO: ros, HUB_RELEASE: melodic, HUB_OS_NAME: ubuntu, HUB_OS_CODE_NAME: bionic}
           - {HUB_REPO: ros, HUB_RELEASE: melodic, HUB_OS_NAME: debian, HUB_OS_CODE_NAME: stretch}
           - {HUB_REPO: ros, HUB_RELEASE: kinetic, HUB_OS_NAME: ubuntu, HUB_OS_CODE_NAME: xenial}

--- a/ros/manifest.yaml
+++ b/ros/manifest.yaml
@@ -327,6 +327,55 @@ release_names:
                             perception:
                                 aliases:
                                     - "$release_name-perception-$os_code_name"
+    noetic:
+        eol: 2025-05
+        os_names:
+            ubuntu:
+                os_code_names:
+                    focal:
+                        <<: *DEFAULT_ROS1
+                        archs:
+                            - amd64
+                            - arm32v7
+                            - arm64v8
+                        tag_names:
+                            ros-core:
+                                aliases:
+                                    - "$release_name-ros-core"
+                                    - "$release_name-ros-core-$os_code_name"
+                            ros-base:
+                                aliases:
+                                    - "$release_name-ros-base"
+                                    - "$release_name-ros-base-$os_code_name"
+                                    - "$release_name"
+                            robot:
+                                aliases:
+                                    - "$release_name-robot"
+                                    - "$release_name-robot-$os_code_name"
+                            perception:
+                                aliases:
+                                    - "$release_name-perception"
+                                    - "$release_name-perception-$os_code_name"
+            debian:
+                os_code_names:
+                    buster:
+                        <<: *DEFAULT_ROS1
+                        archs:
+                            - amd64
+                            - arm64v8
+                        tag_names:
+                            ros-core:
+                                aliases:
+                                    - "$release_name-ros-core-$os_code_name"
+                            ros-base:
+                                aliases:
+                                    - "$release_name-ros-base-$os_code_name"
+                            robot:
+                                aliases:
+                                    - "$release_name-robot-$os_code_name"
+                            perception:
+                                aliases:
+                                    - "$release_name-perception-$os_code_name"
     ardent:
         eol: 2018-12
         os_names:
@@ -551,6 +600,16 @@ hacks:
             ubuntu:
                 os_code_names:
                     bionic:
+                        tag_names:
+                            desktop:
+                                <<: *DEFAULT_HOOKS
+                            desktop-full:
+                                <<: *DEFAULT_HOOKS
+    noetic:
+        os_names:
+            ubuntu:
+                os_code_names:
+                    focal:
                         tag_names:
                             desktop:
                                 <<: *DEFAULT_HOOKS

--- a/ros/noetic/debian/buster/Makefile
+++ b/ros/noetic/debian/buster/Makefile
@@ -1,0 +1,34 @@
+all: help
+
+help:
+	@echo ""
+	@echo "-- Help Menu"
+	@echo ""
+	@echo "   1. make build            - build all images"
+	@echo "   2. make pull             - pull all images"
+	@echo "   3. make clean            - remove all images"
+	@echo ""
+
+build:
+	@docker build --tag=ros:noetic-ros-core-buster          ros-core/.
+	@docker build --tag=ros:noetic-ros-base-buster          ros-base/.
+	@docker build --tag=ros:noetic-robot-buster             robot/.
+	@docker build --tag=ros:noetic-perception-buster        perception/.
+	# @docker build --tag=osrf/ros:noetic-desktop-buster      desktop/.
+	# @docker build --tag=osrf/ros:noetic-desktop-full-buster desktop-full/.
+
+pull:
+	@docker pull ros:noetic-ros-core-buster
+	@docker pull ros:noetic-ros-base-buster
+	@docker pull ros:noetic-robot-buster
+	@docker pull ros:noetic-perception-buster
+	# @docker pull osrf/ros:noetic-desktop-buster
+	# @docker pull osrf/ros:noetic-desktop-full-buster
+
+clean:
+	@docker rmi -f ros:noetic-ros-core-buster
+	@docker rmi -f ros:noetic-ros-base-buster
+	@docker rmi -f ros:noetic-robot-buster
+	@docker rmi -f ros:noetic-perception-buster
+	# @docker rmi -f osrf/ros:noetic-desktop-buster
+	# @docker rmi -f osrf/ros:noetic-desktop-full-buster

--- a/ros/noetic/debian/buster/desktop-full/Dockerfile
+++ b/ros/noetic/debian/buster/desktop-full/Dockerfile
@@ -1,0 +1,9 @@
+# This is an auto generated Dockerfile for ros:desktop-full
+# generated from docker_images/create_ros_image.Dockerfile.em
+FROM osrf/ros:noetic-desktop-buster
+
+# install ros packages
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ros-noetic-desktop-full=1.5.0-1* \
+    && rm -rf /var/lib/apt/lists/*
+

--- a/ros/noetic/debian/buster/desktop/Dockerfile
+++ b/ros/noetic/debian/buster/desktop/Dockerfile
@@ -1,0 +1,9 @@
+# This is an auto generated Dockerfile for ros:desktop
+# generated from docker_images/create_ros_image.Dockerfile.em
+FROM ros:noetic-robot-buster
+
+# install ros packages
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ros-noetic-desktop=1.5.0-1* \
+    && rm -rf /var/lib/apt/lists/*
+

--- a/ros/noetic/debian/buster/images.yaml.em
+++ b/ros/noetic/debian/buster/images.yaml.em
@@ -1,0 +1,54 @@
+%YAML 1.1
+# ROS Dockerfile database
+---
+images:
+    ros-core:
+        base_image: @(os_name):@(os_code_name)
+        maintainer_name: @(maintainer_name)
+        template_name: docker_images/create_ros_core_image.Dockerfile.em
+        entrypoint_name: docker_images/ros_entrypoint.sh
+        template_packages:
+            - docker_templates
+        ros_packages:
+            - ros-core
+    ros-base:
+        base_image: @(user_name):@(rosdistro_name)-ros-core-@(os_code_name)
+        maintainer_name: @(maintainer_name)
+        template_name: docker_images/create_ros_image.Dockerfile.em
+        template_packages:
+            - docker_templates
+        ros_packages:
+            - ros-base
+        bootstrap_ros_tools:
+    robot:
+        base_image: @(user_name):@(rosdistro_name)-ros-base-@(os_code_name)
+        maintainer_name: @(maintainer_name)
+        template_name: docker_images/create_ros_image.Dockerfile.em
+        template_packages:
+            - docker_templates
+        ros_packages:
+            - robot
+    perception:
+        base_image: @(user_name):@(rosdistro_name)-ros-base-@(os_code_name)
+        maintainer_name: @(maintainer_name)
+        template_name: docker_images/create_ros_image.Dockerfile.em
+        template_packages:
+            - docker_templates
+        ros_packages:
+            - perception
+    desktop:
+        base_image: @(user_name):@(rosdistro_name)-robot-@(os_code_name)
+        maintainer_name: @(maintainer_name)
+        template_name: docker_images/create_ros_image.Dockerfile.em
+        template_packages:
+            - docker_templates
+        ros_packages:
+            - desktop
+    desktop-full:
+        base_image: osrf/@(user_name):@(rosdistro_name)-desktop-@(os_code_name)
+        maintainer_name: @(maintainer_name)
+        template_name: docker_images/create_ros_image.Dockerfile.em
+        template_packages:
+            - docker_templates
+        ros_packages:
+            - desktop-full

--- a/ros/noetic/debian/buster/perception/Dockerfile
+++ b/ros/noetic/debian/buster/perception/Dockerfile
@@ -1,0 +1,9 @@
+# This is an auto generated Dockerfile for ros:perception
+# generated from docker_images/create_ros_image.Dockerfile.em
+FROM ros:noetic-ros-base-buster
+
+# install ros packages
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ros-noetic-perception=1.5.0-1* \
+    && rm -rf /var/lib/apt/lists/*
+

--- a/ros/noetic/debian/buster/platform.yaml
+++ b/ros/noetic/debian/buster/platform.yaml
@@ -1,0 +1,14 @@
+%YAML 1.1
+# ROS Dockerfile database
+---
+platform:
+    os_name: debian
+    os_code_name: buster
+    rosdistro_name: noetic
+    user_name: ros
+    maintainer_name:
+    arch: amd64
+    type: distribution
+    version:
+    release: ros
+    ros_version: 1

--- a/ros/noetic/debian/buster/robot/Dockerfile
+++ b/ros/noetic/debian/buster/robot/Dockerfile
@@ -1,0 +1,9 @@
+# This is an auto generated Dockerfile for ros:robot
+# generated from docker_images/create_ros_image.Dockerfile.em
+FROM ros:noetic-ros-base-buster
+
+# install ros packages
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ros-noetic-robot=1.5.0-1* \
+    && rm -rf /var/lib/apt/lists/*
+

--- a/ros/noetic/debian/buster/ros-base/Dockerfile
+++ b/ros/noetic/debian/buster/ros-base/Dockerfile
@@ -1,0 +1,21 @@
+# This is an auto generated Dockerfile for ros:ros-base
+# generated from docker_images/create_ros_image.Dockerfile.em
+FROM ros:noetic-ros-core-buster
+
+# install bootstrap tools
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    build-essential \
+    python-rosdep \
+    python-rosinstall \
+    python-vcstools \
+    && rm -rf /var/lib/apt/lists/*
+
+# bootstrap rosdep
+RUN rosdep init && \
+  rosdep update --rosdistro $ROS_DISTRO
+
+# install ros packages
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ros-noetic-ros-base=1.5.0-1* \
+    && rm -rf /var/lib/apt/lists/*
+

--- a/ros/noetic/debian/buster/ros-base/Dockerfile
+++ b/ros/noetic/debian/buster/ros-base/Dockerfile
@@ -5,9 +5,9 @@ FROM ros:noetic-ros-core-buster
 # install bootstrap tools
 RUN apt-get update && apt-get install --no-install-recommends -y \
     build-essential \
-    python-rosdep \
-    python-rosinstall \
-    python-vcstools \
+    python3-rosdep \
+    python3-rosinstall \
+    python3-vcstools \
     && rm -rf /var/lib/apt/lists/*
 
 # bootstrap rosdep

--- a/ros/noetic/debian/buster/ros-core/Dockerfile
+++ b/ros/noetic/debian/buster/ros-core/Dockerfile
@@ -1,0 +1,32 @@
+# This is an auto generated Dockerfile for ros:ros-core
+# generated from docker_images/create_ros_core_image.Dockerfile.em
+FROM debian:buster
+
+# install packages
+RUN apt-get update && apt-get install -q -y --no-install-recommends \
+    dirmngr \
+    gnupg2 \
+    && rm -rf /var/lib/apt/lists/*
+
+# setup keys
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
+
+# setup sources.list
+RUN echo "deb http://packages.ros.org/ros/ubuntu buster main" > /etc/apt/sources.list.d/ros1-latest.list
+
+# setup environment
+ENV LANG C.UTF-8
+ENV LC_ALL C.UTF-8
+
+ENV ROS_DISTRO noetic
+
+# install ros packages
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ros-noetic-ros-core=1.5.0-1* \
+    && rm -rf /var/lib/apt/lists/*
+
+# setup entrypoint
+COPY ./ros_entrypoint.sh /
+
+ENTRYPOINT ["/ros_entrypoint.sh"]
+CMD ["bash"]

--- a/ros/noetic/debian/buster/ros-core/ros_entrypoint.sh
+++ b/ros/noetic/debian/buster/ros-core/ros_entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+# setup ros environment
+source "/opt/ros/$ROS_DISTRO/setup.bash"
+exec "$@"

--- a/ros/noetic/ubuntu/focal/Makefile
+++ b/ros/noetic/ubuntu/focal/Makefile
@@ -1,0 +1,34 @@
+all: help
+
+help:
+	@echo ""
+	@echo "-- Help Menu"
+	@echo ""
+	@echo "   1. make build            - build all images"
+	@echo "   2. make pull             - pull all images"
+	@echo "   3. make clean            - remove all images"
+	@echo ""
+
+build:
+	@docker build --tag=ros:noetic-ros-core-focal          ros-core/.
+	@docker build --tag=ros:noetic-ros-base-focal          ros-base/.
+	@docker build --tag=ros:noetic-robot-focal             robot/.
+	@docker build --tag=ros:noetic-perception-focal        perception/.
+	# @docker build --tag=osrf/ros:noetic-desktop-focal      desktop/.
+	# @docker build --tag=osrf/ros:noetic-desktop-full-focal desktop-full/.
+
+pull:
+	@docker pull ros:noetic-ros-core-focal
+	@docker pull ros:noetic-ros-base-focal
+	@docker pull ros:noetic-robot-focal
+	@docker pull ros:noetic-perception-focal
+	# @docker pull osrf/ros:noetic-desktop-focal
+	# @docker pull osrf/ros:noetic-desktop-full-focal
+
+clean:
+	@docker rmi -f ros:noetic-ros-core-focal
+	@docker rmi -f ros:noetic-ros-base-focal
+	@docker rmi -f ros:noetic-robot-focal
+	@docker rmi -f ros:noetic-perception-focal
+	# @docker rmi -f osrf/ros:noetic-desktop-focal
+	# @docker rmi -f osrf/ros:noetic-desktop-full-focal

--- a/ros/noetic/ubuntu/focal/desktop-full/Dockerfile
+++ b/ros/noetic/ubuntu/focal/desktop-full/Dockerfile
@@ -1,0 +1,9 @@
+# This is an auto generated Dockerfile for ros:desktop-full
+# generated from docker_images/create_ros_image.Dockerfile.em
+FROM osrf/ros:noetic-desktop-focal
+
+# install ros packages
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ros-noetic-desktop-full=1.5.0-1* \
+    && rm -rf /var/lib/apt/lists/*
+

--- a/ros/noetic/ubuntu/focal/desktop-full/hooks/post_push
+++ b/ros/noetic/ubuntu/focal/desktop-full/hooks/post_push
@@ -1,0 +1,14 @@
+#!/bin/bash
+# http://windsock.io/automated-docker-image-builds-with-multiple-tags/
+
+set -e
+
+# Parse image name for repo name
+tagStart=$(expr index "$IMAGE_NAME" :)
+repoName=${IMAGE_NAME:0:tagStart-1}
+
+# Tag and push image for each additional tag
+for tag in noetic-desktop-full; do
+    docker tag $IMAGE_NAME ${repoName}:${tag}
+    docker push ${repoName}:${tag}
+done

--- a/ros/noetic/ubuntu/focal/desktop/Dockerfile
+++ b/ros/noetic/ubuntu/focal/desktop/Dockerfile
@@ -1,0 +1,9 @@
+# This is an auto generated Dockerfile for ros:desktop
+# generated from docker_images/create_ros_image.Dockerfile.em
+FROM ros:noetic-robot-focal
+
+# install ros packages
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ros-noetic-desktop=1.5.0-1* \
+    && rm -rf /var/lib/apt/lists/*
+

--- a/ros/noetic/ubuntu/focal/desktop/hooks/post_push
+++ b/ros/noetic/ubuntu/focal/desktop/hooks/post_push
@@ -1,0 +1,14 @@
+#!/bin/bash
+# http://windsock.io/automated-docker-image-builds-with-multiple-tags/
+
+set -e
+
+# Parse image name for repo name
+tagStart=$(expr index "$IMAGE_NAME" :)
+repoName=${IMAGE_NAME:0:tagStart-1}
+
+# Tag and push image for each additional tag
+for tag in noetic-desktop; do
+    docker tag $IMAGE_NAME ${repoName}:${tag}
+    docker push ${repoName}:${tag}
+done

--- a/ros/noetic/ubuntu/focal/images.yaml.em
+++ b/ros/noetic/ubuntu/focal/images.yaml.em
@@ -1,0 +1,54 @@
+%YAML 1.1
+# ROS Dockerfile database
+---
+images:
+    ros-core:
+        base_image: @(os_name):@(os_code_name)
+        maintainer_name: @(maintainer_name)
+        template_name: docker_images/create_ros_core_image.Dockerfile.em
+        entrypoint_name: docker_images/ros_entrypoint.sh
+        template_packages:
+            - docker_templates
+        ros_packages:
+            - ros-core
+    ros-base:
+        base_image: @(user_name):@(rosdistro_name)-ros-core-@(os_code_name)
+        maintainer_name: @(maintainer_name)
+        template_name: docker_images/create_ros_image.Dockerfile.em
+        template_packages:
+            - docker_templates
+        ros_packages:
+            - ros-base
+        bootstrap_ros_tools:
+    robot:
+        base_image: @(user_name):@(rosdistro_name)-ros-base-@(os_code_name)
+        maintainer_name: @(maintainer_name)
+        template_name: docker_images/create_ros_image.Dockerfile.em
+        template_packages:
+            - docker_templates
+        ros_packages:
+            - robot
+    perception:
+        base_image: @(user_name):@(rosdistro_name)-ros-base-@(os_code_name)
+        maintainer_name: @(maintainer_name)
+        template_name: docker_images/create_ros_image.Dockerfile.em
+        template_packages:
+            - docker_templates
+        ros_packages:
+            - perception
+    desktop:
+        base_image: @(user_name):@(rosdistro_name)-robot-@(os_code_name)
+        maintainer_name: @(maintainer_name)
+        template_name: docker_images/create_ros_image.Dockerfile.em
+        template_packages:
+            - docker_templates
+        ros_packages:
+            - desktop
+    desktop-full:
+        base_image: osrf/@(user_name):@(rosdistro_name)-desktop-@(os_code_name)
+        maintainer_name: @(maintainer_name)
+        template_name: docker_images/create_ros_image.Dockerfile.em
+        template_packages:
+            - docker_templates
+        ros_packages:
+            - desktop-full

--- a/ros/noetic/ubuntu/focal/perception/Dockerfile
+++ b/ros/noetic/ubuntu/focal/perception/Dockerfile
@@ -1,0 +1,9 @@
+# This is an auto generated Dockerfile for ros:perception
+# generated from docker_images/create_ros_image.Dockerfile.em
+FROM ros:noetic-ros-base-focal
+
+# install ros packages
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ros-noetic-perception=1.5.0-1* \
+    && rm -rf /var/lib/apt/lists/*
+

--- a/ros/noetic/ubuntu/focal/platform.yaml
+++ b/ros/noetic/ubuntu/focal/platform.yaml
@@ -1,0 +1,14 @@
+%YAML 1.1
+# ROS Dockerfile database
+---
+platform:
+    os_name: ubuntu
+    os_code_name: focal
+    rosdistro_name: noetic
+    user_name: ros
+    maintainer_name:
+    arch: amd64
+    type: distribution
+    version:
+    release: ros
+    ros_version: 1

--- a/ros/noetic/ubuntu/focal/robot/Dockerfile
+++ b/ros/noetic/ubuntu/focal/robot/Dockerfile
@@ -1,0 +1,9 @@
+# This is an auto generated Dockerfile for ros:robot
+# generated from docker_images/create_ros_image.Dockerfile.em
+FROM ros:noetic-ros-base-focal
+
+# install ros packages
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ros-noetic-robot=1.5.0-1* \
+    && rm -rf /var/lib/apt/lists/*
+

--- a/ros/noetic/ubuntu/focal/ros-base/Dockerfile
+++ b/ros/noetic/ubuntu/focal/ros-base/Dockerfile
@@ -5,9 +5,9 @@ FROM ros:noetic-ros-core-focal
 # install bootstrap tools
 RUN apt-get update && apt-get install --no-install-recommends -y \
     build-essential \
-    python-rosdep \
-    python-rosinstall \
-    python-vcstools \
+    python3-rosdep \
+    python3-rosinstall \
+    python3-vcstools \
     && rm -rf /var/lib/apt/lists/*
 
 # bootstrap rosdep

--- a/ros/noetic/ubuntu/focal/ros-base/Dockerfile
+++ b/ros/noetic/ubuntu/focal/ros-base/Dockerfile
@@ -1,0 +1,21 @@
+# This is an auto generated Dockerfile for ros:ros-base
+# generated from docker_images/create_ros_image.Dockerfile.em
+FROM ros:noetic-ros-core-focal
+
+# install bootstrap tools
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    build-essential \
+    python-rosdep \
+    python-rosinstall \
+    python-vcstools \
+    && rm -rf /var/lib/apt/lists/*
+
+# bootstrap rosdep
+RUN rosdep init && \
+  rosdep update --rosdistro $ROS_DISTRO
+
+# install ros packages
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ros-noetic-ros-base=1.5.0-1* \
+    && rm -rf /var/lib/apt/lists/*
+

--- a/ros/noetic/ubuntu/focal/ros-core/Dockerfile
+++ b/ros/noetic/ubuntu/focal/ros-core/Dockerfile
@@ -1,0 +1,39 @@
+# This is an auto generated Dockerfile for ros:ros-core
+# generated from docker_images/create_ros_core_image.Dockerfile.em
+FROM ubuntu:focal
+
+# setup timezone
+RUN echo 'Etc/UTC' > /etc/timezone && \
+    ln -s /usr/share/zoneinfo/Etc/UTC /etc/localtime && \
+    apt-get update && \
+    apt-get install -q -y --no-install-recommends tzdata && \
+    rm -rf /var/lib/apt/lists/*
+
+# install packages
+RUN apt-get update && apt-get install -q -y --no-install-recommends \
+    dirmngr \
+    gnupg2 \
+    && rm -rf /var/lib/apt/lists/*
+
+# setup keys
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
+
+# setup sources.list
+RUN echo "deb http://packages.ros.org/ros/ubuntu focal main" > /etc/apt/sources.list.d/ros1-latest.list
+
+# setup environment
+ENV LANG C.UTF-8
+ENV LC_ALL C.UTF-8
+
+ENV ROS_DISTRO noetic
+
+# install ros packages
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ros-noetic-ros-core=1.5.0-1* \
+    && rm -rf /var/lib/apt/lists/*
+
+# setup entrypoint
+COPY ./ros_entrypoint.sh /
+
+ENTRYPOINT ["/ros_entrypoint.sh"]
+CMD ["bash"]

--- a/ros/noetic/ubuntu/focal/ros-core/ros_entrypoint.sh
+++ b/ros/noetic/ubuntu/focal/ros-core/ros_entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+# setup ros environment
+source "/opt/ros/$ROS_DISTRO/setup.bash"
+exec "$@"

--- a/ros/ros
+++ b/ros/ros
@@ -79,6 +79,56 @@ Directory: ros/melodic/debian/stretch/perception
 
 
 ################################################################################
+# Release: noetic
+
+########################################
+# Distro: ubuntu:focal
+
+Tags: noetic-ros-core, noetic-ros-core-focal
+Architectures: amd64, arm32v7, arm64v8
+GitCommit: bba0ef85a9b417f3815d2cba3b36e7754611a428
+Directory: ros/noetic/ubuntu/focal/ros-core
+
+Tags: noetic-ros-base, noetic-ros-base-focal, noetic
+Architectures: amd64, arm32v7, arm64v8
+GitCommit: bba0ef85a9b417f3815d2cba3b36e7754611a428
+Directory: ros/noetic/ubuntu/focal/ros-base
+
+Tags: noetic-robot, noetic-robot-focal
+Architectures: amd64, arm32v7, arm64v8
+GitCommit: bba0ef85a9b417f3815d2cba3b36e7754611a428
+Directory: ros/noetic/ubuntu/focal/robot
+
+Tags: noetic-perception, noetic-perception-focal
+Architectures: amd64, arm32v7, arm64v8
+GitCommit: bba0ef85a9b417f3815d2cba3b36e7754611a428
+Directory: ros/noetic/ubuntu/focal/perception
+
+########################################
+# Distro: debian:buster
+
+Tags: noetic-ros-core-buster
+Architectures: amd64, arm64v8
+GitCommit: bba0ef85a9b417f3815d2cba3b36e7754611a428
+Directory: ros/noetic/debian/buster/ros-core
+
+Tags: noetic-ros-base-buster
+Architectures: amd64, arm64v8
+GitCommit: bba0ef85a9b417f3815d2cba3b36e7754611a428
+Directory: ros/noetic/debian/buster/ros-base
+
+Tags: noetic-robot-buster
+Architectures: amd64, arm64v8
+GitCommit: bba0ef85a9b417f3815d2cba3b36e7754611a428
+Directory: ros/noetic/debian/buster/robot
+
+Tags: noetic-perception-buster
+Architectures: amd64, arm64v8
+GitCommit: bba0ef85a9b417f3815d2cba3b36e7754611a428
+Directory: ros/noetic/debian/buster/perception
+
+
+################################################################################
 # Release: dashing
 
 ########################################

--- a/ros/ros
+++ b/ros/ros
@@ -91,7 +91,7 @@ Directory: ros/noetic/ubuntu/focal/ros-core
 
 Tags: noetic-ros-base, noetic-ros-base-focal, noetic
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: bba0ef85a9b417f3815d2cba3b36e7754611a428
+GitCommit: cc4e832f92bcac995b9a2c9ca8a7b8fcf85c5c28
 Directory: ros/noetic/ubuntu/focal/ros-base
 
 Tags: noetic-robot, noetic-robot-focal
@@ -114,7 +114,7 @@ Directory: ros/noetic/debian/buster/ros-core
 
 Tags: noetic-ros-base-buster
 Architectures: amd64, arm64v8
-GitCommit: bba0ef85a9b417f3815d2cba3b36e7754611a428
+GitCommit: cc4e832f92bcac995b9a2c9ca8a7b8fcf85c5c28
 Directory: ros/noetic/debian/buster/ros-base
 
 Tags: noetic-robot-buster


### PR DESCRIPTION
These files won't compile just yet, because apparently the ROS bootstrap tools are not released in their python2 version for focal.

We'll need to modify the [bootstrap tools template](https://github.com/osrf/docker_templates/blob/d2b95496aede816e6f33b412b5c20dcae7bb7ac5/docker_templates/templates/snippet/install_ros_bootstrap_tools.Dockerfile.em#L1) to not only use the `ros_version` but to also get the `ROS_PYTHON_VERSION` to install the tools accordingly. It would be great to get it from e.g. rosdistro rather than hard-coding it.

@sloretz FYI