### PR TITLE
Add ROS2 testing image

### DIFF
--- a/.github/workflows/trigger_testing.yaml
+++ b/.github/workflows/trigger_testing.yaml
@@ -1,0 +1,47 @@
+---
+name: CRON Trigger testing images
+
+on:
+  schedule:
+  # 7am UTC, 12am PDT
+  - cron:  '0 7 * * *'
+  push:
+    branches:
+    - main
+    paths:
+    - 'ros2/testing/**'
+
+jobs:
+  testing_build:
+    name: Trigger testing image
+    runs-on: ubuntu-latest
+    container:
+      image: osrf/ros2:testing
+    steps:
+      - name: "Check apt updates"
+        if: ${{ github.event_name == 'schedule' }}
+        env:
+          SOURCELIST: sources.list.d/ros2-testing.list
+        run: |
+          apt-get update \
+            -o Dir::Etc::sourcelist="${SOURCELIST}"
+          apt-get --simulate upgrade \
+            -o Dir::Etc::sourcelist="${SOURCELIST}" \
+            | grep "0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded." \
+            && echo "No apt updates" || echo "TRIGGER=true" >> $GITHUB_ENV
+      - name: "Check file updates"
+        if: ${{ github.event_name == 'push' }}
+        run: |
+          echo "TRIGGER=true" >> $GITHUB_ENV
+      - name: "Trigger Dockerhub URL"
+        if: ${{ fromJSON(env.TRIGGER) }}
+        env:
+          DATA: |
+            {
+              "docker_tag": "testing"
+            }
+        run: |
+          echo ${DATA} \
+            | curl -H "Content-Type: application/json" \
+              --data @- \
+              -X POST ${{ secrets.DOCKER_ROS2_POST_PUSH_TRIGGER }}

--- a/ros2/testing/rolling/Dockerfile
+++ b/ros2/testing/rolling/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update && apt-get install -q -y --no-install-recommends \
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
 
 # setup sources.list
-RUN echo "deb http://packages.ros.org/ros2/ubuntu focal main" > /etc/apt/sources.list.d/ros2-latest.list
+RUN echo "deb http://packages.ros.org/ros2-testing/ubuntu focal main" > /etc/apt/sources.list.d/ros2-testing.list
 
 # setup environment
 ENV LANG C.UTF-8

--- a/ros2/testing/rolling/Dockerfile
+++ b/ros2/testing/rolling/Dockerfile
@@ -1,0 +1,71 @@
+# This is an auto generated Dockerfile for ros:ros-core
+# generated from docker_images_ros2/create_ros_core_image.Dockerfile.em
+FROM ubuntu:focal
+
+# setup timezone
+RUN echo 'Etc/UTC' > /etc/timezone && \
+    ln -s /usr/share/zoneinfo/Etc/UTC /etc/localtime && \
+    apt-get update && \
+    apt-get install -q -y --no-install-recommends tzdata && \
+    rm -rf /var/lib/apt/lists/*
+
+# install packages
+RUN apt-get update && apt-get install -q -y --no-install-recommends \
+    dirmngr \
+    gnupg2 \
+    && rm -rf /var/lib/apt/lists/*
+
+# setup keys
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
+
+# setup sources.list
+RUN echo "deb http://packages.ros.org/ros2/ubuntu focal main" > /etc/apt/sources.list.d/ros2-latest.list
+
+# setup environment
+ENV LANG C.UTF-8
+ENV LC_ALL C.UTF-8
+
+ENV ROS_DISTRO rolling
+
+# install ros2 packages
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ros-rolling-ros-core=0.9.3-1* \
+    && rm -rf /var/lib/apt/lists/*
+
+# setup entrypoint
+COPY ./ros_entrypoint.sh /
+
+ENTRYPOINT ["/ros_entrypoint.sh"]
+CMD ["bash"]
+
+# This is an auto generated Dockerfile for ros:ros-base
+# generated from docker_images_ros2/create_ros_image.Dockerfile.em
+FROM ros:rolling-ros-core-focal
+
+# install bootstrap tools
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    build-essential \
+    git \
+    python3-colcon-common-extensions \
+    python3-colcon-mixin \
+    python3-rosdep \
+    python3-vcstool \
+    && rm -rf /var/lib/apt/lists/*
+
+# bootstrap rosdep
+RUN rosdep init && \
+  rosdep update --rosdistro $ROS_DISTRO
+
+# setup colcon mixin and metadata
+RUN colcon mixin add default \
+      https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml && \
+    colcon mixin update && \
+    colcon metadata add default \
+      https://raw.githubusercontent.com/colcon/colcon-metadata-repository/master/index.yaml && \
+    colcon metadata update
+
+# install ros2 packages
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ros-rolling-ros-base=0.9.3-1* \
+    && rm -rf /var/lib/apt/lists/*
+

--- a/ros2/testing/rolling/Dockerfile
+++ b/ros2/testing/rolling/Dockerfile
@@ -1,5 +1,3 @@
-# This is an auto generated Dockerfile for ros:ros-core
-# generated from docker_images_ros2/create_ros_core_image.Dockerfile.em
 FROM ubuntu:focal
 
 # setup timezone
@@ -24,23 +22,7 @@ RUN echo "deb http://packages.ros.org/ros2-testing/ubuntu focal main" > /etc/apt
 # setup environment
 ENV LANG C.UTF-8
 ENV LC_ALL C.UTF-8
-
 ENV ROS_DISTRO rolling
-
-# install ros2 packages
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    ros-rolling-ros-core=0.9.3-1* \
-    && rm -rf /var/lib/apt/lists/*
-
-# setup entrypoint
-COPY ./ros_entrypoint.sh /
-
-ENTRYPOINT ["/ros_entrypoint.sh"]
-CMD ["bash"]
-
-# This is an auto generated Dockerfile for ros:ros-base
-# generated from docker_images_ros2/create_ros_image.Dockerfile.em
-FROM ros:rolling-ros-core-focal
 
 # install bootstrap tools
 RUN apt-get update && apt-get install --no-install-recommends -y \
@@ -64,8 +46,7 @@ RUN colcon mixin add default \
       https://raw.githubusercontent.com/colcon/colcon-metadata-repository/master/index.yaml && \
     colcon metadata update
 
-# install ros2 packages
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    ros-rolling-ros-base=0.9.3-1* \
-    && rm -rf /var/lib/apt/lists/*
-
+# setup entrypoint
+COPY ./ros_entrypoint.sh /
+ENTRYPOINT ["/ros_entrypoint.sh"]
+CMD ["bash"]

--- a/ros2/testing/rolling/ros_entrypoint.sh
+++ b/ros2/testing/rolling/ros_entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+# setup ros2 environment
+source "/opt/ros/$ROS_DISTRO/setup.bash"
+exec "$@"


### PR DESCRIPTION
Fixes: https://github.com/osrf/docker_images/issues/533

Useful for CI, where not all of `osrf/ros2:nightly` is needed, but `ros:rolling` is too behind upstream.

CC @SteveMacenski 