### PR TITLE
Retire melodic

### DIFF
--- a/.github/workflows/ros_ci.yaml
+++ b/.github/workflows/ros_ci.yaml
@@ -10,7 +10,6 @@ on:
     - 'ros/iron/**'
     - 'ros/humble/**'
     - 'ros/noetic/**'
-    - 'ros/melodic/**'
   push:
     paths:
     - '.ci/**'
@@ -19,7 +18,6 @@ on:
     - 'ros/iron/**'
     - 'ros/humble/**'
     - 'ros/noetic/**'
-    - 'ros/melodic/**'
   schedule:
     # Trigger daily to check for upstream changes
     - cron: '0 0 * * *'
@@ -33,7 +31,6 @@ jobs:
           - {HUB_REPO: ros, HUB_RELEASE: iron, HUB_OS_NAME: ubuntu, HUB_OS_CODE_NAME: jammy}
           - {HUB_REPO: ros, HUB_RELEASE: humble, HUB_OS_NAME: ubuntu, HUB_OS_CODE_NAME: jammy}
           - {HUB_REPO: ros, HUB_RELEASE: noetic, HUB_OS_NAME: ubuntu, HUB_OS_CODE_NAME: focal}
-          - {HUB_REPO: ros, HUB_RELEASE: melodic, HUB_OS_NAME: ubuntu, HUB_OS_CODE_NAME: bionic}
     runs-on: ubuntu-latest
     env:
       GITHUBEMAIL: ${{ secrets.GITHUBEMAIL }}

--- a/ros/manifest.yaml
+++ b/ros/manifest.yaml
@@ -288,23 +288,24 @@ release_names:
                             - arm32v7
                             - arm64v8
                         tag_names:
-                            ros-core:
-                                aliases:
-                                    - "$release_name-ros-core"
-                                    - "$release_name-ros-core-$os_code_name"
-                            ros-base:
-                                aliases:
-                                    - "$release_name-ros-base"
-                                    - "$release_name-ros-base-$os_code_name"
-                                    - "$release_name"
-                            robot:
-                                aliases:
-                                    - "$release_name-robot"
-                                    - "$release_name-robot-$os_code_name"
-                            perception:
-                                aliases:
-                                    - "$release_name-perception"
-                                    - "$release_name-perception-$os_code_name"
+                            # EOL
+                            # ros-core:
+                            #     aliases:
+                            #         - "$release_name-ros-core"
+                            #         - "$release_name-ros-core-$os_code_name"
+                            # ros-base:
+                            #     aliases:
+                            #         - "$release_name-ros-base"
+                            #         - "$release_name-ros-base-$os_code_name"
+                            #         - "$release_name"
+                            # robot:
+                            #     aliases:
+                            #         - "$release_name-robot"
+                            #         - "$release_name-robot-$os_code_name"
+                            # perception:
+                            #     aliases:
+                            #         - "$release_name-perception"
+                            #         - "$release_name-perception-$os_code_name"
             debian:
                 os_code_names:
                     stretch:

--- a/ros/ros
+++ b/ros/ros
@@ -2,33 +2,6 @@ Maintainers: Tully Foote <tfoote+buildfarm@osrfoundation.org> (@tfoote)
 GitRepo: https://github.com/osrf/docker_images.git
 
 ################################################################################
-# Release: melodic
-
-########################################
-# Distro: ubuntu:bionic
-
-Tags: melodic-ros-core, melodic-ros-core-bionic
-Architectures: amd64, arm32v7, arm64v8
-GitCommit: 443033d08e72da7282fe3b68167f01a2995118b8
-Directory: ros/melodic/ubuntu/bionic/ros-core
-
-Tags: melodic-ros-base, melodic-ros-base-bionic, melodic
-Architectures: amd64, arm32v7, arm64v8
-GitCommit: df19ab7d5993d3b78a908362cdcd1479a8e78b35
-Directory: ros/melodic/ubuntu/bionic/ros-base
-
-Tags: melodic-robot, melodic-robot-bionic
-Architectures: amd64, arm32v7, arm64v8
-GitCommit: df19ab7d5993d3b78a908362cdcd1479a8e78b35
-Directory: ros/melodic/ubuntu/bionic/robot
-
-Tags: melodic-perception, melodic-perception-bionic
-Architectures: amd64, arm32v7, arm64v8
-GitCommit: df19ab7d5993d3b78a908362cdcd1479a8e78b35
-Directory: ros/melodic/ubuntu/bionic/perception
-
-
-################################################################################
 # Release: noetic
 
 ########################################


### PR DESCRIPTION
Melodic is now EOL https://discourse.ros.org/t/new-packages-for-melodic-2023-06-27/32121 and final images have been built https://github.com/docker-library/official-images/pull/14968