### PR TITLE
Update ROS_DISTRO env to rolling for nightly tag

### DIFF
--- a/ros2/nightly/nightly/Dockerfile
+++ b/ros2/nightly/nightly/Dockerfile
@@ -38,7 +38,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     && rm -rf /var/lib/apt/lists/*
 
 # setup environment
-ENV ROS_DISTRO foxy
+ENV ROS_DISTRO rolling
 ENV LANG C.UTF-8
 ENV LC_ALL C.UTF-8
 ENV ROSDISTRO_INDEX_URL https://raw.githubusercontent.com/osrf/docker_images/master/ros2/nightly/nightly/index-v4.yaml


### PR DESCRIPTION
Fixes https://github.com/osrf/docker_images/issues/512