### PR TITLE
attempt to fix dependabot docker version fix

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,19 @@
 version: 2
 updates:
   - package-ecosystem: "docker"
-    directory: "/ros2"
+    directory: "/ros2/source/devel"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "🐳"
+  - package-ecosystem: "docker"
+    directory: "/ros2/testing/testing"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "🐳"
+  - package-ecosystem: "docker"
+    directory: "/ros2/nightly/nightly"
     schedule:
       interval: "daily"
     commit-message:


### PR DESCRIPTION
Apparently recursively finding Dockerfile is not working: https://github.com/dependabot/dependabot-core/issues/1015

Not sure why it stopped working, last successful Prs were from early 2022: https://github.com/osrf/docker_images/pull/594
