### PR TITLE
Add rolling desktop-full

### DIFF
--- a/ros/rolling/ubuntu/jammy/desktop-full/Dockerfile
+++ b/ros/rolling/ubuntu/jammy/desktop-full/Dockerfile
@@ -1,0 +1,9 @@
+# This is an auto generated Dockerfile for ros:desktop-full
+# generated from docker_images_ros2/create_ros_image.Dockerfile.em
+FROM osrf/ros:rolling-desktop-jammy
+
+# install ros2 packages
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ros-rolling-desktop-full=0.9.3-2* \
+    && rm -rf /var/lib/apt/lists/*
+

--- a/ros/rolling/ubuntu/jammy/perception/Dockerfile
+++ b/ros/rolling/ubuntu/jammy/perception/Dockerfile
@@ -1,9 +1,9 @@
 # This is an auto generated Dockerfile for ros:desktop-full
 # generated from docker_images_ros2/create_ros_image.Dockerfile.em
-FROM osrf/ros:rolling-desktop-jammy
+FROM ros:rolling-ros-base-jammy
 
 # install ros2 packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    ros-rolling-desktop-full=0.10.0-1* \
+    ros-rolling-perception=0.10.0-1* \
     && rm -rf /var/lib/apt/lists/*
 

--- a/ros/rolling/ubuntu/jammy/simulation/Dockerfile
+++ b/ros/rolling/ubuntu/jammy/simulation/Dockerfile
@@ -1,9 +1,9 @@
 # This is an auto generated Dockerfile for ros:desktop-full
 # generated from docker_images_ros2/create_ros_image.Dockerfile.em
-FROM osrf/ros:rolling-desktop-jammy
+FROM ros:rolling-ros-base-jammy
 
 # install ros2 packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    ros-rolling-desktop-full=0.10.0-1* \
+    ros-rolling-simulation=0.10.0-1* \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Desktop-full is finally on ROS 2, see

* https://github.com/ros-infrastructure/rep/pull/334
* https://github.com/ros2/variants/pull/34

`variants` hasn't been bloomed with the new package yet, but I wanted to make sure I opened this PR before I forgot. The exact hardcoded version will likely change.

