### PR TITLE
Revert to separate Dockerfiles for nightly tags

### DIFF
--- a/.github/workflows/trigger_nightly.yaml
+++ b/.github/workflows/trigger_nightly.yaml
@@ -114,10 +114,11 @@ jobs:
         id: docker_build_nightly-rmw
         uses: docker/build-push-action@v2
         with:
-          context: ros2/nightly/nightly
-          pull: false
+          context: ros2/nightly/nightly-rmw
+          pull: true
           push: true
           no-cache: false
+          cache-from: type=registry,ref=osrf/ros2:nightly-rmw
           cache-to: type=inline
           build-args: |
             TIMESTAMP=${{ steps.config.outputs.timestamp }}
@@ -133,10 +134,11 @@ jobs:
         id: docker_build_nightly-rmw-nonfree
         uses: docker/build-push-action@v2
         with:
-          context: ros2/nightly/nightly
-          pull: false
+          context: ros2/nightly/nightly-rmw-nonfree
+          pull: true
           push: true
           no-cache: false
+          cache-from: type=registry,ref=osrf/ros2:nightly-rmw-nonfree
           cache-to: type=inline
           build-args: |
             TIMESTAMP=${{ steps.config.outputs.timestamp }}

--- a/ros2/nightly/Makefile
+++ b/ros2/nightly/Makefile
@@ -10,9 +10,9 @@ help:
 	@echo ""
 
 build:
-	@docker build --tag=osrf/ros2:nightly --target nightly nightly/.
-	@docker build --tag=osrf/ros2:nightly-rmw --target nightly-rmw nightly/.
-	@docker build --tag=osrf/ros2:nightly-rmw-nonfree --target nightly-rmw-nonfree nightly/.
+	@docker build --tag=osrf/ros2:nightly nightly/.
+	@docker build --tag=osrf/ros2:nightly-rmw nightly-rmw/.
+	@docker build --tag=osrf/ros2:nightly-rmw-nonfree nightly-rmw-nonfree/.
 
 pull:
 	@docker pull osrf/ros2:nightly

--- a/ros2/nightly/nightly-rmw-nonfree/Dockerfile
+++ b/ros2/nightly/nightly-rmw-nonfree/Dockerfile
@@ -1,0 +1,16 @@
+FROM osrf/ros2:nightly-rmw
+ARG DEBIAN_FRONTEND=noninteractive
+
+# install dependencies
+ARG RTI_NC_LICENSE_ACCEPTED=yes
+RUN apt-get update && rosdep install -y \
+    --from-paths /opt/ros/$ROS_DISTRO/share \
+    --ignore-src \
+    --skip-keys " \
+      " \
+    && rm -rf /var/lib/apt/lists/*
+
+# set up environment
+ENV NDDSHOME /opt/rti.com/rti_connext_dds-5.3.1
+ENV PATH "$NDDSHOME/bin":$PATH
+ENV LD_LIBRARY_PATH "$NDDSHOME/lib/x64Linux3gcc5.4.0":$LD_LIBRARY_PATH

--- a/ros2/nightly/nightly-rmw/Dockerfile
+++ b/ros2/nightly/nightly-rmw/Dockerfile
@@ -1,0 +1,10 @@
+FROM osrf/ros2:nightly
+ARG DEBIAN_FRONTEND=noninteractive
+
+# install dependencies
+RUN apt-get update && rosdep install -y \
+    --from-paths /opt/ros/$ROS_DISTRO/share \
+    --ignore-src \
+    --skip-keys " \
+      rti-connext-dds-5.3.1" \
+    && rm -rf /var/lib/apt/lists/*

--- a/ros2/nightly/nightly/Dockerfile
+++ b/ros2/nightly/nightly/Dockerfile
@@ -125,35 +125,3 @@ COPY ./ros_entrypoint.sh /
 
 ENTRYPOINT ["/ros_entrypoint.sh"]
 CMD ["bash"]
-
-
-# multi-stage for nightly-rmw
-FROM nightly AS nightly-rmw
-ARG DEBIAN_FRONTEND=noninteractive
-
-# install dependencies
-RUN apt-get update && rosdep install -y \
-    --from-paths /opt/ros/$ROS_DISTRO/share \
-    --ignore-src \
-    --skip-keys " \
-      rti-connext-dds-5.3.1" \
-    && rm -rf /var/lib/apt/lists/*
-
-
-# multi-stage for nightly-rmw-nonfree
-FROM nightly-rmw AS nightly-rmw-nonfree
-ARG DEBIAN_FRONTEND=noninteractive
-
-# install dependencies
-ARG RTI_NC_LICENSE_ACCEPTED=yes
-RUN apt-get update && rosdep install -y \
-    --from-paths /opt/ros/$ROS_DISTRO/share \
-    --ignore-src \
-    --skip-keys " \
-      " \
-    && rm -rf /var/lib/apt/lists/*
-
-# set up environment
-ENV NDDSHOME /opt/rti.com/rti_connext_dds-5.3.1
-ENV PATH "$NDDSHOME/bin":$PATH
-ENV LD_LIBRARY_PATH "$NDDSHOME/lib/x64Linux3gcc5.4.0":$LD_LIBRARY_PATH


### PR DESCRIPTION
workarround cache busts that occur with multistages and docker build action
E.g: https://github.com/osrf/docker_images/runs/4972843126?check_suite_focus=true