### PR TITLE
update rosdep before install

### DIFF
--- a/ros2/nightly/nightly/Dockerfile
+++ b/ros2/nightly/nightly/Dockerfile
@@ -109,7 +109,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 # install dependencies
 COPY --from=cacher /tmp/opt/ros/$ROS_DISTRO /opt/ros/$ROS_DISTRO
-RUN apt-get update && rosdep install -y \
+RUN apt-get update && rosdep update && rosdep install -y \
     --from-paths /opt/ros/$ROS_DISTRO/share \
     --ignore-src \
     --skip-keys " \


### PR DESCRIPTION
CI has been failing on nightly for a couple days. Looks like it struggles to resolve some rosdep keys. Attempting to fix that with the addition of a rosdep update before install 