### PR TITLE
[ros] Noetic/Buster and Foxy point to snapshots repository before retirement

### DIFF
--- a/ros/foxy/ubuntu/focal/ros-core/Dockerfile
+++ b/ros/foxy/ubuntu/focal/ros-core/Dockerfile
@@ -16,10 +16,10 @@ RUN apt-get update && apt-get install -q -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # setup sources.list
-RUN echo "deb http://packages.ros.org/ros2/ubuntu focal main" > /etc/apt/sources.list.d/ros2-latest.list
+RUN echo "deb http://snapshots.ros.org/foxy/final/ubuntu focal main" > /etc/apt/sources.list.d/ros2-snapshots.list
 
 # setup keys
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 4B63CF8FDE49746E98FA01DDAD19BAB3CBF125EA
 
 # setup environment
 ENV LANG C.UTF-8

--- a/ros/foxy/ubuntu/focal/ros1-bridge/Dockerfile
+++ b/ros/foxy/ubuntu/focal/ros1-bridge/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # install ros2 packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    ros-foxy-ros1-bridge=0.9.6-1* \
+    ros-foxy-ros1-bridge=0.9.7-1* \
     ros-foxy-demo-nodes-cpp=0.9.4-1* \
     ros-foxy-demo-nodes-py=0.9.4-1* \
     && rm -rf /var/lib/apt/lists/*

--- a/ros/noetic/debian/buster/ros-core/Dockerfile
+++ b/ros/noetic/debian/buster/ros-core/Dockerfile
@@ -9,10 +9,10 @@ RUN apt-get update && apt-get install -q -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # setup sources.list
-RUN echo "deb http://packages.ros.org/ros/ubuntu buster main" > /etc/apt/sources.list.d/ros1-latest.list
+RUN echo "deb http://snapshots.ros.org/noetic/final/debian buster main" > /etc/apt/sources.list.d/ros1-snapshots.list
 
 # setup keys
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 4B63CF8FDE49746E98FA01DDAD19BAB3CBF125EA
 
 # setup environment
 ENV LANG C.UTF-8

--- a/ros/ros
+++ b/ros/ros
@@ -59,7 +59,7 @@ Directory: ros/noetic/ubuntu/focal/perception
 
 Tags: noetic-ros-core-buster
 Architectures: amd64, arm64v8
-GitCommit: 3f4fbca923d80f834f3a89b5960bad5582652519
+GitCommit: 0c31bf0bc023e3ddb663b9934513270401d82a97
 Directory: ros/noetic/debian/buster/ros-core
 
 Tags: noetic-ros-base-buster
@@ -86,7 +86,7 @@ Directory: ros/noetic/debian/buster/perception
 
 Tags: foxy-ros-core, foxy-ros-core-focal
 Architectures: amd64, arm64v8
-GitCommit: 3f4fbca923d80f834f3a89b5960bad5582652519
+GitCommit: 0c31bf0bc023e3ddb663b9934513270401d82a97
 Directory: ros/foxy/ubuntu/focal/ros-core
 
 Tags: foxy-ros-base, foxy-ros-base-focal, foxy
@@ -96,7 +96,7 @@ Directory: ros/foxy/ubuntu/focal/ros-base
 
 Tags: foxy-ros1-bridge, foxy-ros1-bridge-focal
 Architectures: amd64, arm64v8
-GitCommit: c40ef6e5116c88f44e9ef3694614c1e8a60725a0
+GitCommit: 0c31bf0bc023e3ddb663b9934513270401d82a97
 Directory: ros/foxy/ubuntu/focal/ros1-bridge
 
 


### PR DESCRIPTION
ROS Foxy is now EOL : https://discourse.ros.org/t/new-packages-for-foxy-fitzroy-2023-06-20/32039
Debian buster has been EOl for a while.

This PR make them build from the ROS snapshots repository before disabling the builds