### PR TITLE
Melodic Stretch and Eloquent are EOL and use snapshots apt repo

### DIFF
--- a/ros/eloquent/ubuntu/bionic/ros-core/Dockerfile
+++ b/ros/eloquent/ubuntu/bionic/ros-core/Dockerfile
@@ -15,11 +15,11 @@ RUN apt-get update && apt-get install -q -y --no-install-recommends \
     gnupg2 \
     && rm -rf /var/lib/apt/lists/*
 
-# setup keys
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
-
 # setup sources.list
-RUN echo "deb http://packages.ros.org/ros2/ubuntu bionic main" > /etc/apt/sources.list.d/ros2-latest.list
+RUN echo "deb http://snapshots.ros.org/eloquent/final/ubuntu bionic main" > /etc/apt/sources.list.d/ros2-snapshots.list
+
+# setup keys
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 4B63CF8FDE49746E98FA01DDAD19BAB3CBF125EA
 
 # setup environment
 ENV LANG C.UTF-8

--- a/ros/eloquent/ubuntu/bionic/ros1-bridge/Dockerfile
+++ b/ros/eloquent/ubuntu/bionic/ros1-bridge/Dockerfile
@@ -2,18 +2,18 @@
 # generated from docker_images_ros2/ros1_bridge/create_ros_ros1_bridge_image.Dockerfile.em
 FROM ros:eloquent-ros-base-bionic
 
-# setup keys
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
-
 # setup sources.list
 RUN echo "deb http://packages.ros.org/ros/ubuntu bionic main" > /etc/apt/sources.list.d/ros1-latest.list
+
+# setup keys
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
 
 ENV ROS1_DISTRO melodic
 ENV ROS2_DISTRO eloquent
 
 # install ros packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    ros-melodic-ros-comm=1.14.10-1* \
+    ros-melodic-ros-comm=1.14.11-1* \
     ros-melodic-roscpp-tutorials=0.9.3-1* \
     ros-melodic-rospy-tutorials=0.9.3-1* \
     && rm -rf /var/lib/apt/lists/*

--- a/ros/melodic/debian/stretch/ros-core/Dockerfile
+++ b/ros/melodic/debian/stretch/ros-core/Dockerfile
@@ -8,11 +8,11 @@ RUN apt-get update && apt-get install -q -y --no-install-recommends \
     gnupg2 \
     && rm -rf /var/lib/apt/lists/*
 
-# setup keys
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
-
 # setup sources.list
-RUN echo "deb http://packages.ros.org/ros/ubuntu stretch main" > /etc/apt/sources.list.d/ros1-latest.list
+RUN echo "deb http://snapshots.ros.org/melodic/final/debian stretch main" > /etc/apt/sources.list.d/ros1-snapshots.list
+
+# setup keys
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 4B63CF8FDE49746E98FA01DDAD19BAB3CBF125EA
 
 # setup environment
 ENV LANG C.UTF-8

--- a/ros/ros
+++ b/ros/ros
@@ -59,7 +59,7 @@ Directory: ros/melodic/ubuntu/bionic/perception
 
 Tags: melodic-ros-core-stretch
 Architectures: amd64, arm64v8
-GitCommit: df19ab7d5993d3b78a908362cdcd1479a8e78b35
+GitCommit: d017429ffef82c2ae91e5f81a4a60640b2ad6c1b
 Directory: ros/melodic/debian/stretch/ros-core
 
 Tags: melodic-ros-base-stretch
@@ -158,7 +158,7 @@ Directory: ros/dashing/ubuntu/bionic/ros1-bridge
 
 Tags: eloquent-ros-core, eloquent-ros-core-bionic
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: b3e79c3aef3687b56b3c1052ae38aa7010234834
+GitCommit: 45dbb7bd0bb08303e50ecde4a60e827f7cec0ab0
 Directory: ros/eloquent/ubuntu/bionic/ros-core
 
 Tags: eloquent-ros-base, eloquent-ros-base-bionic, eloquent
@@ -168,7 +168,7 @@ Directory: ros/eloquent/ubuntu/bionic/ros-base
 
 Tags: eloquent-ros1-bridge, eloquent-ros1-bridge-bionic
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: b3e79c3aef3687b56b3c1052ae38aa7010234834
+GitCommit: 45dbb7bd0bb08303e50ecde4a60e827f7cec0ab0
 Directory: ros/eloquent/ubuntu/bionic/ros1-bridge
 
 


### PR DESCRIPTION
Part of hotfix for #535

This will allow to build a last official version of these images before retiring them definitely.
Required before #430 and #529 