### PR TITLE
Move to gpg keyring for non-EOL images

### DIFF
--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -9,7 +9,7 @@ ros_buildfarm
 
 ###### Requirements with Repo Specifiers ######
 #   See https://pip.readthedocs.io/en/stable/reference/pip_install/#git
-git+https://github.com/osrf/docker_templates.git@gpg-keyring#egg=docker_templates
+git+https://github.com/osrf/docker_templates.git@master#egg=docker_templates
 
 ###### Requirements with Version Specifiers ######
 #   See https://www.python.org/dev/peps/pep-0440/#version-specifiers

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -9,7 +9,7 @@ ros_buildfarm
 
 ###### Requirements with Repo Specifiers ######
 #   See https://pip.readthedocs.io/en/stable/reference/pip_install/#git
-git+https://github.com/osrf/docker_templates.git@master#egg=docker_templates
+git+https://github.com/osrf/docker_templates.git@gpg-keyring#egg=docker_templates
 
 ###### Requirements with Version Specifiers ######
 #   See https://www.python.org/dev/peps/pep-0440/#version-specifiers

--- a/gazebo/11/ubuntu/focal/gzserver11/Dockerfile
+++ b/gazebo/11/ubuntu/focal/gzserver11/Dockerfile
@@ -16,12 +16,20 @@ RUN apt-get update && apt-get install -q -y --no-install-recommends \
     lsb-release \
     && rm -rf /var/lib/apt/lists/*
 
+
 # setup keys
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys D2486D2DD83DB69272AFE98867170598AF249743
+RUN set -eux; \
+	key='D2486D2DD83DB69272AFE98867170598AF249743'; \
+	export GNUPGHOME="$(mktemp -d)"; \
+	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key"; \
+	mkdir -p /etc/apt/keyrings; \
+	gpg --batch --export "$key" > /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg; \
+	gpgconf --kill all; \
+	rm -rf "$GNUPGHOME"
 
 # setup sources.list
 RUN . /etc/os-release \
-    && echo "deb http://packages.osrfoundation.org/gazebo/$ID-stable `lsb_release -sc` main" > /etc/apt/sources.list.d/gazebo-latest.list
+    && echo "deb [ signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg ] http://packages.osrfoundation.org/gazebo/$ID-stable $VERSION_CODENAME main" > /etc/apt/sources.list.d/gazebo-latest.list
 
 # install gazebo packages
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/gazebo/11/ubuntu/focal/gzserver11/Dockerfile
+++ b/gazebo/11/ubuntu/focal/gzserver11/Dockerfile
@@ -21,7 +21,7 @@ RUN set -eux; \
 	key='D2486D2DD83DB69272AFE98867170598AF249743'; \
 	export GNUPGHOME="$(mktemp -d)"; \
 	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key"; \
-	mkdir -p /etc/apt/keyrings; \
+	mkdir -p /usr/share/keyrings; \
 	gpg --batch --export "$key" > /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg; \
 	gpgconf --kill all; \
 	rm -rf "$GNUPGHOME"

--- a/gazebo/11/ubuntu/focal/gzserver11/Dockerfile
+++ b/gazebo/11/ubuntu/focal/gzserver11/Dockerfile
@@ -13,7 +13,6 @@ RUN echo 'Etc/UTC' > /etc/timezone && \
 RUN apt-get update && apt-get install -q -y --no-install-recommends \
     dirmngr \
     gnupg2 \
-    lsb-release \
     && rm -rf /var/lib/apt/lists/*
 
 

--- a/gazebo/gazebo
+++ b/gazebo/gazebo
@@ -9,7 +9,7 @@ GitRepo: https://github.com/osrf/docker_images.git
 
 Tags: gzserver11, gzserver11-focal
 Architectures: amd64
-GitCommit: ffc42e32296247283fc92861e3cf0acc689e764f
+GitCommit: 27cc0b68263bbbb10bb58dd814efc0a6b0a01ec7
 Directory: gazebo/11/ubuntu/focal/gzserver11
 
 Tags: libgazebo11, libgazebo11-focal, latest

--- a/gazebo/gazebo
+++ b/gazebo/gazebo
@@ -9,7 +9,7 @@ GitRepo: https://github.com/osrf/docker_images.git
 
 Tags: gzserver11, gzserver11-focal
 Architectures: amd64
-GitCommit: 532c4f1af8c9dadb54b0c9769543c67c40c0c84f
+GitCommit: ffc42e32296247283fc92861e3cf0acc689e764f
 Directory: gazebo/11/ubuntu/focal/gzserver11
 
 Tags: libgazebo11, libgazebo11-focal, latest

--- a/ros/humble/ubuntu/jammy/ros-core/Dockerfile
+++ b/ros/humble/ubuntu/jammy/ros-core/Dockerfile
@@ -16,10 +16,17 @@ RUN apt-get update && apt-get install -q -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # setup keys
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
+RUN set -eux; \
+       key='C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654'; \
+       export GNUPGHOME="$(mktemp -d)"; \
+       gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key"; \
+       mkdir -p /etc/apt/keyrings; \
+       gpg --batch --export "$key" > /usr/share/keyrings/ros2-latest-archive-keyring.gpg; \
+       gpgconf --kill all; \
+       rm -rf "$GNUPGHOME"
 
 # setup sources.list
-RUN echo "deb http://packages.ros.org/ros2/ubuntu jammy main" > /etc/apt/sources.list.d/ros2-latest.list
+RUN echo "deb [ signed-by=/usr/share/keyrings/ros2-latest-archive-keyring.gpg ] http://packages.ros.org/ros2/ubuntu jammy main" > /etc/apt/sources.list.d/ros2-latest.list
 
 # setup environment
 ENV LANG C.UTF-8

--- a/ros/humble/ubuntu/jammy/ros-core/Dockerfile
+++ b/ros/humble/ubuntu/jammy/ros-core/Dockerfile
@@ -20,7 +20,7 @@ RUN set -eux; \
        key='C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654'; \
        export GNUPGHOME="$(mktemp -d)"; \
        gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key"; \
-       mkdir -p /etc/apt/keyrings; \
+       mkdir -p /usr/share/keyrings; \
        gpg --batch --export "$key" > /usr/share/keyrings/ros2-latest-archive-keyring.gpg; \
        gpgconf --kill all; \
        rm -rf "$GNUPGHOME"

--- a/ros/iron/ubuntu/jammy/ros-core/Dockerfile
+++ b/ros/iron/ubuntu/jammy/ros-core/Dockerfile
@@ -16,10 +16,17 @@ RUN apt-get update && apt-get install -q -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # setup keys
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
+RUN set -eux; \
+       key='C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654'; \
+       export GNUPGHOME="$(mktemp -d)"; \
+       gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key"; \
+       mkdir -p /etc/apt/keyrings; \
+       gpg --batch --export "$key" > /usr/share/keyrings/ros2-latest-archive-keyring.gpg; \
+       gpgconf --kill all; \
+       rm -rf "$GNUPGHOME"
 
 # setup sources.list
-RUN echo "deb http://packages.ros.org/ros2/ubuntu jammy main" > /etc/apt/sources.list.d/ros2-latest.list
+RUN echo "deb [ signed-by=/usr/share/keyrings/ros2-latest-archive-keyring.gpg ] http://packages.ros.org/ros2/ubuntu jammy main" > /etc/apt/sources.list.d/ros2-latest.list
 
 # setup environment
 ENV LANG C.UTF-8

--- a/ros/iron/ubuntu/jammy/ros-core/Dockerfile
+++ b/ros/iron/ubuntu/jammy/ros-core/Dockerfile
@@ -20,7 +20,7 @@ RUN set -eux; \
        key='C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654'; \
        export GNUPGHOME="$(mktemp -d)"; \
        gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key"; \
-       mkdir -p /etc/apt/keyrings; \
+       mkdir -p /usr/share/keyrings; \
        gpg --batch --export "$key" > /usr/share/keyrings/ros2-latest-archive-keyring.gpg; \
        gpgconf --kill all; \
        rm -rf "$GNUPGHOME"

--- a/ros/noetic/ubuntu/focal/ros-core/Dockerfile
+++ b/ros/noetic/ubuntu/focal/ros-core/Dockerfile
@@ -20,7 +20,7 @@ RUN set -eux; \
        key='C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654'; \
        export GNUPGHOME="$(mktemp -d)"; \
        gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key"; \
-       mkdir -p /etc/apt/keyrings; \
+       mkdir -p /usr/share/keyrings; \
        gpg --batch --export "$key" > /usr/share/keyrings/ros1-latest-archive-keyring.gpg; \
        gpgconf --kill all; \
        rm -rf "$GNUPGHOME"

--- a/ros/noetic/ubuntu/focal/ros-core/Dockerfile
+++ b/ros/noetic/ubuntu/focal/ros-core/Dockerfile
@@ -16,10 +16,17 @@ RUN apt-get update && apt-get install -q -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # setup keys
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
+RUN set -eux; \
+       key='C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654'; \
+       export GNUPGHOME="$(mktemp -d)"; \
+       gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key"; \
+       mkdir -p /etc/apt/keyrings; \
+       gpg --batch --export "$key" > /usr/share/keyrings/ros1-latest-archive-keyring.gpg; \
+       gpgconf --kill all; \
+       rm -rf "$GNUPGHOME"
 
 # setup sources.list
-RUN echo "deb http://packages.ros.org/ros/ubuntu focal main" > /etc/apt/sources.list.d/ros1-latest.list
+RUN echo "deb [ signed-by=/usr/share/keyrings/ros1-latest-archive-keyring.gpg ] http://packages.ros.org/ros/ubuntu focal main" > /etc/apt/sources.list.d/ros1-latest.list
 
 # setup environment
 ENV LANG C.UTF-8

--- a/ros/rolling/ubuntu/jammy/ros-core/Dockerfile
+++ b/ros/rolling/ubuntu/jammy/ros-core/Dockerfile
@@ -16,10 +16,17 @@ RUN apt-get update && apt-get install -q -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # setup keys
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
+RUN set -eux; \
+       key='C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654'; \
+       export GNUPGHOME="$(mktemp -d)"; \
+       gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key"; \
+       mkdir -p /etc/apt/keyrings; \
+       gpg --batch --export "$key" > /usr/share/keyrings/ros2-latest-archive-keyring.gpg; \
+       gpgconf --kill all; \
+       rm -rf "$GNUPGHOME"
 
 # setup sources.list
-RUN echo "deb http://packages.ros.org/ros2/ubuntu jammy main" > /etc/apt/sources.list.d/ros2-latest.list
+RUN echo "deb [ signed-by=/usr/share/keyrings/ros2-latest-archive-keyring.gpg ] http://packages.ros.org/ros2/ubuntu jammy main" > /etc/apt/sources.list.d/ros2-latest.list
 
 # setup environment
 ENV LANG C.UTF-8

--- a/ros/rolling/ubuntu/jammy/ros-core/Dockerfile
+++ b/ros/rolling/ubuntu/jammy/ros-core/Dockerfile
@@ -20,7 +20,7 @@ RUN set -eux; \
        key='C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654'; \
        export GNUPGHOME="$(mktemp -d)"; \
        gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key"; \
-       mkdir -p /etc/apt/keyrings; \
+       mkdir -p /usr/share/keyrings; \
        gpg --batch --export "$key" > /usr/share/keyrings/ros2-latest-archive-keyring.gpg; \
        gpgconf --kill all; \
        rm -rf "$GNUPGHOME"

--- a/ros/ros
+++ b/ros/ros
@@ -9,7 +9,7 @@ GitRepo: https://github.com/osrf/docker_images.git
 
 Tags: noetic-ros-core, noetic-ros-core-focal
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 701fa8c330f4c62f51b5fd2427382bd8a56a0f1e
+GitCommit: 27cc0b68263bbbb10bb58dd814efc0a6b0a01ec7
 Directory: ros/noetic/ubuntu/focal/ros-core
 
 Tags: noetic-ros-base, noetic-ros-base-focal, noetic
@@ -36,7 +36,7 @@ Directory: ros/noetic/ubuntu/focal/perception
 
 Tags: humble-ros-core, humble-ros-core-jammy
 Architectures: amd64, arm64v8
-GitCommit: 701fa8c330f4c62f51b5fd2427382bd8a56a0f1e
+GitCommit: 27cc0b68263bbbb10bb58dd814efc0a6b0a01ec7
 Directory: ros/humble/ubuntu/jammy/ros-core
 
 Tags: humble-ros-base, humble-ros-base-jammy, humble, latest
@@ -58,7 +58,7 @@ Directory: ros/humble/ubuntu/jammy/perception
 
 Tags: iron-ros-core, iron-ros-core-jammy
 Architectures: amd64, arm64v8
-GitCommit: 701fa8c330f4c62f51b5fd2427382bd8a56a0f1e
+GitCommit: 27cc0b68263bbbb10bb58dd814efc0a6b0a01ec7
 Directory: ros/iron/ubuntu/jammy/ros-core
 
 Tags: iron-ros-base, iron-ros-base-jammy, iron
@@ -80,7 +80,7 @@ Directory: ros/iron/ubuntu/jammy/perception
 
 Tags: rolling-ros-core, rolling-ros-core-jammy
 Architectures: amd64, arm64v8
-GitCommit: 701fa8c330f4c62f51b5fd2427382bd8a56a0f1e
+GitCommit: 27cc0b68263bbbb10bb58dd814efc0a6b0a01ec7
 Directory: ros/rolling/ubuntu/jammy/ros-core
 
 Tags: rolling-ros-base, rolling-ros-base-jammy, rolling

--- a/ros/ros
+++ b/ros/ros
@@ -9,7 +9,7 @@ GitRepo: https://github.com/osrf/docker_images.git
 
 Tags: noetic-ros-core, noetic-ros-core-focal
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 9ab23751d41735b448da8cfa1580958279ae5101
+GitCommit: 701fa8c330f4c62f51b5fd2427382bd8a56a0f1e
 Directory: ros/noetic/ubuntu/focal/ros-core
 
 Tags: noetic-ros-base, noetic-ros-base-focal, noetic
@@ -36,7 +36,7 @@ Directory: ros/noetic/ubuntu/focal/perception
 
 Tags: humble-ros-core, humble-ros-core-jammy
 Architectures: amd64, arm64v8
-GitCommit: 87074e54828d12dacf84f15273e95e03eeb17d24
+GitCommit: 701fa8c330f4c62f51b5fd2427382bd8a56a0f1e
 Directory: ros/humble/ubuntu/jammy/ros-core
 
 Tags: humble-ros-base, humble-ros-base-jammy, humble, latest
@@ -58,7 +58,7 @@ Directory: ros/humble/ubuntu/jammy/perception
 
 Tags: iron-ros-core, iron-ros-core-jammy
 Architectures: amd64, arm64v8
-GitCommit: 87074e54828d12dacf84f15273e95e03eeb17d24
+GitCommit: 701fa8c330f4c62f51b5fd2427382bd8a56a0f1e
 Directory: ros/iron/ubuntu/jammy/ros-core
 
 Tags: iron-ros-base, iron-ros-base-jammy, iron
@@ -80,7 +80,7 @@ Directory: ros/iron/ubuntu/jammy/perception
 
 Tags: rolling-ros-core, rolling-ros-core-jammy
 Architectures: amd64, arm64v8
-GitCommit: 87074e54828d12dacf84f15273e95e03eeb17d24
+GitCommit: 701fa8c330f4c62f51b5fd2427382bd8a56a0f1e
 Directory: ros/rolling/ubuntu/jammy/ros-core
 
 Tags: rolling-ros-base, rolling-ros-base-jammy, rolling

--- a/ros2/nightly/nightly/Dockerfile
+++ b/ros2/nightly/nightly/Dockerfile
@@ -17,7 +17,6 @@ RUN apt-get update && apt-get install -q -y --no-install-recommends \
     git \
     gnupg2 \
     libssl-dev \
-    lsb-release \
     python3-flake8 \
     python3-flake8-blind-except \
     python3-flake8-builtins \

--- a/ros2/nightly/nightly/Dockerfile
+++ b/ros2/nightly/nightly/Dockerfile
@@ -33,11 +33,18 @@ RUN apt-get update && apt-get install -q -y --no-install-recommends \
     wget \
     && rm -rf /var/lib/apt/lists/*
 
-# setup sources.list
-RUN echo "deb http://packages.ros.org/ros2-testing/ubuntu jammy main" > /etc/apt/sources.list.d/ros2-testing.list
-
 # setup keys
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
+RUN set -eux; \
+       key='C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654'; \
+       export GNUPGHOME="$(mktemp -d)"; \
+       gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key"; \
+       mkdir -p /etc/apt/keyrings; \
+       gpg --batch --export "$key" > /usr/share/keyrings/ros2-testing-archive-keyring.gpg; \
+       gpgconf --kill all; \
+       rm -rf "$GNUPGHOME"
+
+# setup sources.list
+RUN echo "deb [ signed-by=/usr/share/keyrings/ros2-testing-archive-keyring.gpg ] http://packages.ros.org/ros2-testing/ubuntu jammy main" > /etc/apt/sources.list.d/ros2-testing.list
 
 # install bootstrap tools
 RUN apt-get update && apt-get install --no-install-recommends -y \

--- a/ros2/nightly/nightly/Dockerfile
+++ b/ros2/nightly/nightly/Dockerfile
@@ -37,7 +37,7 @@ RUN set -eux; \
        key='C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654'; \
        export GNUPGHOME="$(mktemp -d)"; \
        gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key"; \
-       mkdir -p /etc/apt/keyrings; \
+       mkdir -p /usr/share/keyrings; \
        gpg --batch --export "$key" > /usr/share/keyrings/ros2-testing-archive-keyring.gpg; \
        gpgconf --kill all; \
        rm -rf "$GNUPGHOME"

--- a/ros2/source/devel/Dockerfile
+++ b/ros2/source/devel/Dockerfile
@@ -31,7 +31,7 @@ RUN set -eux; \
        key='C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654'; \
        export GNUPGHOME="$(mktemp -d)"; \
        gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key"; \
-       mkdir -p /etc/apt/keyrings; \
+       mkdir -p /usr/share/keyrings; \
        gpg --batch --export "$key" > /usr/share/keyrings/ros2-latest-archive-keyring.gpg; \
        gpgconf --kill all; \
        rm -rf "$GNUPGHOME"

--- a/ros2/source/devel/Dockerfile
+++ b/ros2/source/devel/Dockerfile
@@ -27,11 +27,18 @@ RUN apt-get update && apt-get install -q -y --no-install-recommends \
     python3-pytest-rerunfailures \
     && rm -rf /var/lib/apt/lists/*
 
-# setup sources.list
-RUN echo "deb http://packages.ros.org/ros2/ubuntu jammy main" > /etc/apt/sources.list.d/ros2-latest.list
-
 # setup keys
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
+RUN set -eux; \
+       key='C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654'; \
+       export GNUPGHOME="$(mktemp -d)"; \
+       gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key"; \
+       mkdir -p /etc/apt/keyrings; \
+       gpg --batch --export "$key" > /usr/share/keyrings/ros2-latest-archive-keyring.gpg; \
+       gpgconf --kill all; \
+       rm -rf "$GNUPGHOME"
+
+# setup sources.list
+RUN echo "deb [ signed-by=/usr/share/keyrings/ros2-latest-archive-keyring.gpg ] http://packages.ros.org/ros2/ubuntu jammy main" > /etc/apt/sources.list.d/ros2-latest.list
 
 # setup environment
 ENV LANG C.UTF-8

--- a/ros2/source/devel/Dockerfile
+++ b/ros2/source/devel/Dockerfile
@@ -12,7 +12,6 @@ RUN apt-get update && apt-get install -q -y --no-install-recommends \
     bash-completion \
     dirmngr \
     gnupg2 \
-    lsb-release \
     python3-flake8 \
     python3-flake8-blind-except \
     python3-flake8-builtins \

--- a/ros2/testing/testing/Dockerfile
+++ b/ros2/testing/testing/Dockerfile
@@ -14,11 +14,18 @@ RUN apt-get update && apt-get install -q -y --no-install-recommends \
     lsb-release \
     && rm -rf /var/lib/apt/lists/*
 
-# setup sources.list
-RUN echo "deb http://packages.ros.org/ros2-testing/ubuntu jammy main" > /etc/apt/sources.list.d/ros2-testing.list
-
 # setup keys
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
+RUN set -eux; \
+       key='C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654'; \
+       export GNUPGHOME="$(mktemp -d)"; \
+       gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key"; \
+       mkdir -p /etc/apt/keyrings; \
+       gpg --batch --export "$key" > /usr/share/keyrings/ros2-testing-archive-keyring.gpg; \
+       gpgconf --kill all; \
+       rm -rf "$GNUPGHOME"
+
+# setup sources.list
+RUN echo "deb [ signed-by=/usr/share/keyrings/ros2-testing-archive-keyring.gpg ] http://packages.ros.org/ros2-testing/ubuntu jammy main" > /etc/apt/sources.list.d/ros2-testing.list
 
 # setup environment
 ENV LANG C.UTF-8

--- a/ros2/testing/testing/Dockerfile
+++ b/ros2/testing/testing/Dockerfile
@@ -18,7 +18,7 @@ RUN set -eux; \
        key='C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654'; \
        export GNUPGHOME="$(mktemp -d)"; \
        gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key"; \
-       mkdir -p /etc/apt/keyrings; \
+       mkdir -p /usr/share/keyrings; \
        gpg --batch --export "$key" > /usr/share/keyrings/ros2-testing-archive-keyring.gpg; \
        gpgconf --kill all; \
        rm -rf "$GNUPGHOME"

--- a/ros2/testing/testing/Dockerfile
+++ b/ros2/testing/testing/Dockerfile
@@ -11,7 +11,6 @@ RUN echo 'Etc/UTC' > /etc/timezone && \
 RUN apt-get update && apt-get install -q -y --no-install-recommends \
     dirmngr \
     gnupg2 \
-    lsb-release \
     && rm -rf /var/lib/apt/lists/*
 
 # setup keys


### PR DESCRIPTION
Will close https://github.com/osrf/docker_images/issues/621 and follow guidelines provided in https://github.com/docker-library/official-images/pull/15809#issuecomment-1846053036

Will result in https://github.com/docker-library/official-images/pull/15936