### PR TITLE
Add sha256 labels

### DIFF
--- a/gazebo/10/ubuntu/bionic/gzclient10/Dockerfile
+++ b/gazebo/10/ubuntu/bionic/gzclient10/Dockerfile
@@ -10,7 +10,11 @@ RUN apt-get update && apt-get install -q -y --no-install-recommends \
     x-window-system \
     && rm -rf /var/lib/apt/lists/*
 
+# label gazebo packages
+LABEL sha256.gazebo10=c069dd36e141269464acd9b0fb560ce6928aad77b661b4ef811e9b16432467b4
+
 # install gazebo packages
-RUN apt-get update && apt-get install -q -y --no-install-recommends \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     gazebo10=10.2.0-1* \
     && rm -rf /var/lib/apt/lists/*
+

--- a/gazebo/10/ubuntu/bionic/gzserver10/Dockerfile
+++ b/gazebo/10/ubuntu/bionic/gzserver10/Dockerfile
@@ -23,8 +23,11 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys D2486D2DD8
 RUN . /etc/os-release \
     && echo "deb http://packages.osrfoundation.org/gazebo/$ID-stable `lsb_release -sc` main" > /etc/apt/sources.list.d/gazebo-latest.list
 
+# label gazebo packages
+LABEL sha256.gazebo10=c069dd36e141269464acd9b0fb560ce6928aad77b661b4ef811e9b16432467b4
+
 # install gazebo packages
-RUN apt-get update && apt-get install -q -y --no-install-recommends \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     gazebo10=10.2.0-1* \
     && rm -rf /var/lib/apt/lists/*
 

--- a/gazebo/10/ubuntu/bionic/gzweb10/Dockerfile
+++ b/gazebo/10/ubuntu/bionic/gzweb10/Dockerfile
@@ -20,8 +20,11 @@ RUN apt-get update && apt-get install -q -y --no-install-recommends \
     xvfb \
     && rm -rf /var/lib/apt/lists/*
 
+# label gazebo packages
+LABEL sha256.libgazebo10-dev=c069dd36e141269464acd9b0fb560ce6928aad77b661b4ef811e9b16432467b4
+
 # install gazebo packages
-RUN apt-get update && apt-get install -q -y --no-install-recommends \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     libgazebo10-dev=10.2.0-1* \
     && rm -rf /var/lib/apt/lists/*
 

--- a/gazebo/10/ubuntu/bionic/libgazebo10/Dockerfile
+++ b/gazebo/10/ubuntu/bionic/libgazebo10/Dockerfile
@@ -1,7 +1,11 @@
 # This is an auto generated Dockerfile for gazebo:libgazebo10
 # generated from docker_images/create_gzclient_image.Dockerfile.em
 FROM gazebo:gzserver10-bionic
+# label gazebo packages
+LABEL sha256.libgazebo10-dev=c069dd36e141269464acd9b0fb560ce6928aad77b661b4ef811e9b16432467b4
+
 # install gazebo packages
-RUN apt-get update && apt-get install -q -y --no-install-recommends \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     libgazebo10-dev=10.2.0-1* \
     && rm -rf /var/lib/apt/lists/*
+

--- a/gazebo/11/ubuntu/bionic/gzclient11/Dockerfile
+++ b/gazebo/11/ubuntu/bionic/gzclient11/Dockerfile
@@ -10,7 +10,11 @@ RUN apt-get update && apt-get install -q -y --no-install-recommends \
     x-window-system \
     && rm -rf /var/lib/apt/lists/*
 
+# label gazebo packages
+LABEL sha256.gazebo11=a6663fdb1cbbb1ef38cb07ca486e6dbf5e0ef29af013794b995d6157f5230a5f
+
 # install gazebo packages
-RUN apt-get update && apt-get install -q -y --no-install-recommends \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     gazebo11=11.1.0-1* \
     && rm -rf /var/lib/apt/lists/*
+

--- a/gazebo/11/ubuntu/bionic/gzserver11/Dockerfile
+++ b/gazebo/11/ubuntu/bionic/gzserver11/Dockerfile
@@ -23,8 +23,11 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys D2486D2DD8
 RUN . /etc/os-release \
     && echo "deb http://packages.osrfoundation.org/gazebo/$ID-stable `lsb_release -sc` main" > /etc/apt/sources.list.d/gazebo-latest.list
 
+# label gazebo packages
+LABEL sha256.gazebo11=a6663fdb1cbbb1ef38cb07ca486e6dbf5e0ef29af013794b995d6157f5230a5f
+
 # install gazebo packages
-RUN apt-get update && apt-get install -q -y --no-install-recommends \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     gazebo11=11.1.0-1* \
     && rm -rf /var/lib/apt/lists/*
 

--- a/gazebo/11/ubuntu/bionic/gzweb11/Dockerfile
+++ b/gazebo/11/ubuntu/bionic/gzweb11/Dockerfile
@@ -20,8 +20,11 @@ RUN apt-get update && apt-get install -q -y --no-install-recommends \
     xvfb \
     && rm -rf /var/lib/apt/lists/*
 
+# label gazebo packages
+LABEL sha256.libgazebo11-dev=a6663fdb1cbbb1ef38cb07ca486e6dbf5e0ef29af013794b995d6157f5230a5f
+
 # install gazebo packages
-RUN apt-get update && apt-get install -q -y --no-install-recommends \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     libgazebo11-dev=11.1.0-1* \
     && rm -rf /var/lib/apt/lists/*
 

--- a/gazebo/11/ubuntu/bionic/libgazebo11/Dockerfile
+++ b/gazebo/11/ubuntu/bionic/libgazebo11/Dockerfile
@@ -1,7 +1,11 @@
 # This is an auto generated Dockerfile for gazebo:libgazebo11
 # generated from docker_images/create_gzclient_image.Dockerfile.em
 FROM gazebo:gzserver11-bionic
+# label gazebo packages
+LABEL sha256.libgazebo11-dev=a6663fdb1cbbb1ef38cb07ca486e6dbf5e0ef29af013794b995d6157f5230a5f
+
 # install gazebo packages
-RUN apt-get update && apt-get install -q -y --no-install-recommends \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     libgazebo11-dev=11.1.0-1* \
     && rm -rf /var/lib/apt/lists/*
+

--- a/gazebo/11/ubuntu/focal/gzclient11/Dockerfile
+++ b/gazebo/11/ubuntu/focal/gzclient11/Dockerfile
@@ -10,7 +10,11 @@ RUN apt-get update && apt-get install -q -y --no-install-recommends \
     x-window-system \
     && rm -rf /var/lib/apt/lists/*
 
+# label gazebo packages
+LABEL sha256.gazebo11=63cfdf1692924539ed84a573aa47d98ab699f9a710f8f6144bdeb5dee76fe691
+
 # install gazebo packages
-RUN apt-get update && apt-get install -q -y --no-install-recommends \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     gazebo11=11.1.0-1* \
     && rm -rf /var/lib/apt/lists/*
+

--- a/gazebo/11/ubuntu/focal/gzserver11/Dockerfile
+++ b/gazebo/11/ubuntu/focal/gzserver11/Dockerfile
@@ -23,8 +23,11 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys D2486D2DD8
 RUN . /etc/os-release \
     && echo "deb http://packages.osrfoundation.org/gazebo/$ID-stable `lsb_release -sc` main" > /etc/apt/sources.list.d/gazebo-latest.list
 
+# label gazebo packages
+LABEL sha256.gazebo11=63cfdf1692924539ed84a573aa47d98ab699f9a710f8f6144bdeb5dee76fe691
+
 # install gazebo packages
-RUN apt-get update && apt-get install -q -y --no-install-recommends \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     gazebo11=11.1.0-1* \
     && rm -rf /var/lib/apt/lists/*
 

--- a/gazebo/11/ubuntu/focal/gzweb11/Dockerfile
+++ b/gazebo/11/ubuntu/focal/gzweb11/Dockerfile
@@ -20,8 +20,11 @@ RUN apt-get update && apt-get install -q -y --no-install-recommends \
     xvfb \
     && rm -rf /var/lib/apt/lists/*
 
+# label gazebo packages
+LABEL sha256.libgazebo11-dev=63cfdf1692924539ed84a573aa47d98ab699f9a710f8f6144bdeb5dee76fe691
+
 # install gazebo packages
-RUN apt-get update && apt-get install -q -y --no-install-recommends \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     libgazebo11-dev=11.1.0-1* \
     && rm -rf /var/lib/apt/lists/*
 

--- a/gazebo/11/ubuntu/focal/libgazebo11/Dockerfile
+++ b/gazebo/11/ubuntu/focal/libgazebo11/Dockerfile
@@ -1,7 +1,11 @@
 # This is an auto generated Dockerfile for gazebo:libgazebo11
 # generated from docker_images/create_gzclient_image.Dockerfile.em
 FROM gazebo:gzserver11-focal
+# label gazebo packages
+LABEL sha256.libgazebo11-dev=63cfdf1692924539ed84a573aa47d98ab699f9a710f8f6144bdeb5dee76fe691
+
 # install gazebo packages
-RUN apt-get update && apt-get install -q -y --no-install-recommends \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     libgazebo11-dev=11.1.0-1* \
     && rm -rf /var/lib/apt/lists/*
+

--- a/gazebo/7/ubuntu/xenial/gzclient7/Dockerfile
+++ b/gazebo/7/ubuntu/xenial/gzclient7/Dockerfile
@@ -10,7 +10,11 @@ RUN apt-get update && apt-get install -q -y --no-install-recommends \
     x-window-system \
     && rm -rf /var/lib/apt/lists/*
 
+# label gazebo packages
+LABEL sha256.gazebo7=b1aee9ca46363b8b8ae56503af3876466ced9d86b166b69af633204e74317024
+
 # install gazebo packages
-RUN apt-get update && apt-get install -q -y --no-install-recommends \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     gazebo7=7.16.1-1* \
     && rm -rf /var/lib/apt/lists/*
+

--- a/gazebo/7/ubuntu/xenial/gzserver7/Dockerfile
+++ b/gazebo/7/ubuntu/xenial/gzserver7/Dockerfile
@@ -16,8 +16,11 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys D2486D2DD8
 RUN . /etc/os-release \
     && echo "deb http://packages.osrfoundation.org/gazebo/$ID-stable `lsb_release -sc` main" > /etc/apt/sources.list.d/gazebo-latest.list
 
+# label gazebo packages
+LABEL sha256.gazebo7=b1aee9ca46363b8b8ae56503af3876466ced9d86b166b69af633204e74317024
+
 # install gazebo packages
-RUN apt-get update && apt-get install -q -y --no-install-recommends \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     gazebo7=7.16.1-1* \
     && rm -rf /var/lib/apt/lists/*
 

--- a/gazebo/7/ubuntu/xenial/gzweb7/Dockerfile
+++ b/gazebo/7/ubuntu/xenial/gzweb7/Dockerfile
@@ -20,8 +20,11 @@ RUN apt-get update && apt-get install -q -y --no-install-recommends \
     xvfb \
     && rm -rf /var/lib/apt/lists/*
 
+# label gazebo packages
+LABEL sha256.libgazebo7-dev=b1aee9ca46363b8b8ae56503af3876466ced9d86b166b69af633204e74317024
+
 # install gazebo packages
-RUN apt-get update && apt-get install -q -y --no-install-recommends \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     libgazebo7-dev=7.16.1-1* \
     && rm -rf /var/lib/apt/lists/*
 

--- a/gazebo/7/ubuntu/xenial/libgazebo7/Dockerfile
+++ b/gazebo/7/ubuntu/xenial/libgazebo7/Dockerfile
@@ -1,7 +1,11 @@
 # This is an auto generated Dockerfile for gazebo:libgazebo7
 # generated from docker_images/create_gzclient_image.Dockerfile.em
 FROM gazebo:gzserver7-xenial
+# label gazebo packages
+LABEL sha256.libgazebo7-dev=b1aee9ca46363b8b8ae56503af3876466ced9d86b166b69af633204e74317024
+
 # install gazebo packages
-RUN apt-get update && apt-get install -q -y --no-install-recommends \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     libgazebo7-dev=7.16.1-1* \
     && rm -rf /var/lib/apt/lists/*
+

--- a/gazebo/9/debian/stretch/gzclient9/Dockerfile
+++ b/gazebo/9/debian/stretch/gzclient9/Dockerfile
@@ -10,7 +10,11 @@ RUN apt-get update && apt-get install -q -y --no-install-recommends \
     x-window-system \
     && rm -rf /var/lib/apt/lists/*
 
+# label gazebo packages
+LABEL sha256.gazebo9=0f34a73d7ba023e45aa86474adf0249b4b8f69146192d4c4594cc68d338b3193
+
 # install gazebo packages
-RUN apt-get update && apt-get install -q -y --no-install-recommends \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     gazebo9=9.14.0-1* \
     && rm -rf /var/lib/apt/lists/*
+

--- a/gazebo/9/debian/stretch/gzserver9/Dockerfile
+++ b/gazebo/9/debian/stretch/gzserver9/Dockerfile
@@ -16,8 +16,11 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys D2486D2DD8
 RUN . /etc/os-release \
     && echo "deb http://packages.osrfoundation.org/gazebo/$ID-stable `lsb_release -sc` main" > /etc/apt/sources.list.d/gazebo-latest.list
 
+# label gazebo packages
+LABEL sha256.gazebo9=0f34a73d7ba023e45aa86474adf0249b4b8f69146192d4c4594cc68d338b3193
+
 # install gazebo packages
-RUN apt-get update && apt-get install -q -y --no-install-recommends \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     gazebo9=9.14.0-1* \
     && rm -rf /var/lib/apt/lists/*
 

--- a/gazebo/9/debian/stretch/gzweb9/Dockerfile
+++ b/gazebo/9/debian/stretch/gzweb9/Dockerfile
@@ -20,8 +20,11 @@ RUN apt-get update && apt-get install -q -y --no-install-recommends \
     xvfb \
     && rm -rf /var/lib/apt/lists/*
 
+# label gazebo packages
+LABEL sha256.libgazebo9-dev=0f34a73d7ba023e45aa86474adf0249b4b8f69146192d4c4594cc68d338b3193
+
 # install gazebo packages
-RUN apt-get update && apt-get install -q -y --no-install-recommends \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     libgazebo9-dev=9.14.0-1* \
     && rm -rf /var/lib/apt/lists/*
 

--- a/gazebo/9/debian/stretch/libgazebo9/Dockerfile
+++ b/gazebo/9/debian/stretch/libgazebo9/Dockerfile
@@ -1,7 +1,11 @@
 # This is an auto generated Dockerfile for gazebo:libgazebo9
 # generated from docker_images/create_gzclient_image.Dockerfile.em
 FROM gazebo:gzserver9-stretch
+# label gazebo packages
+LABEL sha256.libgazebo9-dev=0f34a73d7ba023e45aa86474adf0249b4b8f69146192d4c4594cc68d338b3193
+
 # install gazebo packages
-RUN apt-get update && apt-get install -q -y --no-install-recommends \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     libgazebo9-dev=9.14.0-1* \
     && rm -rf /var/lib/apt/lists/*
+

--- a/gazebo/9/ubuntu/bionic/gzclient9/Dockerfile
+++ b/gazebo/9/ubuntu/bionic/gzclient9/Dockerfile
@@ -10,7 +10,11 @@ RUN apt-get update && apt-get install -q -y --no-install-recommends \
     x-window-system \
     && rm -rf /var/lib/apt/lists/*
 
+# label gazebo packages
+LABEL sha256.gazebo9=9df95001fb3d160f0a70ee743c833c889d8bfb1ec6963716e7ebf8bc0c51b5c8
+
 # install gazebo packages
-RUN apt-get update && apt-get install -q -y --no-install-recommends \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     gazebo9=9.14.0-1* \
     && rm -rf /var/lib/apt/lists/*
+

--- a/gazebo/9/ubuntu/bionic/gzserver9/Dockerfile
+++ b/gazebo/9/ubuntu/bionic/gzserver9/Dockerfile
@@ -23,8 +23,11 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys D2486D2DD8
 RUN . /etc/os-release \
     && echo "deb http://packages.osrfoundation.org/gazebo/$ID-stable `lsb_release -sc` main" > /etc/apt/sources.list.d/gazebo-latest.list
 
+# label gazebo packages
+LABEL sha256.gazebo9=9df95001fb3d160f0a70ee743c833c889d8bfb1ec6963716e7ebf8bc0c51b5c8
+
 # install gazebo packages
-RUN apt-get update && apt-get install -q -y --no-install-recommends \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     gazebo9=9.14.0-1* \
     && rm -rf /var/lib/apt/lists/*
 

--- a/gazebo/9/ubuntu/bionic/gzweb9/Dockerfile
+++ b/gazebo/9/ubuntu/bionic/gzweb9/Dockerfile
@@ -20,8 +20,11 @@ RUN apt-get update && apt-get install -q -y --no-install-recommends \
     xvfb \
     && rm -rf /var/lib/apt/lists/*
 
+# label gazebo packages
+LABEL sha256.libgazebo9-dev=9df95001fb3d160f0a70ee743c833c889d8bfb1ec6963716e7ebf8bc0c51b5c8
+
 # install gazebo packages
-RUN apt-get update && apt-get install -q -y --no-install-recommends \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     libgazebo9-dev=9.14.0-1* \
     && rm -rf /var/lib/apt/lists/*
 

--- a/gazebo/9/ubuntu/bionic/libgazebo9/Dockerfile
+++ b/gazebo/9/ubuntu/bionic/libgazebo9/Dockerfile
@@ -1,7 +1,11 @@
 # This is an auto generated Dockerfile for gazebo:libgazebo9
 # generated from docker_images/create_gzclient_image.Dockerfile.em
 FROM gazebo:gzserver9-bionic
+# label gazebo packages
+LABEL sha256.libgazebo9-dev=9df95001fb3d160f0a70ee743c833c889d8bfb1ec6963716e7ebf8bc0c51b5c8
+
 # install gazebo packages
-RUN apt-get update && apt-get install -q -y --no-install-recommends \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     libgazebo9-dev=9.14.0-1* \
     && rm -rf /var/lib/apt/lists/*
+

--- a/gazebo/9/ubuntu/xenial/gzclient9/Dockerfile
+++ b/gazebo/9/ubuntu/xenial/gzclient9/Dockerfile
@@ -10,7 +10,11 @@ RUN apt-get update && apt-get install -q -y --no-install-recommends \
     x-window-system \
     && rm -rf /var/lib/apt/lists/*
 
+# label gazebo packages
+LABEL sha256.gazebo9=62bbaada3e4f1c4ee30211402f3c4bf2c9bf00b59584b678f44249ebf43fdd95
+
 # install gazebo packages
-RUN apt-get update && apt-get install -q -y --no-install-recommends \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     gazebo9=9.14.0-1* \
     && rm -rf /var/lib/apt/lists/*
+

--- a/gazebo/9/ubuntu/xenial/gzserver9/Dockerfile
+++ b/gazebo/9/ubuntu/xenial/gzserver9/Dockerfile
@@ -16,8 +16,11 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys D2486D2DD8
 RUN . /etc/os-release \
     && echo "deb http://packages.osrfoundation.org/gazebo/$ID-stable `lsb_release -sc` main" > /etc/apt/sources.list.d/gazebo-latest.list
 
+# label gazebo packages
+LABEL sha256.gazebo9=62bbaada3e4f1c4ee30211402f3c4bf2c9bf00b59584b678f44249ebf43fdd95
+
 # install gazebo packages
-RUN apt-get update && apt-get install -q -y --no-install-recommends \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     gazebo9=9.14.0-1* \
     && rm -rf /var/lib/apt/lists/*
 

--- a/gazebo/9/ubuntu/xenial/gzweb9/Dockerfile
+++ b/gazebo/9/ubuntu/xenial/gzweb9/Dockerfile
@@ -20,8 +20,11 @@ RUN apt-get update && apt-get install -q -y --no-install-recommends \
     xvfb \
     && rm -rf /var/lib/apt/lists/*
 
+# label gazebo packages
+LABEL sha256.libgazebo9-dev=62bbaada3e4f1c4ee30211402f3c4bf2c9bf00b59584b678f44249ebf43fdd95
+
 # install gazebo packages
-RUN apt-get update && apt-get install -q -y --no-install-recommends \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     libgazebo9-dev=9.14.0-1* \
     && rm -rf /var/lib/apt/lists/*
 

--- a/gazebo/9/ubuntu/xenial/libgazebo9/Dockerfile
+++ b/gazebo/9/ubuntu/xenial/libgazebo9/Dockerfile
@@ -1,7 +1,11 @@
 # This is an auto generated Dockerfile for gazebo:libgazebo9
 # generated from docker_images/create_gzclient_image.Dockerfile.em
 FROM gazebo:gzserver9-xenial
+# label gazebo packages
+LABEL sha256.libgazebo9-dev=62bbaada3e4f1c4ee30211402f3c4bf2c9bf00b59584b678f44249ebf43fdd95
+
 # install gazebo packages
-RUN apt-get update && apt-get install -q -y --no-install-recommends \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     libgazebo9-dev=9.14.0-1* \
     && rm -rf /var/lib/apt/lists/*
+

--- a/ros/dashing/ubuntu/bionic/desktop/Dockerfile
+++ b/ros/dashing/ubuntu/bionic/desktop/Dockerfile
@@ -2,6 +2,9 @@
 # generated from docker_images_ros2/create_ros_image.Dockerfile.em
 FROM ros:dashing-ros-base-bionic
 
+# label ros2 packages
+LABEL sha256.ros-dashing-desktop=38001f9e52a1f152b201759ada19bd653abf492dff3f3c5f47640bfcaa64838b
+
 # install ros2 packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ros-dashing-desktop=0.7.4-1* \

--- a/ros/dashing/ubuntu/bionic/ros-base/Dockerfile
+++ b/ros/dashing/ubuntu/bionic/ros-base/Dockerfile
@@ -24,6 +24,9 @@ RUN colcon mixin add default \
       https://raw.githubusercontent.com/colcon/colcon-metadata-repository/master/index.yaml && \
     colcon metadata update
 
+# label ros2 packages
+LABEL sha256.ros-dashing-ros-base=b68279eb8936043bbc2e8e04f833f7915be0d9b637f9cbe5b71cdb2ff08a3251
+
 # install ros2 packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ros-dashing-ros-base=0.7.4-1* \

--- a/ros/dashing/ubuntu/bionic/ros-core/Dockerfile
+++ b/ros/dashing/ubuntu/bionic/ros-core/Dockerfile
@@ -27,6 +27,9 @@ ENV LC_ALL C.UTF-8
 
 ENV ROS_DISTRO dashing
 
+# label ros2 packages
+LABEL sha256.ros-dashing-ros-core=cac0351e38f37fa9bd1a2f227f68a5320e131f78959071484ddc793fecf2d989
+
 # install ros2 packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ros-dashing-ros-core=0.7.4-1* \

--- a/ros/dashing/ubuntu/bionic/ros1-bridge/Dockerfile
+++ b/ros/dashing/ubuntu/bionic/ros1-bridge/Dockerfile
@@ -10,12 +10,23 @@ RUN echo "deb http://packages.ros.org/ros/ubuntu bionic main" > /etc/apt/sources
 
 ENV ROS1_DISTRO melodic
 ENV ROS2_DISTRO dashing
+
+# label ros packages
+LABEL sha256.ros-melodic-ros-comm=a0fca5a04686610280d507c61b76c956a7acada71255910b7b9b47bf44a375dc \
+      sha256.ros-melodic-roscpp-tutorials=d676c108b642f0243992795ee3fb5c75e2ef0b28ccd1e843a9d8603bda3a6555 \
+      sha256.ros-melodic-rospy-tutorials=46ee4d1e9f93cca81e75ef0fdbc6701e90ffab2514f049e96700c9f1114cdcea
+
 # install ros packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ros-melodic-ros-comm=1.14.9-1* \
     ros-melodic-roscpp-tutorials=0.9.3-1* \
     ros-melodic-rospy-tutorials=0.9.3-1* \
     && rm -rf /var/lib/apt/lists/*
+
+# label ros2 packages
+LABEL sha256.ros-dashing-ros1-bridge=a7ee934891873f72455a068407351a1350ac4589a9369b330dc6e77e7e9524ab \
+      sha256.ros-dashing-demo-nodes-cpp=7b2e093429cecb20bc73172dba95bd53c861dcb912e97047003f928a33329cb1 \
+      sha256.ros-dashing-demo-nodes-py=dc4ca847d6876bccbb9a9e4c36d499766296da79d53f5f89218b39301c6ae65e
 
 # install ros2 packages
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/ros/eloquent/ubuntu/bionic/desktop/Dockerfile
+++ b/ros/eloquent/ubuntu/bionic/desktop/Dockerfile
@@ -2,6 +2,9 @@
 # generated from docker_images_ros2/create_ros_image.Dockerfile.em
 FROM ros:eloquent-ros-base-bionic
 
+# label ros2 packages
+LABEL sha256.ros-eloquent-desktop=423ee592ad7d969a17c0f0164daa90dec57359138ac6fe6309178a15876b2c20
+
 # install ros2 packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ros-eloquent-desktop=0.8.4-1* \

--- a/ros/eloquent/ubuntu/bionic/ros-base/Dockerfile
+++ b/ros/eloquent/ubuntu/bionic/ros-base/Dockerfile
@@ -24,6 +24,9 @@ RUN colcon mixin add default \
       https://raw.githubusercontent.com/colcon/colcon-metadata-repository/master/index.yaml && \
     colcon metadata update
 
+# label ros2 packages
+LABEL sha256.ros-eloquent-ros-base=3ba498156ca86b1f528ee57cdaf26908ec5bfc883047dd3661dcebef48fba399
+
 # install ros2 packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ros-eloquent-ros-base=0.8.4-1* \

--- a/ros/eloquent/ubuntu/bionic/ros-core/Dockerfile
+++ b/ros/eloquent/ubuntu/bionic/ros-core/Dockerfile
@@ -27,6 +27,9 @@ ENV LC_ALL C.UTF-8
 
 ENV ROS_DISTRO eloquent
 
+# label ros2 packages
+LABEL sha256.ros-eloquent-ros-core=7b375ff186ab1f16ab82986720e3e47471d25d7d62b15e35b5bab96ba4dc9638
+
 # install ros2 packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ros-eloquent-ros-core=0.8.4-1* \

--- a/ros/eloquent/ubuntu/bionic/ros1-bridge/Dockerfile
+++ b/ros/eloquent/ubuntu/bionic/ros1-bridge/Dockerfile
@@ -10,12 +10,23 @@ RUN echo "deb http://packages.ros.org/ros/ubuntu bionic main" > /etc/apt/sources
 
 ENV ROS1_DISTRO melodic
 ENV ROS2_DISTRO eloquent
+
+# label ros packages
+LABEL sha256.ros-melodic-ros-comm=a0fca5a04686610280d507c61b76c956a7acada71255910b7b9b47bf44a375dc \
+      sha256.ros-melodic-roscpp-tutorials=d676c108b642f0243992795ee3fb5c75e2ef0b28ccd1e843a9d8603bda3a6555 \
+      sha256.ros-melodic-rospy-tutorials=46ee4d1e9f93cca81e75ef0fdbc6701e90ffab2514f049e96700c9f1114cdcea
+
 # install ros packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ros-melodic-ros-comm=1.14.9-1* \
     ros-melodic-roscpp-tutorials=0.9.3-1* \
     ros-melodic-rospy-tutorials=0.9.3-1* \
     && rm -rf /var/lib/apt/lists/*
+
+# label ros2 packages
+LABEL sha256.ros-eloquent-ros1-bridge=969cd222afd076ae3989f73a1dbea0f877f29983e062415697e721e52a6f7f4f \
+      sha256.ros-eloquent-demo-nodes-cpp=e07fd5f0b1afbd1695b5afb0a8e6d8bcba213ff1690fe5c8768a364578d0fcfc \
+      sha256.ros-eloquent-demo-nodes-py=36cc41b867918c9a2206ec8d1a1643529523fce4d876736e85c285e6fd9f2d5f
 
 # install ros2 packages
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/ros/foxy/ubuntu/focal/desktop/Dockerfile
+++ b/ros/foxy/ubuntu/focal/desktop/Dockerfile
@@ -2,6 +2,9 @@
 # generated from docker_images_ros2/create_ros_image.Dockerfile.em
 FROM ros:foxy-ros-base-focal
 
+# label ros2 packages
+LABEL sha256.ros-foxy-desktop=067c3082e5a73de0273fa4b03d3f250a9d4fcd2652a1d1ff5e411e7575f2fb7e
+
 # install ros2 packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ros-foxy-desktop=0.9.2-1* \

--- a/ros/foxy/ubuntu/focal/ros-base/Dockerfile
+++ b/ros/foxy/ubuntu/focal/ros-base/Dockerfile
@@ -24,6 +24,9 @@ RUN colcon mixin add default \
       https://raw.githubusercontent.com/colcon/colcon-metadata-repository/master/index.yaml && \
     colcon metadata update
 
+# label ros2 packages
+LABEL sha256.ros-foxy-ros-base=832b6d5d4cf9930072823428748a494d65a04626445d61e8b3778cc00f544622
+
 # install ros2 packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ros-foxy-ros-base=0.9.2-1* \

--- a/ros/foxy/ubuntu/focal/ros-core/Dockerfile
+++ b/ros/foxy/ubuntu/focal/ros-core/Dockerfile
@@ -27,6 +27,9 @@ ENV LC_ALL C.UTF-8
 
 ENV ROS_DISTRO foxy
 
+# label ros2 packages
+LABEL sha256.ros-foxy-ros-core=d9d0400818ff1a4ba4f80a15f616fc7f67d30a38b160acd8f7a6abb6f7f8c97c
+
 # install ros2 packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ros-foxy-ros-core=0.9.2-1* \

--- a/ros/foxy/ubuntu/focal/ros1-bridge/Dockerfile
+++ b/ros/foxy/ubuntu/focal/ros1-bridge/Dockerfile
@@ -10,12 +10,23 @@ RUN echo "deb http://packages.ros.org/ros/ubuntu focal main" > /etc/apt/sources.
 
 ENV ROS1_DISTRO noetic
 ENV ROS2_DISTRO foxy
+
+# label ros packages
+LABEL sha256.ros-noetic-ros-comm=265f35291ff4339377e247fd094d6f122958db85e4db656d8bb4aa275978929a \
+      sha256.ros-noetic-roscpp-tutorials=a4bafc15b204f8cd7457a4500be4e9e53edc6721e0a64bae03c6fe65ed1eb3e6 \
+      sha256.ros-noetic-rospy-tutorials=46cf19b27678c1d70a73c33e30ce4fd4a23e651dc0a0da39234c5a673ce550be
+
 # install ros packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ros-noetic-ros-comm=1.15.8-1* \
     ros-noetic-roscpp-tutorials=0.10.2-1* \
     ros-noetic-rospy-tutorials=0.10.2-1* \
     && rm -rf /var/lib/apt/lists/*
+
+# label ros2 packages
+LABEL sha256.ros-foxy-ros1-bridge=b0058d42ef7bccde6df35714d2db86b3020d5d15b589b9dedfd3a94567d4767d \
+      sha256.ros-foxy-demo-nodes-cpp=1825308b556599aa1c6936a00f0bf2991494620acc4b89e43681bf0eaaa199bf \
+      sha256.ros-foxy-demo-nodes-py=9d6ded456c9399202faaf2a0b73552c0583804a25880ea045b121d19d409c0da
 
 # install ros2 packages
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/ros/kinetic/ubuntu/xenial/desktop-full/Dockerfile
+++ b/ros/kinetic/ubuntu/xenial/desktop-full/Dockerfile
@@ -2,6 +2,9 @@
 # generated from docker_images/create_ros_image.Dockerfile.em
 FROM osrf/ros:kinetic-desktop-xenial
 
+# label ros packages
+LABEL sha256.ros-kinetic-desktop-full=5eb2b54af9275604e3025a57c7a8fedec0790a3a30d849da4a24f7c5212833f0
+
 # install ros packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ros-kinetic-desktop-full=1.3.2-0* \

--- a/ros/kinetic/ubuntu/xenial/desktop/Dockerfile
+++ b/ros/kinetic/ubuntu/xenial/desktop/Dockerfile
@@ -2,6 +2,9 @@
 # generated from docker_images/create_ros_image.Dockerfile.em
 FROM ros:kinetic-robot-xenial
 
+# label ros packages
+LABEL sha256.ros-kinetic-desktop=b9622d22222dca7554ce11e6c42abd6e0412bce289f0b2f334f2b728d322ec66
+
 # install ros packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ros-kinetic-desktop=1.3.2-0* \

--- a/ros/kinetic/ubuntu/xenial/perception/Dockerfile
+++ b/ros/kinetic/ubuntu/xenial/perception/Dockerfile
@@ -2,6 +2,9 @@
 # generated from docker_images/create_ros_image.Dockerfile.em
 FROM ros:kinetic-ros-base-xenial
 
+# label ros packages
+LABEL sha256.ros-kinetic-perception=7c8a2df83dbaf9bce97adcaa8ad1bf91781c27e5938417e47bf404411aca36f5
+
 # install ros packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ros-kinetic-perception=1.3.2-0* \

--- a/ros/kinetic/ubuntu/xenial/robot/Dockerfile
+++ b/ros/kinetic/ubuntu/xenial/robot/Dockerfile
@@ -2,6 +2,9 @@
 # generated from docker_images/create_ros_image.Dockerfile.em
 FROM ros:kinetic-ros-base-xenial
 
+# label ros packages
+LABEL sha256.ros-kinetic-robot=0e35cd6e02ac12a3e416fb0b2c5ed8eaf5c30b3dffd5d6af0f52329061b18e6b
+
 # install ros packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ros-kinetic-robot=1.3.2-0* \

--- a/ros/kinetic/ubuntu/xenial/ros-base/Dockerfile
+++ b/ros/kinetic/ubuntu/xenial/ros-base/Dockerfile
@@ -14,6 +14,9 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 RUN rosdep init && \
   rosdep update --rosdistro $ROS_DISTRO
 
+# label ros packages
+LABEL sha256.ros-kinetic-ros-base=76cd90ab6f750ba44562496e98518dd915cefc8ddfac2649ba76e6da578a70d2
+
 # install ros packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ros-kinetic-ros-base=1.3.2-0* \

--- a/ros/kinetic/ubuntu/xenial/ros-core/Dockerfile
+++ b/ros/kinetic/ubuntu/xenial/ros-core/Dockerfile
@@ -20,6 +20,9 @@ ENV LC_ALL C.UTF-8
 
 ENV ROS_DISTRO kinetic
 
+# label ros packages
+LABEL sha256.ros-kinetic-ros-core=ef0744aacec0bf8d268c059df29aac5fe0ff92178c6807f5d02a8b2b6a7bd2c1
+
 # install ros packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ros-kinetic-ros-core=1.3.2-0* \

--- a/ros/melodic/debian/stretch/desktop-full/Dockerfile
+++ b/ros/melodic/debian/stretch/desktop-full/Dockerfile
@@ -2,6 +2,9 @@
 # generated from docker_images/create_ros_image.Dockerfile.em
 FROM osrf/ros:melodic-desktop-stretch
 
+# label ros packages
+LABEL sha256.ros-melodic-desktop-full=b65fec1171c245889a6097f7894d85c2d4884595ed2aa8ed0553303412c13ddd
+
 # install ros packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ros-melodic-desktop-full=1.4.1-0* \

--- a/ros/melodic/debian/stretch/desktop/Dockerfile
+++ b/ros/melodic/debian/stretch/desktop/Dockerfile
@@ -2,6 +2,9 @@
 # generated from docker_images/create_ros_image.Dockerfile.em
 FROM ros:melodic-robot-stretch
 
+# label ros packages
+LABEL sha256.ros-melodic-desktop=0a5380b3d8db4ed4299a680cbdee84d5200f921b88f6ee325cb84dc5e3f369af
+
 # install ros packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ros-melodic-desktop=1.4.1-0* \

--- a/ros/melodic/debian/stretch/perception/Dockerfile
+++ b/ros/melodic/debian/stretch/perception/Dockerfile
@@ -2,6 +2,9 @@
 # generated from docker_images/create_ros_image.Dockerfile.em
 FROM ros:melodic-ros-base-stretch
 
+# label ros packages
+LABEL sha256.ros-melodic-perception=6ddef84cc6ad853264d7851d7845d54d599681b9044358f52f65cfb362a2a361
+
 # install ros packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ros-melodic-perception=1.4.1-0* \

--- a/ros/melodic/debian/stretch/robot/Dockerfile
+++ b/ros/melodic/debian/stretch/robot/Dockerfile
@@ -2,6 +2,9 @@
 # generated from docker_images/create_ros_image.Dockerfile.em
 FROM ros:melodic-ros-base-stretch
 
+# label ros packages
+LABEL sha256.ros-melodic-robot=2687b386e56c07ad5c3429454103347135bc7903ee86ae00fc990cf4dcac763a
+
 # install ros packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ros-melodic-robot=1.4.1-0* \

--- a/ros/melodic/debian/stretch/ros-base/Dockerfile
+++ b/ros/melodic/debian/stretch/ros-base/Dockerfile
@@ -14,6 +14,9 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 RUN rosdep init && \
   rosdep update --rosdistro $ROS_DISTRO
 
+# label ros packages
+LABEL sha256.ros-melodic-ros-base=d503c830b9730dd0b30d2de01081f398c441783c41e8e5425aaef6efe29126c0
+
 # install ros packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ros-melodic-ros-base=1.4.1-0* \

--- a/ros/melodic/debian/stretch/ros-core/Dockerfile
+++ b/ros/melodic/debian/stretch/ros-core/Dockerfile
@@ -20,6 +20,9 @@ ENV LC_ALL C.UTF-8
 
 ENV ROS_DISTRO melodic
 
+# label ros packages
+LABEL sha256.ros-melodic-ros-core=e62c37100ea12d746f161710b3e5b84e29bd0cbab178636bc1e8c38752a90ee5
+
 # install ros packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ros-melodic-ros-core=1.4.1-0* \

--- a/ros/melodic/ubuntu/bionic/desktop-full/Dockerfile
+++ b/ros/melodic/ubuntu/bionic/desktop-full/Dockerfile
@@ -2,6 +2,9 @@
 # generated from docker_images/create_ros_image.Dockerfile.em
 FROM osrf/ros:melodic-desktop-bionic
 
+# label ros packages
+LABEL sha256.ros-melodic-desktop-full=216b2c54c65a90a954df10e7b78bfd2d73ac77a2dc49a97be990aa3384b9da95
+
 # install ros packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ros-melodic-desktop-full=1.4.1-0* \

--- a/ros/melodic/ubuntu/bionic/desktop/Dockerfile
+++ b/ros/melodic/ubuntu/bionic/desktop/Dockerfile
@@ -2,6 +2,9 @@
 # generated from docker_images/create_ros_image.Dockerfile.em
 FROM ros:melodic-robot-bionic
 
+# label ros packages
+LABEL sha256.ros-melodic-desktop=48639769187c88a5c65950bd48a7f771680526dec5d36c7c32e26d546c54f274
+
 # install ros packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ros-melodic-desktop=1.4.1-0* \

--- a/ros/melodic/ubuntu/bionic/perception/Dockerfile
+++ b/ros/melodic/ubuntu/bionic/perception/Dockerfile
@@ -2,6 +2,9 @@
 # generated from docker_images/create_ros_image.Dockerfile.em
 FROM ros:melodic-ros-base-bionic
 
+# label ros packages
+LABEL sha256.ros-melodic-perception=85d89645dde03c38ed55f80f22d3f9c9ad32e79497d5eb314e091bd1f35d260e
+
 # install ros packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ros-melodic-perception=1.4.1-0* \

--- a/ros/melodic/ubuntu/bionic/robot/Dockerfile
+++ b/ros/melodic/ubuntu/bionic/robot/Dockerfile
@@ -2,6 +2,9 @@
 # generated from docker_images/create_ros_image.Dockerfile.em
 FROM ros:melodic-ros-base-bionic
 
+# label ros packages
+LABEL sha256.ros-melodic-robot=2c9e4eef14000d66722a84850bdcf55449db051829258505126e64ddc9a415be
+
 # install ros packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ros-melodic-robot=1.4.1-0* \

--- a/ros/melodic/ubuntu/bionic/ros-base/Dockerfile
+++ b/ros/melodic/ubuntu/bionic/ros-base/Dockerfile
@@ -14,6 +14,9 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 RUN rosdep init && \
   rosdep update --rosdistro $ROS_DISTRO
 
+# label ros packages
+LABEL sha256.ros-melodic-ros-base=8ecd99575ba8a262af2a4efb5a92c293abb9228ac303e107f4b45d933b9f66ec
+
 # install ros packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ros-melodic-ros-base=1.4.1-0* \

--- a/ros/melodic/ubuntu/bionic/ros-core/Dockerfile
+++ b/ros/melodic/ubuntu/bionic/ros-core/Dockerfile
@@ -27,6 +27,9 @@ ENV LC_ALL C.UTF-8
 
 ENV ROS_DISTRO melodic
 
+# label ros packages
+LABEL sha256.ros-melodic-ros-core=ca489b24786862a0b7231f6181e2fb27d3794832b0086e84fa2885369e3f40b8
+
 # install ros packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ros-melodic-ros-core=1.4.1-0* \

--- a/ros/noetic/debian/buster/desktop-full/Dockerfile
+++ b/ros/noetic/debian/buster/desktop-full/Dockerfile
@@ -2,6 +2,9 @@
 # generated from docker_images/create_ros_image.Dockerfile.em
 FROM osrf/ros:noetic-desktop-buster
 
+# label ros packages
+LABEL sha256.ros-noetic-desktop-full=6a3f71573b2477e1b74c32c2439259991dfc82d64bfdb7f541edcfcd6aafbec2
+
 # install ros packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ros-noetic-desktop-full=1.5.0-1* \

--- a/ros/noetic/debian/buster/desktop/Dockerfile
+++ b/ros/noetic/debian/buster/desktop/Dockerfile
@@ -2,6 +2,9 @@
 # generated from docker_images/create_ros_image.Dockerfile.em
 FROM ros:noetic-robot-buster
 
+# label ros packages
+LABEL sha256.ros-noetic-desktop=384ef7e5a5fa0711cb36f5bb8fd1c2be95e19ba8d85717fadea1f9e4f8bcf349
+
 # install ros packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ros-noetic-desktop=1.5.0-1* \

--- a/ros/noetic/debian/buster/perception/Dockerfile
+++ b/ros/noetic/debian/buster/perception/Dockerfile
@@ -2,6 +2,9 @@
 # generated from docker_images/create_ros_image.Dockerfile.em
 FROM ros:noetic-ros-base-buster
 
+# label ros packages
+LABEL sha256.ros-noetic-perception=b3262e58b2c2c007e0077b5951d95f2e959e41b120b6bcd805857649241e56b7
+
 # install ros packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ros-noetic-perception=1.5.0-1* \

--- a/ros/noetic/debian/buster/robot/Dockerfile
+++ b/ros/noetic/debian/buster/robot/Dockerfile
@@ -2,6 +2,9 @@
 # generated from docker_images/create_ros_image.Dockerfile.em
 FROM ros:noetic-ros-base-buster
 
+# label ros packages
+LABEL sha256.ros-noetic-robot=aa909e807d2e76ba8fe901606dcd23b846631c12d89aa251ce9204b5d6aad4e1
+
 # install ros packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ros-noetic-robot=1.5.0-1* \

--- a/ros/noetic/debian/buster/ros-base/Dockerfile
+++ b/ros/noetic/debian/buster/ros-base/Dockerfile
@@ -14,6 +14,9 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 RUN rosdep init && \
   rosdep update --rosdistro $ROS_DISTRO
 
+# label ros packages
+LABEL sha256.ros-noetic-ros-base=b39a3a2d0633646382b90827833221fd8dac3741c681b8611be6de6cad5894d1
+
 # install ros packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ros-noetic-ros-base=1.5.0-1* \

--- a/ros/noetic/debian/buster/ros-core/Dockerfile
+++ b/ros/noetic/debian/buster/ros-core/Dockerfile
@@ -20,6 +20,9 @@ ENV LC_ALL C.UTF-8
 
 ENV ROS_DISTRO noetic
 
+# label ros packages
+LABEL sha256.ros-noetic-ros-core=8874b0941863de09255f0ba13c2f8899952a9aace8c90fb7be520a1c2923df4a
+
 # install ros packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ros-noetic-ros-core=1.5.0-1* \

--- a/ros/noetic/ubuntu/focal/desktop-full/Dockerfile
+++ b/ros/noetic/ubuntu/focal/desktop-full/Dockerfile
@@ -2,6 +2,9 @@
 # generated from docker_images/create_ros_image.Dockerfile.em
 FROM osrf/ros:noetic-desktop-focal
 
+# label ros packages
+LABEL sha256.ros-noetic-desktop-full=3f01090798b8baa573d2c7c795c1ceb8a774e920811123bbbdac9a32fe653631
+
 # install ros packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ros-noetic-desktop-full=1.5.0-1* \

--- a/ros/noetic/ubuntu/focal/desktop/Dockerfile
+++ b/ros/noetic/ubuntu/focal/desktop/Dockerfile
@@ -2,6 +2,9 @@
 # generated from docker_images/create_ros_image.Dockerfile.em
 FROM ros:noetic-robot-focal
 
+# label ros packages
+LABEL sha256.ros-noetic-desktop=02bb5e9bff827e959f0dc551ce35c84f115782a8b5b0db33aa4d6d15ce847850
+
 # install ros packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ros-noetic-desktop=1.5.0-1* \

--- a/ros/noetic/ubuntu/focal/perception/Dockerfile
+++ b/ros/noetic/ubuntu/focal/perception/Dockerfile
@@ -2,6 +2,9 @@
 # generated from docker_images/create_ros_image.Dockerfile.em
 FROM ros:noetic-ros-base-focal
 
+# label ros packages
+LABEL sha256.ros-noetic-perception=9d410adf22169130b240d0f9710bd37fd7f59b1f29695f8f3ef4493ed213039b
+
 # install ros packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ros-noetic-perception=1.5.0-1* \

--- a/ros/noetic/ubuntu/focal/robot/Dockerfile
+++ b/ros/noetic/ubuntu/focal/robot/Dockerfile
@@ -2,6 +2,9 @@
 # generated from docker_images/create_ros_image.Dockerfile.em
 FROM ros:noetic-ros-base-focal
 
+# label ros packages
+LABEL sha256.ros-noetic-robot=2a6c6e1d99b75ecb9c1bb35312723c3e757f9b5cc955d19063f1097aef7db9d7
+
 # install ros packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ros-noetic-robot=1.5.0-1* \

--- a/ros/noetic/ubuntu/focal/ros-base/Dockerfile
+++ b/ros/noetic/ubuntu/focal/ros-base/Dockerfile
@@ -14,6 +14,9 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 RUN rosdep init && \
   rosdep update --rosdistro $ROS_DISTRO
 
+# label ros packages
+LABEL sha256.ros-noetic-ros-base=e7e5895d7b99ed7c3d2607fbdf8bba0134a03fa240e94ee1dbfa5ac1a9e3ac16
+
 # install ros packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ros-noetic-ros-base=1.5.0-1* \

--- a/ros/noetic/ubuntu/focal/ros-core/Dockerfile
+++ b/ros/noetic/ubuntu/focal/ros-core/Dockerfile
@@ -27,6 +27,9 @@ ENV LC_ALL C.UTF-8
 
 ENV ROS_DISTRO noetic
 
+# label ros packages
+LABEL sha256.ros-noetic-ros-core=4586cdeb59ec4fc87968f4013a839b78e71a262d3bbc7c60ba2b5befbc8d0928
+
 # install ros packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ros-noetic-ros-core=1.5.0-1* \

--- a/ros/rolling/ubuntu/focal/desktop/Dockerfile
+++ b/ros/rolling/ubuntu/focal/desktop/Dockerfile
@@ -2,6 +2,9 @@
 # generated from docker_images_ros2/create_ros_image.Dockerfile.em
 FROM ros:rolling-ros-base-focal
 
+# label ros2 packages
+LABEL sha256.ros-rolling-desktop=326adef4b12ec616d4bfbf1f222f8e80a7aee775bc993a6645f542e9a851520b
+
 # install ros2 packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ros-rolling-desktop=0.9.1-2* \

--- a/ros/rolling/ubuntu/focal/ros-base/Dockerfile
+++ b/ros/rolling/ubuntu/focal/ros-base/Dockerfile
@@ -24,6 +24,9 @@ RUN colcon mixin add default \
       https://raw.githubusercontent.com/colcon/colcon-metadata-repository/master/index.yaml && \
     colcon metadata update
 
+# label ros2 packages
+LABEL sha256.ros-rolling-ros-base=e7bbf2b5dc0a2379f25a48e4e92ae2a1eb0af261ca61a79e09662150c26b3428
+
 # install ros2 packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ros-rolling-ros-base=0.9.1-2* \

--- a/ros/rolling/ubuntu/focal/ros-core/Dockerfile
+++ b/ros/rolling/ubuntu/focal/ros-core/Dockerfile
@@ -27,6 +27,9 @@ ENV LC_ALL C.UTF-8
 
 ENV ROS_DISTRO rolling
 
+# label ros2 packages
+LABEL sha256.ros-rolling-ros-core=7a5cd2cfa2697126c157c2d585f8f8f158c7ee4f4b32c8ea03f410a2128d21c1
+
 # install ros2 packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ros-rolling-ros-core=0.9.1-2* \

--- a/ros/rolling/ubuntu/focal/ros1-bridge/Dockerfile
+++ b/ros/rolling/ubuntu/focal/ros1-bridge/Dockerfile
@@ -10,12 +10,23 @@ RUN echo "deb http://packages.ros.org/ros/ubuntu focal main" > /etc/apt/sources.
 
 ENV ROS1_DISTRO noetic
 ENV ROS2_DISTRO rolling
+
+# label ros packages
+LABEL sha256.ros-noetic-ros-comm=265f35291ff4339377e247fd094d6f122958db85e4db656d8bb4aa275978929a \
+      sha256.ros-noetic-roscpp-tutorials=a4bafc15b204f8cd7457a4500be4e9e53edc6721e0a64bae03c6fe65ed1eb3e6 \
+      sha256.ros-noetic-rospy-tutorials=46cf19b27678c1d70a73c33e30ce4fd4a23e651dc0a0da39234c5a673ce550be
+
 # install ros packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ros-noetic-ros-comm=1.15.8-1* \
     ros-noetic-roscpp-tutorials=0.10.2-1* \
     ros-noetic-rospy-tutorials=0.10.2-1* \
     && rm -rf /var/lib/apt/lists/*
+
+# label ros2 packages
+LABEL sha256.ros-rolling-ros1-bridge=57b580f25e8f1e416cf22322f393f5e184b487a41e4471a65effc8a126e9add2 \
+      sha256.ros-rolling-demo-nodes-cpp=5e21bb58eff49573d5d83e3a6dfdd0edff59418990a86d8751ea83deaa136934 \
+      sha256.ros-rolling-demo-nodes-py=5ba20c171117c0198b15c5e20101eb3eeac17bf8bd3715056c05a4ffd0178981
 
 # install ros2 packages
 RUN apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
But only for non EOL images, while not changing current out-of-template patches.

Replaces: https://github.com/osrf/docker_images/pull/454
Requires: https://github.com/osrf/docker_templates/pull/90