### PR TITLE
Use dependabot to trigger rebuilds for osrf/ros2:testing

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,9 @@ updates:
       interval: "daily"
     commit-message:
       prefix: "🐳"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "🛠️"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "docker"
+    directory: "/ros2/testing/testing"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "🐳"

--- a/ros2/testing/testing/Dockerfile
+++ b/ros2/testing/testing/Dockerfile
@@ -1,7 +1,7 @@
 # This is an auto generated Dockerfile for ros:testing
 # generated from docker_images_ros2/testing/create_ros_image.Dockerfile.em
-ARG FROM_IMAGE=ubuntu:focal
-FROM $FROM_IMAGE
+# ARG FROM_IMAGE=ubuntu:focal
+FROM ubuntu:focal-20210401
 
 # setup timezone
 RUN echo 'Etc/UTC' > /etc/timezone && \

--- a/ros2/testing/testing/hooks/post_push
+++ b/ros2/testing/testing/hooks/post_push
@@ -1,0 +1,15 @@
+#!/bin/bash
+# http://windsock.io/automated-docker-image-builds-with-multiple-tags/
+
+set -e
+
+# Parse image name for repo name
+tagStart=$(expr index "$IMAGE_NAME" :)
+repoName=${IMAGE_NAME:0:tagStart-1}
+timestamp=$(date +%Y%m%d%H%M%S)
+
+# Tag and push image for each additional tag
+for tag in testing-${timestamp}; do
+    docker tag $IMAGE_NAME ${repoName}:${tag}
+    docker push ${repoName}:${tag}
+done

--- a/ros2/testing/testing/hooks/post_push
+++ b/ros2/testing/testing/hooks/post_push
@@ -6,7 +6,7 @@ set -e
 # Parse image name for repo name
 tagStart=$(expr index "$IMAGE_NAME" :)
 repoName=${IMAGE_NAME:0:tagStart-1}
-timestamp=$(date +%Y%m%d%H%M%S)
+timestamp=$(date --utc +%Y%m%d%H%M%S)
 
 # Tag and push image for each additional tag
 for tag in testing-${timestamp}; do


### PR DESCRIPTION
Using [dependabot](https://docs.github.com/en/code-security/supply-chain-security/managing-vulnerabilities-in-your-projects-dependencies/configuring-dependabot-security-updates), we can automate the rebuilding of local docker images to be in lock step with that of respective parent images. We can do this by pinning the tag of the parent image to include the [version identifier](https://hub.docker.com/_/ubuntu?tab=tags&page=1&ordering=last_updated&name=focal-2021) provided by the parent repo, and then configuring dependabot to watch the local manifest (or Dockerfile) for available version updates. This will subsequently open auto generate PRs to ratchet up the parent image tag when a newer version is pushed to the public docker registry upstream. 

Upon merging changes to local Dockerfiles, existing github actions (https://github.com/osrf/docker_images/pull/542) will trigger docker rebuilds of local image tags. The added build hook will also timestamp newly built image tags, allowing downstream projects building from our local images to use dependabot to similarly watch for updates to parent image tags.

Example dependabot PR:

- https://github.com/ruffsl/docker_images/pull/29

While the earlier beta version of dependabot provided a feature for auto merging dependabot PRs, this has been subsequently removed from the native integration offered by GitHub. While this feature can be replicated via third-party actions, it seems that  much of this is still in flux due to migration and roadmap changes.

References:

- https://hugo.alliau.me/2021/05/04/migration-to-github-native-dependabot-solutions-for-auto-merge-and-action-secrets/
- https://github.com/ahmadnassri/action-dependabot-auto-merge/issues/89
- https://github.com/dependabot/dependabot-core/issues/1973
- https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates