### PR TITLE
Revert "remove foxy from CI"

### DIFF
--- a/.github/workflows/ros_ci.yaml
+++ b/.github/workflows/ros_ci.yaml
@@ -9,6 +9,7 @@ on:
     - 'ros/rolling/**'
     - 'ros/iron/**'
     - 'ros/humble/**'
+    - 'ros/foxy/**'
     - 'ros/noetic/**'
     - 'ros/melodic/**'
   push:
@@ -18,6 +19,7 @@ on:
     - 'ros/rolling/**'
     - 'ros/iron/**'
     - 'ros/humble/**'
+    - 'ros/foxy/**'
     - 'ros/noetic/**'
     - 'ros/melodic/**'
   schedule:
@@ -32,6 +34,7 @@ jobs:
           - {HUB_REPO: ros, HUB_RELEASE: rolling, HUB_OS_NAME: ubuntu, HUB_OS_CODE_NAME: jammy}
           - {HUB_REPO: ros, HUB_RELEASE: iron, HUB_OS_NAME: ubuntu, HUB_OS_CODE_NAME: jammy}
           - {HUB_REPO: ros, HUB_RELEASE: humble, HUB_OS_NAME: ubuntu, HUB_OS_CODE_NAME: jammy}
+          - {HUB_REPO: ros, HUB_RELEASE: foxy, HUB_OS_NAME: ubuntu, HUB_OS_CODE_NAME: focal}
           - {HUB_REPO: ros, HUB_RELEASE: noetic, HUB_OS_NAME: ubuntu, HUB_OS_CODE_NAME: focal}
           - {HUB_REPO: ros, HUB_RELEASE: melodic, HUB_OS_NAME: ubuntu, HUB_OS_CODE_NAME: bionic}
     runs-on: ubuntu-latest


### PR DESCRIPTION
This reverts commit 734d6d8c27b71670ff26773237dcb5fd706e0c8a.

Because the images on the osrf profile have not been built with the final images from the snapshots repository. To be reverted in a couple days.