### PR TITLE
Move melodic images to snapshots repository

### DIFF
--- a/ros/melodic/ubuntu/bionic/ros-core/Dockerfile
+++ b/ros/melodic/ubuntu/bionic/ros-core/Dockerfile
@@ -16,10 +16,10 @@ RUN apt-get update && apt-get install -q -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # setup sources.list
-RUN echo "deb http://packages.ros.org/ros/ubuntu bionic main" > /etc/apt/sources.list.d/ros1-latest.list
+RUN echo "deb http://snapshots.ros.org/melodic/final/ubuntu bionic main" > /etc/apt/sources.list.d/ros1-snapshots.list
 
 # setup keys
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 4B63CF8FDE49746E98FA01DDAD19BAB3CBF125EA
 
 # setup environment
 ENV LANG C.UTF-8

--- a/ros/ros
+++ b/ros/ros
@@ -9,7 +9,7 @@ GitRepo: https://github.com/osrf/docker_images.git
 
 Tags: melodic-ros-core, melodic-ros-core-bionic
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 3f4fbca923d80f834f3a89b5960bad5582652519
+GitCommit: 443033d08e72da7282fe3b68167f01a2995118b8
 Directory: ros/melodic/ubuntu/bionic/ros-core
 
 Tags: melodic-ros-base, melodic-ros-base-bionic, melodic


### PR DESCRIPTION
Follow-up of https://github.com/osrf/docker_templates/pull/107
Part of https://github.com/osrf/docker_images/issues/660