### PR TITLE
[ros2/nightly] fix ros2 distro in platform.yaml file

### DIFF
--- a/ros2/nightly/platform.yaml
+++ b/ros2/nightly/platform.yaml
@@ -4,7 +4,7 @@
 platform:
     os_name: ubuntu
     os_code_name: focal
-    ros2distro_name: foxy
+    ros2distro_name: rolling
     user_name: ros
     maintainer_name:
     arch: amd64


### PR DESCRIPTION
Follow-up of https://github.com/osrf/docker_images/pull/513