### PR TITLE
EOL Eloquent

### DIFF
--- a/.github/workflows/ros_ci.yaml
+++ b/.github/workflows/ros_ci.yaml
@@ -8,7 +8,6 @@ on:
     - '.github/workflows/ros_ci.yaml'
     - 'ros/rolling/**'
     - 'ros/foxy/**'
-    - 'ros/eloquent/**'
     - 'ros/dashing/**'
     # - 'ros/noetic/**'
     - 'ros/melodic/**'
@@ -19,7 +18,6 @@ on:
     - '.github/workflows/ros_ci.yaml'
     - 'ros/rolling/**'
     - 'ros/foxy/**'
-    - 'ros/eloquent/**'
     - 'ros/dashing/**'
     # - 'ros/noetic/**'
     - 'ros/melodic/**'
@@ -35,7 +33,6 @@ jobs:
         env:
           - {HUB_REPO: ros, HUB_RELEASE: rolling, HUB_OS_NAME: ubuntu, HUB_OS_CODE_NAME: focal}
           - {HUB_REPO: ros, HUB_RELEASE: foxy, HUB_OS_NAME: ubuntu, HUB_OS_CODE_NAME: focal}
-          - {HUB_REPO: ros, HUB_RELEASE: eloquent, HUB_OS_NAME: ubuntu, HUB_OS_CODE_NAME: bionic}
           - {HUB_REPO: ros, HUB_RELEASE: dashing, HUB_OS_NAME: ubuntu, HUB_OS_CODE_NAME: bionic}
           # - {HUB_REPO: ros, HUB_RELEASE: noetic, HUB_OS_NAME: ubuntu, HUB_OS_CODE_NAME: focal}
           # - {HUB_REPO: ros, HUB_RELEASE: noetic, HUB_OS_NAME: debian, HUB_OS_CODE_NAME: buster}

--- a/ros/manifest.yaml
+++ b/ros/manifest.yaml
@@ -480,19 +480,20 @@ release_names:
                             - arm32v7
                             - arm64v8
                         tag_names:
-                            ros-core:
-                                aliases:
-                                    - "$release_name-ros-core"
-                                    - "$release_name-ros-core-$os_code_name"
-                            ros-base:
-                                aliases:
-                                    - "$release_name-ros-base"
-                                    - "$release_name-ros-base-$os_code_name"
-                                    - "$release_name"
-                            ros1-bridge:
-                                aliases:
-                                    - "$release_name-ros1-bridge"
-                                    - "$release_name-ros1-bridge-$os_code_name"
+                            # EOL
+                            # ros-core:
+                            #     aliases:
+                            #         - "$release_name-ros-core"
+                            #         - "$release_name-ros-core-$os_code_name"
+                            # ros-base:
+                            #     aliases:
+                            #         - "$release_name-ros-base"
+                            #         - "$release_name-ros-base-$os_code_name"
+                            #         - "$release_name"
+                            # ros1-bridge:
+                            #     aliases:
+                            #         - "$release_name-ros1-bridge"
+                            #         - "$release_name-ros1-bridge-$os_code_name"
     foxy:
         eol: 2025-05
         os_names:

--- a/ros/ros
+++ b/ros/ros
@@ -151,28 +151,6 @@ Directory: ros/dashing/ubuntu/bionic/ros1-bridge
 
 
 ################################################################################
-# Release: eloquent
-
-########################################
-# Distro: ubuntu:bionic
-
-Tags: eloquent-ros-core, eloquent-ros-core-bionic
-Architectures: amd64, arm32v7, arm64v8
-GitCommit: b3e79c3aef3687b56b3c1052ae38aa7010234834
-Directory: ros/eloquent/ubuntu/bionic/ros-core
-
-Tags: eloquent-ros-base, eloquent-ros-base-bionic, eloquent
-Architectures: amd64, arm32v7, arm64v8
-GitCommit: b3e79c3aef3687b56b3c1052ae38aa7010234834
-Directory: ros/eloquent/ubuntu/bionic/ros-base
-
-Tags: eloquent-ros1-bridge, eloquent-ros1-bridge-bionic
-Architectures: amd64, arm32v7, arm64v8
-GitCommit: b3e79c3aef3687b56b3c1052ae38aa7010234834
-Directory: ros/eloquent/ubuntu/bionic/ros1-bridge
-
-
-################################################################################
 # Release: foxy
 
 ########################################


### PR DESCRIPTION
Eloquent has been EOl since 2020-11.

There doesnt seem to be a final snapshot for it though so we cannot do a final image like we do for other ROS images at the moment.

@tfoote @nuclearsandwich Are ROS2 distros supposed to get a final snapshot when they EOL ?