### PR TITLE
install curl to be able to push images to dockerhub

### DIFF
--- a/.github/workflows/trigger_testing.yaml
+++ b/.github/workflows/trigger_testing.yaml
@@ -32,6 +32,7 @@ jobs:
             -o Dir::Etc::sourcelist="${SOURCELIST}" \
             | grep "0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded." \
             && echo "No apt updates" || echo "TRIGGER=true" >> $GITHUB_ENV
+          apt-get install -q -y curl
       - name: "Check file updates"
         if: ${{ github.event_name == 'push' }}
         run: |


### PR DESCRIPTION
looks like it's been month the trigger testing job fails.
Log extract:
```
Run echo ${DATA} \
  echo ${DATA} \
    | curl -H "Content-Type: application/json" \
      --data @- \
      -X POST ***
  shell: sh -e {0}
  env:
    TRIGGER: true
    DATA: {
    "docker_tag": "testing"
  }
  
/__w/_temp/cd465d4e-1d7f-4b03-8630-d512411916bc.sh: 2: curl: not found
Error: Process completed with exit code 127.
```

This is an attempt to fix it by installing curl earlier in the workflow @ruffsl FYI