### PR TITLE
Ros2 reinstate no install recommends + update osrf/ros2:source to build foxy

### DIFF
--- a/ros2/nightly/nightly/Dockerfile
+++ b/ros2/nightly/nightly/Dockerfile
@@ -5,10 +5,12 @@ FROM ubuntu:focal
 # setup timezone
 RUN echo 'Etc/UTC' > /etc/timezone && \
     ln -s /usr/share/zoneinfo/Etc/UTC /etc/localtime && \
-    apt-get update && apt-get install -q -y tzdata && rm -rf /var/lib/apt/lists/*
+    apt-get update && \
+    apt-get install -q -y --no-install-recommends tzdata && \
+    rm -rf /var/lib/apt/lists/*
 
 # install packages
-RUN apt-get update && apt-get install -q -y \
+RUN apt-get update && apt-get install -q -y --no-install-recommends \
     bash-completion \
     cmake \
     dirmngr \
@@ -19,7 +21,6 @@ RUN apt-get update && apt-get install -q -y \
     python3-pip \
     wget \
     && rm -rf /var/lib/apt/lists/*
-
 # setup ros2 keys
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
 
@@ -28,6 +29,7 @@ RUN echo "deb http://packages.ros.org/ros2-testing/ubuntu `lsb_release -sc` main
 
 # install bootstrap tools
 RUN apt-get update && apt-get install --no-install-recommends -y \
+    build-essential \
     git \
     python3-colcon-common-extensions \
     python3-colcon-mixin \

--- a/ros2/source/devel/Dockerfile
+++ b/ros2/source/devel/Dockerfile
@@ -6,17 +6,18 @@ FROM $FROM_IMAGE
 # setup timezone
 RUN echo 'Etc/UTC' > /etc/timezone && \
     ln -s /usr/share/zoneinfo/Etc/UTC /etc/localtime && \
-    apt-get update && apt-get install -q -y tzdata && rm -rf /var/lib/apt/lists/*
+    apt-get update && \
+    apt-get install -q -y --no-install-recommends tzdata && \
+    rm -rf /var/lib/apt/lists/*
 
 # install packages
-RUN apt-get update && apt-get install -q -y \
+RUN apt-get update && apt-get install -q -y --no-install-recommends \
     bash-completion \
     dirmngr \
     gnupg2 \
     lsb-release \
     python3-pip \
     && rm -rf /var/lib/apt/lists/*
-
 # setup keys
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
 
@@ -29,6 +30,7 @@ ENV LC_ALL C.UTF-8
 
 # install bootstrap tools
 RUN apt-get update && apt-get install --no-install-recommends -y \
+    build-essential \
     git \
     python3-colcon-common-extensions \
     python3-colcon-mixin \

--- a/ros2/source/images.yaml.em
+++ b/ros2/source/images.yaml.em
@@ -32,8 +32,9 @@ images:
             - docker_templates
         upstream_packages:
             - libasio-dev
+            - libssl-dev
             - libtinyxml2-dev
-        ros2_distro: eloquent
+        ros2_distro: foxy
         ws: /opt/ros2_ws
         colcon_args:
             - build

--- a/ros2/source/source/Dockerfile
+++ b/ros2/source/source/Dockerfile
@@ -7,10 +7,11 @@ FROM $FROM_IMAGE
 # install packages
 RUN apt-get update && apt-get install -q -y --no-install-recommends \
     libasio-dev \
+    libssl-dev \
     libtinyxml2-dev \
     wget \
     && rm -rf /var/lib/apt/lists/*
-ARG ROS_DISTRO=eloquent
+ARG ROS_DISTRO=foxy
 ENV ROS_DISTRO=$ROS_DISTRO
 ENV ROS_VERSION=2 \
     ROS_PYTHON_VERSION=3

--- a/ros2/source/source/Dockerfile
+++ b/ros2/source/source/Dockerfile
@@ -5,12 +5,11 @@ ARG FROM_IMAGE=osrf/ros2:devel
 FROM $FROM_IMAGE
 
 # install packages
-RUN apt-get update && apt-get install -q -y \
+RUN apt-get update && apt-get install -q -y --no-install-recommends \
     libasio-dev \
     libtinyxml2-dev \
     wget \
     && rm -rf /var/lib/apt/lists/*
-
 ARG ROS_DISTRO=eloquent
 ENV ROS_DISTRO=$ROS_DISTRO
 ENV ROS_VERSION=2 \


### PR DESCRIPTION
https://github.com/ros-infrastructure/rosdep/pull/753 is finally out after 8 months!
So we can revert the hack from https://github.com/osrf/docker_images/pull/398 and realign closer to the docker templates.

I also took advantage of this to update the osrf/ros2:source image config to build foxy instead of eloquent: https://github.com/osrf/docker_images/commit/f90b381b9b30b6656f461ddb424a73b6bbaa27c7