### PR TITLE
EOL melodic stretch and eloquent

### DIFF
--- a/.github/workflows/ros_ci.yaml
+++ b/.github/workflows/ros_ci.yaml
@@ -9,7 +9,6 @@ on:
     - 'ros/rolling/**'
     - 'ros/galactic/**'
     - 'ros/foxy/**'
-    - 'ros/eloquent/**'
     - 'ros/dashing/**'
     # - 'ros/noetic/**'
     - 'ros/melodic/**'
@@ -21,7 +20,6 @@ on:
     - 'ros/rolling/**'
     - 'ros/galactic/**'
     - 'ros/foxy/**'
-    - 'ros/eloquent/**'
     - 'ros/dashing/**'
     # - 'ros/noetic/**'
     - 'ros/melodic/**'
@@ -38,12 +36,10 @@ jobs:
           - {HUB_REPO: ros, HUB_RELEASE: rolling, HUB_OS_NAME: ubuntu, HUB_OS_CODE_NAME: focal}
           - {HUB_REPO: ros, HUB_RELEASE: galactic, HUB_OS_NAME: ubuntu, HUB_OS_CODE_NAME: focal}
           - {HUB_REPO: ros, HUB_RELEASE: foxy, HUB_OS_NAME: ubuntu, HUB_OS_CODE_NAME: focal}
-          - {HUB_REPO: ros, HUB_RELEASE: eloquent, HUB_OS_NAME: ubuntu, HUB_OS_CODE_NAME: bionic}
           - {HUB_REPO: ros, HUB_RELEASE: dashing, HUB_OS_NAME: ubuntu, HUB_OS_CODE_NAME: bionic}
           # - {HUB_REPO: ros, HUB_RELEASE: noetic, HUB_OS_NAME: ubuntu, HUB_OS_CODE_NAME: focal}
           # - {HUB_REPO: ros, HUB_RELEASE: noetic, HUB_OS_NAME: debian, HUB_OS_CODE_NAME: buster}
           - {HUB_REPO: ros, HUB_RELEASE: melodic, HUB_OS_NAME: ubuntu, HUB_OS_CODE_NAME: bionic}
-          - {HUB_REPO: ros, HUB_RELEASE: melodic, HUB_OS_NAME: debian, HUB_OS_CODE_NAME: stretch}
           - {HUB_REPO: ros, HUB_RELEASE: kinetic, HUB_OS_NAME: ubuntu, HUB_OS_CODE_NAME: xenial}
     runs-on: ubuntu-latest
     env:

--- a/ros/manifest.yaml
+++ b/ros/manifest.yaml
@@ -314,18 +314,19 @@ release_names:
                             - amd64
                             - arm64v8
                         tag_names:
-                            ros-core:
-                                aliases:
-                                    - "$release_name-ros-core-$os_code_name"
-                            ros-base:
-                                aliases:
-                                    - "$release_name-ros-base-$os_code_name"
-                            robot:
-                                aliases:
-                                    - "$release_name-robot-$os_code_name"
-                            perception:
-                                aliases:
-                                    - "$release_name-perception-$os_code_name"
+                            # EOL
+                            # ros-core:
+                            #     aliases:
+                            #         - "$release_name-ros-core-$os_code_name"
+                            # ros-base:
+                            #     aliases:
+                            #         - "$release_name-ros-base-$os_code_name"
+                            # robot:
+                            #     aliases:
+                            #         - "$release_name-robot-$os_code_name"
+                            # perception:
+                            #     aliases:
+                            #         - "$release_name-perception-$os_code_name"
     noetic:
         eol: 2025-05
         os_names:
@@ -480,19 +481,20 @@ release_names:
                             - arm32v7
                             - arm64v8
                         tag_names:
-                            ros-core:
-                                aliases:
-                                    - "$release_name-ros-core"
-                                    - "$release_name-ros-core-$os_code_name"
-                            ros-base:
-                                aliases:
-                                    - "$release_name-ros-base"
-                                    - "$release_name-ros-base-$os_code_name"
-                                    - "$release_name"
-                            ros1-bridge:
-                                aliases:
-                                    - "$release_name-ros1-bridge"
-                                    - "$release_name-ros1-bridge-$os_code_name"
+                            # EOL
+                            # ros-core:
+                            #     aliases:
+                            #         - "$release_name-ros-core"
+                            #         - "$release_name-ros-core-$os_code_name"
+                            # ros-base:
+                            #     aliases:
+                            #         - "$release_name-ros-base"
+                            #         - "$release_name-ros-base-$os_code_name"
+                            #         - "$release_name"
+                            # ros1-bridge:
+                            #     aliases:
+                            #         - "$release_name-ros1-bridge"
+                            #         - "$release_name-ros1-bridge-$os_code_name"
     foxy:
         eol: 2025-05
         os_names:
@@ -745,8 +747,9 @@ hacks:
                 os_code_names:
                     bionic:
                         tag_names:
-                            desktop:
-                                <<: *DEFAULT_HOOKS
+                            # EOL
+                            # desktop:
+                            #     <<: *DEFAULT_HOOKS
     foxy:
         os_names:
             ubuntu:

--- a/ros/ros
+++ b/ros/ros
@@ -54,29 +54,6 @@ Architectures: amd64, arm32v7, arm64v8
 GitCommit: df19ab7d5993d3b78a908362cdcd1479a8e78b35
 Directory: ros/melodic/ubuntu/bionic/perception
 
-########################################
-# Distro: debian:stretch
-
-Tags: melodic-ros-core-stretch
-Architectures: amd64, arm64v8
-GitCommit: d017429ffef82c2ae91e5f81a4a60640b2ad6c1b
-Directory: ros/melodic/debian/stretch/ros-core
-
-Tags: melodic-ros-base-stretch
-Architectures: amd64, arm64v8
-GitCommit: df19ab7d5993d3b78a908362cdcd1479a8e78b35
-Directory: ros/melodic/debian/stretch/ros-base
-
-Tags: melodic-robot-stretch
-Architectures: amd64, arm64v8
-GitCommit: df19ab7d5993d3b78a908362cdcd1479a8e78b35
-Directory: ros/melodic/debian/stretch/robot
-
-Tags: melodic-perception-stretch
-Architectures: amd64, arm64v8
-GitCommit: df19ab7d5993d3b78a908362cdcd1479a8e78b35
-Directory: ros/melodic/debian/stretch/perception
-
 
 ################################################################################
 # Release: noetic
@@ -148,28 +125,6 @@ Tags: dashing-ros1-bridge, dashing-ros1-bridge-bionic
 Architectures: amd64, arm32v7, arm64v8
 GitCommit: 11c613986e35a1f36fd0fa18b49173e0c564cf1d
 Directory: ros/dashing/ubuntu/bionic/ros1-bridge
-
-
-################################################################################
-# Release: eloquent
-
-########################################
-# Distro: ubuntu:bionic
-
-Tags: eloquent-ros-core, eloquent-ros-core-bionic
-Architectures: amd64, arm32v7, arm64v8
-GitCommit: 45dbb7bd0bb08303e50ecde4a60e827f7cec0ab0
-Directory: ros/eloquent/ubuntu/bionic/ros-core
-
-Tags: eloquent-ros-base, eloquent-ros-base-bionic, eloquent
-Architectures: amd64, arm32v7, arm64v8
-GitCommit: b3e79c3aef3687b56b3c1052ae38aa7010234834
-Directory: ros/eloquent/ubuntu/bionic/ros-base
-
-Tags: eloquent-ros1-bridge, eloquent-ros1-bridge-bionic
-Architectures: amd64, arm32v7, arm64v8
-GitCommit: 45dbb7bd0bb08303e50ecde4a60e827f7cec0ab0
-Directory: ros/eloquent/ubuntu/bionic/ros1-bridge
 
 
 ################################################################################


### PR DESCRIPTION
Now that final images have been built with the final snapshots: https://github.com/docker-library/official-images/pull/10270
we can retire the Eloquent and Melodic on Debian Stretch images

Replaces https://github.com/osrf/docker_images/pull/529 and https://github.com/osrf/docker_images/pull/430