### PR TITLE
replace deprecated github set output

### DIFF
--- a/.github/workflows/trigger_devel.yaml
+++ b/.github/workflows/trigger_devel.yaml
@@ -24,8 +24,8 @@ jobs:
         id: check
         if: github.event_name == 'push'
         run: |
-          echo "::set-output name=trigger::true"
-          echo "::set-output name=no_cache::false"
+          echo "trigger=true" >> $GITHUB_OUTPUT
+          echo "no_cache=false" >> $GITHUB_OUTPUT
   check_image:
     name: Check Image
     if: github.event_name == 'schedule'
@@ -50,9 +50,9 @@ jobs:
           cat upgrade.log
           cat upgrade.log \
             | grep "^0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.$" \
-            && echo "::set-output name=trigger::false" \
-            || echo "::set-output name=trigger::true"
-          echo "::set-output name=no_cache::true"
+            && echo "trigger=false" >> $GITHUB_OUTPUT \
+            || echo "trigger=true" >> $GITHUB_OUTPUT
+          echo "no_cache=true" >> $GITHUB_OUTPUT
   rebuild_image:
     name: Rebuild Image
     if: always()
@@ -74,21 +74,21 @@ jobs:
         id: config
         run: |
           timestamp=$(date --utc +%Y%m%d%H%M%S)
-          echo "::set-output name=timestamp::${timestamp}"
+          echo "timestamp=${timestamp}" >> $GITHUB_OUTPUT
           no_cache=false
           if  [ "${{needs.check_files.outputs.no_cache}}" == 'true' ] || \
               [ "${{needs.check_image.outputs.no_cache}}" == 'true' ]
           then
             no_cache=true
           fi
-          echo "::set-output name=no_cache::${no_cache}"
+          echo "no_cache=${no_cache}" >> $GITHUB_OUTPUT
           trigger=false
           if  [ "${{needs.check_files.outputs.trigger}}" == 'true' ] || \
               [ "${{needs.check_image.outputs.trigger}}" == 'true' ]
           then
             trigger=true
           fi
-          echo "::set-output name=trigger::${trigger}"
+          echo "trigger=${trigger}" >> $GITHUB_OUTPUT
       - name: Build and push
         if: steps.config.outputs.trigger == 'true'
         id: docker_build

--- a/.github/workflows/trigger_nightly.yaml
+++ b/.github/workflows/trigger_nightly.yaml
@@ -24,8 +24,8 @@ jobs:
         id: check
         if: github.event_name == 'push'
         run: |
-          echo "::set-output name=trigger::true"
-          echo "::set-output name=no_cache::false"S
+          echo "trigger=true" >> $GITHUB_OUTPUT
+          echo "no_cache=false" >> $GITHUB_OUTPUT
   check_image:
     name: Check Image
     if: github.event_name == 'schedule'
@@ -50,9 +50,9 @@ jobs:
           cat upgrade.log
           cat upgrade.log \
             | grep "^0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.$" \
-            && echo "::set-output name=no_cache::false" \
-            || echo "::set-output name=no_cache::true"
-          echo "::set-output name=trigger::true"
+            && echo "no_cache=false" >> $GITHUB_OUTPUT \
+            || echo "no_cache=true" >> $GITHUB_OUTPUT
+          echo "trigger=true" >> $GITHUB_OUTPUT
   rebuild_image:
     name: Rebuild Image
     if: always()
@@ -74,21 +74,21 @@ jobs:
         id: config
         run: |
           timestamp=$(date --utc +%Y%m%d%H%M%S)
-          echo "::set-output name=timestamp::${timestamp}"
+          echo "timestamp=${timestamp}" >> $GITHUB_OUTPUT
           no_cache=false
           if  [ "${{needs.check_files.outputs.no_cache}}" == 'true' ] || \
               [ "${{needs.check_image.outputs.no_cache}}" == 'true' ]
           then
             no_cache=true
           fi
-          echo "::set-output name=no_cache::${no_cache}"
+          echo "no_cache=${no_cache}" >> $GITHUB_OUTPUT
           trigger=false
           if  [ "${{needs.check_files.outputs.trigger}}" == 'true' ] || \
               [ "${{needs.check_image.outputs.trigger}}" == 'true' ]
           then
             trigger=true
           fi
-          echo "::set-output name=trigger::${trigger}"
+          echo "trigger=${trigger}" >> $GITHUB_OUTPUT
       - name: Build and push nightly
         if: steps.config.outputs.trigger == 'true'
         id: docker_build_nightly

--- a/.github/workflows/trigger_testing.yaml
+++ b/.github/workflows/trigger_testing.yaml
@@ -24,8 +24,8 @@ jobs:
         id: check
         if: github.event_name == 'push'
         run: |
-          echo "::set-output name=trigger::true"
-          echo "::set-output name=no_cache::false"
+          echo "trigger=true" >> $GITHUB_OUTPUT
+          echo "no_cache=false" >> $GITHUB_OUTPUT
   check_image:
     name: Check Image
     if: github.event_name == 'schedule'
@@ -50,9 +50,9 @@ jobs:
           cat upgrade.log
           cat upgrade.log \
             | grep "^0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.$" \
-            && echo "::set-output name=trigger::false" \
-            || echo "::set-output name=trigger::true"
-          echo "::set-output name=no_cache::true"
+            && echo "trigger=false" >> $GITHUB_OUTPUT \
+            || echo "trigger=true" >> $GITHUB_OUTPUT
+          echo "no_cache=true" >> $GITHUB_OUTPUT
   rebuild_image:
     name: Rebuild Image
     if: always()
@@ -74,21 +74,21 @@ jobs:
         id: config
         run: |
           timestamp=$(date --utc +%Y%m%d%H%M%S)
-          echo "::set-output name=timestamp::${timestamp}"
+          echo "timestamp=${timestamp}" >> $GITHUB_OUTPUT
           no_cache=false
           if  [ "${{needs.check_files.outputs.no_cache}}" == 'true' ] || \
               [ "${{needs.check_image.outputs.no_cache}}" == 'true' ]
           then
             no_cache=true
           fi
-          echo "::set-output name=no_cache::${no_cache}"
+          echo "no_cache=${no_cache}" >> $GITHUB_OUTPUT
           trigger=false
           if  [ "${{needs.check_files.outputs.trigger}}" == 'true' ] || \
               [ "${{needs.check_image.outputs.trigger}}" == 'true' ]
           then
             trigger=true
           fi
-          echo "::set-output name=trigger::${trigger}"
+          echo "trigger=${trigger}" >> $GITHUB_OUTPUT
       - name: Build and push
         if: steps.config.outputs.trigger == 'true'
         id: docker_build


### PR DESCRIPTION
To avoid warnings, update based on https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Signed-off-by: Mikael Arguedas <mikael.arguedas@gmail.com>