### PR TITLE
use git+https to fix https://github.com/pypa/pip/issues/10630

### DIFF
--- a/.ci/requirements.txt
+++ b/.ci/requirements.txt
@@ -6,8 +6,8 @@ PyGithub
 
 ###### Requirements with Repo Specifiers ######
 #   See https://pip.readthedocs.io/en/stable/reference/pip_install/#git
-# git+git://github.com/PyGithub/PyGithub.git@master#egg=PyGithub
-git+git://github.com/ruffsl/chuck-norris-python.git@10eb8b847b8b73dfca16095fc79bdf36fcec8aa5#egg=chuck-norris-python
+# git+https://github.com/PyGithub/PyGithub.git@master#egg=PyGithub
+git+https://github.com/ruffsl/chuck-norris-python.git@10eb8b847b8b73dfca16095fc79bdf36fcec8aa5#egg=chuck-norris-python
 
 ###### Requirements with Version Specifiers ######
 #   See https://www.python.org/dev/peps/pep-0440/#version-specifiers

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -8,8 +8,8 @@ pyyaml
 
 ###### Requirements with Repo Specifiers ######
 #   See https://pip.readthedocs.io/en/stable/reference/pip_install/#git
-git+git://github.com/ros-infrastructure/ros_buildfarm.git@master#egg=ros_buildfarm
-git+git://github.com/osrf/docker_templates.git@master#egg=docker_templates
+git+https://github.com/ros-infrastructure/ros_buildfarm.git@master#egg=ros_buildfarm
+git+https://github.com/osrf/docker_templates.git@master#egg=docker_templates
 
 ###### Requirements with Version Specifiers ######
 #   See https://www.python.org/dev/peps/pep-0440/#version-specifiers


### PR DESCRIPTION
CI has been failing since March 15th due to pip unable to clone git repositories.

```
Collecting ros_buildfarm
  Cloning git://github.com/ros-infrastructure/ros_buildfarm.git (to revision master) to /tmp/pip-install-sir5b5sa/ros-buildfarm_3684ada66f894f47bab666bb4bcdc0e5
  Running command git clone --filter=blob:none --quiet git://github.com/ros-infrastructure/ros_buildfarm.git /tmp/pip-install-sir5b5sa/ros-buildfarm_3684ada66f894f47bab666bb4bcdc0e5
  fatal: remote error:
    The unauthenticated git protocol on port 9418 is no longer supported.
  Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
  error: subprocess-exited-with-error
```

Using `git+https` instead of `git+git` solves the issue

Additionnal references:
https://github.com/pypa/pip/issues/10630
https://github.blog/2021-09-01-improving-git-protocol-security-github/
