### PR TITLE
Gazebo 9 EOL

### DIFF
--- a/.github/workflows/gazebo_ci.yaml
+++ b/.github/workflows/gazebo_ci.yaml
@@ -6,13 +6,11 @@ on:
     - '.ci/**'
     - '.github/workflows/gazebo_ci.yaml'
     - 'gazebo/11/**'
-    - 'gazebo/9/**'
   push:
     paths:
     - '.ci/**'
     - '.github/workflows/gazebo_ci.yaml'
     - 'gazebo/11/**'
-    - 'gazebo/9/**'
   schedule:
     # Trigger daily to check for upstream changes
     - cron: '0 0 * * *'
@@ -24,8 +22,6 @@ jobs:
         env:
           - {HUB_REPO: gazebo, HUB_RELEASE: 11, HUB_OS_NAME: ubuntu, HUB_OS_CODE_NAME: focal}
           - {HUB_REPO: gazebo, HUB_RELEASE: 11, HUB_OS_NAME: ubuntu, HUB_OS_CODE_NAME: bionic}
-          - {HUB_REPO: gazebo, HUB_RELEASE: 9, HUB_OS_NAME: ubuntu, HUB_OS_CODE_NAME: bionic}
-          - {HUB_REPO: gazebo, HUB_RELEASE: 9, HUB_OS_NAME: ubuntu, HUB_OS_CODE_NAME: xenial}
     runs-on: ubuntu-latest
     env:
       GITHUBEMAIL: ${{ secrets.GITHUBEMAIL }}

--- a/gazebo/gazebo
+++ b/gazebo/gazebo
@@ -2,36 +2,6 @@ Maintainers: Tully Foote <tfoote+buildfarm@osrfoundation.org> (@tfoote)
 GitRepo: https://github.com/osrf/docker_images.git
 
 ################################################################################
-# Release: 9
-
-########################################
-# Distro: ubuntu:xenial
-
-Tags: gzserver9-xenial
-Architectures: amd64
-GitCommit: 96c8fa210caaeebd50e067ade05d5fc9a4a60c84
-Directory: gazebo/9/ubuntu/xenial/gzserver9
-
-Tags: libgazebo9-xenial
-Architectures: amd64
-GitCommit: 96c8fa210caaeebd50e067ade05d5fc9a4a60c84
-Directory: gazebo/9/ubuntu/xenial/libgazebo9
-
-########################################
-# Distro: ubuntu:bionic
-
-Tags: gzserver9, gzserver9-bionic
-Architectures: amd64
-GitCommit: 212f7553882e8f3e96af773ede6ef1848277c09e
-Directory: gazebo/9/ubuntu/bionic/gzserver9
-
-Tags: libgazebo9, libgazebo9-bionic
-Architectures: amd64
-GitCommit: 212f7553882e8f3e96af773ede6ef1848277c09e
-Directory: gazebo/9/ubuntu/bionic/libgazebo9
-
-
-################################################################################
 # Release: 11
 
 ########################################

--- a/gazebo/manifest.yaml
+++ b/gazebo/manifest.yaml
@@ -105,49 +105,49 @@ release_names:
     #                             aliases:
     #                                 - "libgazebo$release_name"
     #                                 - "libgazebo$release_name-$os_code_name"
-    '9':
-        eol: 2023-01-25
-        os_names:
-            ubuntu:
-                os_code_names:
-                    xenial:
-                        <<: *DEFAULT
-                        archs:
-                            - amd64
-                        tag_names:
-                            gzserver9:
-                                aliases:
-                                    - "gzserver$release_name-$os_code_name"
-                            libgazebo9:
-                                aliases:
-                                    - "libgazebo$release_name-$os_code_name"
-                    bionic:
-                        <<: *DEFAULT
-                        archs:
-                            - amd64
-                        tag_names:
-                            gzserver9:
-                                aliases:
-                                    - "gzserver$release_name"
-                                    - "gzserver$release_name-$os_code_name"
-                            libgazebo9:
-                                aliases:
-                                    - "libgazebo$release_name"
-                                    - "libgazebo$release_name-$os_code_name"
-            # EOL
-            # debian:
-            #     os_code_names:
-            #         stretch:
-            #             <<: *DEFAULT
-            #             archs:
-            #                 - amd64
-            #             tag_names:
-            #                 gzserver9:
-            #                     aliases:
-            #                         - "gzserver$release_name-$os_code_name"
-            #                 libgazebo9:
-            #                     aliases:
-            #                         - "libgazebo$release_name-$os_code_name"
+    # EOL
+    # '9':
+    #     eol: 2023-01-25
+    #     os_names:
+    #         ubuntu:
+    #             os_code_names:
+    #                 xenial:
+    #                     <<: *DEFAULT
+    #                     archs:
+    #                         - amd64
+    #                     tag_names:
+    #                         gzserver9:
+    #                             aliases:
+    #                                 - "gzserver$release_name-$os_code_name"
+    #                         libgazebo9:
+    #                             aliases:
+    #                                 - "libgazebo$release_name-$os_code_name"
+    #                 bionic:
+    #                     <<: *DEFAULT
+    #                     archs:
+    #                         - amd64
+    #                     tag_names:
+    #                         gzserver9:
+    #                             aliases:
+    #                                 - "gzserver$release_name"
+    #                                 - "gzserver$release_name-$os_code_name"
+    #                         libgazebo9:
+    #                             aliases:
+    #                                 - "libgazebo$release_name"
+    #                                 - "libgazebo$release_name-$os_code_name"
+    #         debian:
+    #             os_code_names:
+    #                 stretch:
+    #                     <<: *DEFAULT
+    #                     archs:
+    #                         - amd64
+    #                     tag_names:
+    #                         gzserver9:
+    #                             aliases:
+    #                                 - "gzserver$release_name-$os_code_name"
+    #                         libgazebo9:
+    #                             aliases:
+    #                                 - "libgazebo$release_name-$os_code_name"
     # EOL
     # '10':
     #     eol: 2021-01-24


### PR DESCRIPTION
Gazebo 9 is EOL https://community.gazebosim.org/t/gazebo-classic-9-officially-end-of-life/1773


also adresses the xenial part of https://github.com/osrf/docker_images/issues/660