### PR TITLE
fix git safe directory for library generation

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,3 +12,4 @@ RUN git clone \
 ENV PYTHONPATH=/tmp/ros_buildfarm:/tmp/docker_images:/tmp/docker_templates:
 
 WORKDIR /tmp/docker_images
+RUN git config --global --add safe.directory /tmp/docker_images


### PR DESCRIPTION
Without this the createlibrary script fails with

```
Traceback (most recent call last):
  File "/tmp/docker_images/ros/./create_dockerlibrary.py", line 50, in <module>
    main()
  File "/tmp/docker_images/ros/./create_dockerlibrary.py", line 37, in main
    manifest = parse_manifest(manifest, repo, repo_name)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/docker_templates/library.py", line 53, in parse_manifest
    commit_sha = latest_commit_sha(repo, commit_path)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/docker_templates/library.py", line 22, in latest_commit_sha
    log_message = repo.git.log("-1", path)
                  ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/git/cmd.py", line 736, in <lambda>
    return lambda *args, **kwargs: self._call_process(name, *args, **kwargs)
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/git/cmd.py", line 1316, in _call_process
    return self.execute(call, **exec_kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/git/cmd.py", line 1111, in execute
    raise GitCommandError(redacted_command, status, stderr_value, stdout_value)
git.exc.GitCommandError: Cmd('git') failed due to: exit code(128)
  cmdline: git log -1 ros/noetic/ubuntu/focal/ros-core
  stderr: 'fatal: detected dubious ownership in repository at '/tmp/docker_images'
To add an exception for this directory, call:

	git config --global --add safe.directory /tmp/docker_images'
```