### PR TITLE
Add Rolling

### DIFF
--- a/.github/workflows/ros_ci.yaml
+++ b/.github/workflows/ros_ci.yaml
@@ -6,6 +6,7 @@ on:
     paths:
     - '.ci/**'
     - '.github/workflows/ros_ci.yaml'
+    - 'ros/rolling/**'
     - 'ros/eloquent/**'
     - 'ros/dashing/**'
     # - 'ros/noetic/**'
@@ -15,6 +16,7 @@ on:
     paths:
     - '.ci/**'
     - '.github/workflows/ros_ci.yaml'
+    - 'ros/rolling/**'
     - 'ros/eloquent/**'
     - 'ros/dashing/**'
     # - 'ros/noetic/**'
@@ -29,6 +31,7 @@ jobs:
       fail-fast: false
       matrix:
         env:
+          - {HUB_REPO: ros, HUB_RELEASE: rolling, HUB_OS_NAME: ubuntu, HUB_OS_CODE_NAME: focal}
           - {HUB_REPO: ros, HUB_RELEASE: eloquent, HUB_OS_NAME: ubuntu, HUB_OS_CODE_NAME: bionic}
           - {HUB_REPO: ros, HUB_RELEASE: dashing, HUB_OS_NAME: ubuntu, HUB_OS_CODE_NAME: bionic}
           # - {HUB_REPO: ros, HUB_RELEASE: noetic, HUB_OS_NAME: ubuntu, HUB_OS_CODE_NAME: focal}

--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ For more documentation on using these images, view the Docker Hub repo link abov
 Images are tagged by distribution name, meta package, as well as code name for supported OS base images.
 For complete listing of tag, view the Repo Info link below.
 
+This repo also contain images for the [ROS 2 Rolling Ridley distribution](https://www.ros.org/reps/rep-2002.html), this distribution is a rolling release providing the latest bleeding edge packages available via apt. Note that these will be updated regularly and may jump base image without notice.
+It sits nicely between the official ROS distributions and the [nightly images](https://github.com/osrf/docker_images#repo-info-3).
+
 #### [Repo Info](https://github.com/docker-library/repo-info/tree/master/repos/ros)
 
 [![Compare Images](https://images.microbadger.com/badges/image/library/ros.svg)](https://microbadger.com/#/images/library/ros)
@@ -145,6 +148,7 @@ List of tags available at https://hub.docker.com/r/osrf/ros2/tags
   - **Notice:**
     - no pre-built image hosted on Docker Hub
     - provides many `ARG` options, like running tests
+- Note: only core packages are available via these images. An alternative for development is to use the [rolling distribution images](https://github.com/osrf/docker_images#ros--), while less recent than the nightly they allow you to install many ROS packages from deb.
 
 #### Architectures
 

--- a/ros/manifest.yaml
+++ b/ros/manifest.yaml
@@ -519,6 +519,31 @@ release_names:
                                 aliases:
                                     - "$release_name-ros1-bridge"
                                     - "$release_name-ros1-bridge-$os_code_name"
+    rolling:
+        eol: 2022-05
+        os_names:
+            ubuntu:
+                os_code_names:
+                    focal:
+                        rosdistro_name: noetic
+                        <<: *DEFAULT_ROS2
+                        archs:
+                            - amd64
+                            - arm64v8
+                        tag_names:
+                            ros-core:
+                                aliases:
+                                    - "$release_name-ros-core"
+                                    - "$release_name-ros-core-$os_code_name"
+                            ros-base:
+                                aliases:
+                                    - "$release_name-ros-base"
+                                    - "$release_name-ros-base-$os_code_name"
+                                    - "$release_name"
+                            ros1-bridge:
+                                aliases:
+                                    - "$release_name-ros1-bridge"
+                                    - "$release_name-ros1-bridge-$os_code_name"
 meta:
     maintainers:
         - Tully Foote <tfoote+buildfarm@osrfoundation.org> (@tfoote)
@@ -698,6 +723,14 @@ hacks:
                             desktop:
                                 <<: *DEFAULT_HOOKS
     foxy:
+        os_names:
+            ubuntu:
+                os_code_names:
+                    focal:
+                        tag_names:
+                            desktop:
+                                <<: *DEFAULT_HOOKS
+    rolling:
         os_names:
             ubuntu:
                 os_code_names:

--- a/ros/rolling/ubuntu/focal/Makefile
+++ b/ros/rolling/ubuntu/focal/Makefile
@@ -1,0 +1,28 @@
+all: help
+
+help:
+	@echo ""
+	@echo "-- Help Menu"
+	@echo ""
+	@echo "   1. make build            - build all images"
+	@echo "   2. make pull             - pull all images"
+	@echo "   3. make clean            - remove all images"
+	@echo ""
+
+build:
+	@docker build --tag=ros:rolling-ros-core-focal			ros-core/.
+	@docker build --tag=ros:rolling-ros-base-focal			ros-base/.
+	@docker build --tag=ros:rolling-ros1-bridge-focal		ros1-bridge/.
+	# @docker build --tag=osrf/ros:rolling-desktop-focal			desktop/.
+
+pull:
+	@docker pull ros:rolling-ros-core-focal
+	@docker pull ros:rolling-ros-base-focal
+	@docker pull ros:rolling-ros1-bridge-focal
+	# @docker pull osrf/ros:rolling-desktop-focal
+
+clean:
+	@docker rmi -f ros:rolling-ros-core-focal
+	@docker rmi -f ros:rolling-ros-base-focal
+	@docker rmi -f ros:rolling-ros1-bridge-focal
+	# @docker rmi -f osrf/ros:rolling-desktop-focal

--- a/ros/rolling/ubuntu/focal/desktop/Dockerfile
+++ b/ros/rolling/ubuntu/focal/desktop/Dockerfile
@@ -1,0 +1,9 @@
+# This is an auto generated Dockerfile for ros:desktop
+# generated from docker_images_ros2/create_ros_image.Dockerfile.em
+FROM ros:rolling-ros-base-focal
+
+# install ros2 packages
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ros-rolling-desktop=0.9.1-2* \
+    && rm -rf /var/lib/apt/lists/*
+

--- a/ros/rolling/ubuntu/focal/desktop/hooks/post_push
+++ b/ros/rolling/ubuntu/focal/desktop/hooks/post_push
@@ -1,0 +1,14 @@
+#!/bin/bash
+# http://windsock.io/automated-docker-image-builds-with-multiple-tags/
+
+set -e
+
+# Parse image name for repo name
+tagStart=$(expr index "$IMAGE_NAME" :)
+repoName=${IMAGE_NAME:0:tagStart-1}
+
+# Tag and push image for each additional tag
+for tag in rolling-desktop; do
+    docker tag $IMAGE_NAME ${repoName}:${tag}
+    docker push ${repoName}:${tag}
+done

--- a/ros/rolling/ubuntu/focal/images.yaml.em
+++ b/ros/rolling/ubuntu/focal/images.yaml.em
@@ -1,0 +1,45 @@
+%YAML 1.1
+# ROS2 Dockerfile database
+---
+images:
+    ros-core:
+        base_image: @(os_name):@(os_code_name)
+        maintainer_name: @(maintainer_name)
+        template_name: docker_images_ros2/create_ros_core_image.Dockerfile.em
+        entrypoint_name: docker_images_ros2/ros_entrypoint.sh
+        template_packages:
+            - docker_templates
+        ros2_packages:
+            - ros-core
+    ros-base:
+        base_image: @(user_name):@(ros2distro_name)-ros-core-@(os_code_name)
+        maintainer_name: @(maintainer_name)
+        template_name: docker_images_ros2/create_ros_image.Dockerfile.em
+        template_packages:
+            - docker_templates
+        ros2_packages:
+            - ros-base
+        bootstrap_ros_tools:
+    desktop:
+        base_image: @(user_name):@(ros2distro_name)-ros-base-@(os_code_name)
+        maintainer_name: @(maintainer_name)
+        template_name: docker_images_ros2/create_ros_image.Dockerfile.em
+        template_packages:
+            - docker_templates
+        ros2_packages:
+            - desktop
+    ros1-bridge:
+        base_image: @(user_name):@(ros2distro_name)-ros-base-@(os_code_name)
+        maintainer_name: @(maintainer_name)
+        template_name: docker_images_ros2/ros1_bridge/create_ros_ros1_bridge_image.Dockerfile.em
+        entrypoint_name: docker_images_ros2/ros1_bridge/ros_entrypoint.sh
+        template_packages:
+            - docker_templates
+        ros2_packages:
+            - ros1-bridge
+            - demo-nodes-cpp
+            - demo-nodes-py
+        ros_packages:
+            - ros-comm
+            - roscpp-tutorials
+            - rospy-tutorials

--- a/ros/rolling/ubuntu/focal/platform.yaml
+++ b/ros/rolling/ubuntu/focal/platform.yaml
@@ -1,0 +1,14 @@
+%YAML 1.1
+# ROS2 Dockerfile database
+---
+platform:
+    os_name: ubuntu
+    os_code_name: focal
+    rosdistro_name: noetic
+    ros2distro_name: rolling
+    user_name: ros
+    maintainer_name:
+    arch: amd64
+    type: distribution
+    version:
+    ros_version: 2

--- a/ros/rolling/ubuntu/focal/ros-base/Dockerfile
+++ b/ros/rolling/ubuntu/focal/ros-base/Dockerfile
@@ -1,0 +1,31 @@
+# This is an auto generated Dockerfile for ros:ros-base
+# generated from docker_images_ros2/create_ros_image.Dockerfile.em
+FROM ros:rolling-ros-core-focal
+
+# install bootstrap tools
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    build-essential \
+    git \
+    python3-colcon-common-extensions \
+    python3-colcon-mixin \
+    python3-rosdep \
+    python3-vcstool \
+    && rm -rf /var/lib/apt/lists/*
+
+# bootstrap rosdep
+RUN rosdep init && \
+  rosdep update --rosdistro $ROS_DISTRO
+
+# setup colcon mixin and metadata
+RUN colcon mixin add default \
+      https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml && \
+    colcon mixin update && \
+    colcon metadata add default \
+      https://raw.githubusercontent.com/colcon/colcon-metadata-repository/master/index.yaml && \
+    colcon metadata update
+
+# install ros2 packages
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ros-rolling-ros-base=0.9.1-2* \
+    && rm -rf /var/lib/apt/lists/*
+

--- a/ros/rolling/ubuntu/focal/ros-core/Dockerfile
+++ b/ros/rolling/ubuntu/focal/ros-core/Dockerfile
@@ -1,0 +1,39 @@
+# This is an auto generated Dockerfile for ros:ros-core
+# generated from docker_images_ros2/create_ros_core_image.Dockerfile.em
+FROM ubuntu:focal
+
+# setup timezone
+RUN echo 'Etc/UTC' > /etc/timezone && \
+    ln -s /usr/share/zoneinfo/Etc/UTC /etc/localtime && \
+    apt-get update && \
+    apt-get install -q -y --no-install-recommends tzdata && \
+    rm -rf /var/lib/apt/lists/*
+
+# install packages
+RUN apt-get update && apt-get install -q -y --no-install-recommends \
+    dirmngr \
+    gnupg2 \
+    && rm -rf /var/lib/apt/lists/*
+
+# setup keys
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
+
+# setup sources.list
+RUN echo "deb http://packages.ros.org/ros2/ubuntu focal main" > /etc/apt/sources.list.d/ros2-latest.list
+
+# setup environment
+ENV LANG C.UTF-8
+ENV LC_ALL C.UTF-8
+
+ENV ROS_DISTRO rolling
+
+# install ros2 packages
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ros-rolling-ros-core=0.9.1-2* \
+    && rm -rf /var/lib/apt/lists/*
+
+# setup entrypoint
+COPY ./ros_entrypoint.sh /
+
+ENTRYPOINT ["/ros_entrypoint.sh"]
+CMD ["bash"]

--- a/ros/rolling/ubuntu/focal/ros-core/ros_entrypoint.sh
+++ b/ros/rolling/ubuntu/focal/ros-core/ros_entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+# setup ros2 environment
+source "/opt/ros/$ROS_DISTRO/setup.bash"
+exec "$@"

--- a/ros/rolling/ubuntu/focal/ros1-bridge/Dockerfile
+++ b/ros/rolling/ubuntu/focal/ros1-bridge/Dockerfile
@@ -1,0 +1,29 @@
+# This is an auto generated Dockerfile for ros:ros1-bridge
+# generated from docker_images_ros2/ros1_bridge/create_ros_ros1_bridge_image.Dockerfile.em
+FROM ros:rolling-ros-base-focal
+
+# setup keys
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
+
+# setup sources.list
+RUN echo "deb http://packages.ros.org/ros/ubuntu focal main" > /etc/apt/sources.list.d/ros1-latest.list
+
+ENV ROS1_DISTRO noetic
+ENV ROS2_DISTRO rolling
+# install ros packages
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ros-noetic-ros-comm=1.15.7-1* \
+    ros-noetic-roscpp-tutorials=0.10.1-1* \
+    ros-noetic-rospy-tutorials=0.10.1-1* \
+    && rm -rf /var/lib/apt/lists/*
+
+# install ros2 packages
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ros-rolling-ros1-bridge=0.9.2-2* \
+    ros-rolling-demo-nodes-cpp=0.10.0-1* \
+    ros-rolling-demo-nodes-py=0.10.0-1* \
+    && rm -rf /var/lib/apt/lists/*
+
+# setup entrypoint
+COPY ./ros_entrypoint.sh /
+

--- a/ros/rolling/ubuntu/focal/ros1-bridge/ros_entrypoint.sh
+++ b/ros/rolling/ubuntu/focal/ros1-bridge/ros_entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+# unsetting ROS_DISTRO to silence ROS_DISTRO override warning
+unset ROS_DISTRO
+# setup ros1 environment
+source "/opt/ros/$ROS1_DISTRO/setup.bash"
+
+# unsetting ROS_DISTRO to silence ROS_DISTRO override warning
+unset ROS_DISTRO
+# setup ros2 environment
+source "/opt/ros/$ROS2_DISTRO/setup.bash"
+
+exec "$@"

--- a/ros/ros
+++ b/ros/ros
@@ -193,3 +193,25 @@ Architectures: amd64, arm64v8
 GitCommit: c71d7177eaad534e42307b4e7ab7e30078c884de
 Directory: ros/foxy/ubuntu/focal/ros1-bridge
 
+
+################################################################################
+# Release: rolling
+
+########################################
+# Distro: ubuntu:focal
+
+Tags: rolling-ros-core, rolling-ros-core-focal
+Architectures: amd64, arm64v8
+GitCommit: f8cfc3fa7ee88d6b59ae18deedd179b8de4c3eb2
+Directory: ros/rolling/ubuntu/focal/ros-core
+
+Tags: rolling-ros-base, rolling-ros-base-focal, rolling
+Architectures: amd64, arm64v8
+GitCommit: f8cfc3fa7ee88d6b59ae18deedd179b8de4c3eb2
+Directory: ros/rolling/ubuntu/focal/ros-base
+
+Tags: rolling-ros1-bridge, rolling-ros1-bridge-focal
+Architectures: amd64, arm64v8
+GitCommit: f8cfc3fa7ee88d6b59ae18deedd179b8de4c3eb2
+Directory: ros/rolling/ubuntu/focal/ros1-bridge
+


### PR DESCRIPTION
The first sync of ROS Rolling happened: https://discourse.ros.org/t/new-packages-for-ros-2-rolling-ridley-2020-06-23/15019

A couple notes:
- I put an EOL of 2022, rationale being that any time in the future could work as it has no "support period", however many assumptions of the current set of images won't hold in 2022 when ROS2-H comes out (ubuntu version, bridging with noetic etc) so we'll need to change things in these images at that time
- this is using the same repo (main) as the other images. It's unclear to me how often sync will happen and if the testing repo has much meaning for an unstable/experimental distro. So I kept main for now
Edit: from [REP-2002](https://www.ros.org/reps/rep-2002.html#support-status) it says the syncs will happen regularly just like other distros