### PR TITLE
Migrate rolling images to ubuntu noble

### DIFF
--- a/.github/workflows/ros_ci.yaml
+++ b/.github/workflows/ros_ci.yaml
@@ -6,7 +6,7 @@ on:
     paths:
     - '.ci/**'
     - '.github/workflows/ros_ci.yaml'
-    - 'ros/rolling/**'
+    # - 'ros/rolling/**'
     - 'ros/iron/**'
     - 'ros/humble/**'
     - 'ros/noetic/**'
@@ -14,7 +14,7 @@ on:
     paths:
     - '.ci/**'
     - '.github/workflows/ros_ci.yaml'
-    - 'ros/rolling/**'
+    # - 'ros/rolling/**'
     - 'ros/iron/**'
     - 'ros/humble/**'
     - 'ros/noetic/**'
@@ -27,7 +27,7 @@ jobs:
       fail-fast: false
       matrix:
         env:
-          - {HUB_REPO: ros, HUB_RELEASE: rolling, HUB_OS_NAME: ubuntu, HUB_OS_CODE_NAME: jammy}
+          # - {HUB_REPO: ros, HUB_RELEASE: rolling, HUB_OS_NAME: ubuntu, HUB_OS_CODE_NAME: jammy}
           - {HUB_REPO: ros, HUB_RELEASE: iron, HUB_OS_NAME: ubuntu, HUB_OS_CODE_NAME: jammy}
           - {HUB_REPO: ros, HUB_RELEASE: humble, HUB_OS_NAME: ubuntu, HUB_OS_CODE_NAME: jammy}
           - {HUB_REPO: ros, HUB_RELEASE: noetic, HUB_OS_NAME: ubuntu, HUB_OS_CODE_NAME: focal}

--- a/ros/manifest.yaml
+++ b/ros/manifest.yaml
@@ -603,8 +603,7 @@ release_names:
         os_names:
             ubuntu:
                 os_code_names:
-                    jammy:
-                        rosdistro_name: noetic
+                    noble:
                         <<: *DEFAULT_ROS2
                         archs:
                             - amd64

--- a/ros/rolling/ubuntu/noble/Makefile
+++ b/ros/rolling/ubuntu/noble/Makefile
@@ -1,0 +1,78 @@
+all: help
+
+help:
+	@echo ""
+	@echo "-- Help Menu"
+	@echo ""
+	@echo "   1. make build            - build all images"
+	@echo "   2. make pull             - pull all images"
+	@echo "   3. make clean            - remove all images"
+	@echo ""
+
+build:
+	@docker build --tag=ros:rolling-ros-core-noble			ros-core/.
+	@docker build --tag=ros:rolling-ros-base-noble			ros-base/.
+	@docker build --tag=ros:rolling-perception-noble			perception/.
+	# @docker build --tag=osrf/ros:rolling-simulation-noble			simulation/.
+	# @docker build --tag=osrf/ros:rolling-desktop-noble			desktop/.
+	# @docker build --tag=osrf/ros:rolling-desktop-full-noble			desktop-full/.
+
+pull:
+	@docker pull ros:rolling-ros-core-noble
+	@docker pull ros:rolling-ros-base-noble
+	@docker pull ros:rolling-perception-noble
+	# @docker pull osrf/ros:rolling-simulation-noble
+	# @docker pull osrf/ros:rolling-desktop-noble
+	# @docker pull osrf/ros:rolling-desktop-full-noble
+
+clean:
+	@docker rmi -f ros:rolling-ros-core-noble
+	@docker rmi -f ros:rolling-ros-base-noble
+	@docker rmi -f ros:rolling-perception-noble
+	# @docker rmi -f osrf/ros:rolling-simulation-noble
+	# @docker rmi -f osrf/ros:rolling-desktop-noble
+	# @docker rmi -f osrf/ros:rolling-desktop-full-noble
+
+ci_buildx:
+	@docker buildx build --pull --push \
+		--cache-from=type=registry,ref=osrf/ros:rolling-desktop-noble \
+		--cache-to=type=inline \
+		--tag=osrf/ros:rolling-desktop-noble \
+		desktop/.
+	@if [ "ubuntu" = "ubuntu" ]; then \
+		docker pull \
+			osrf/ros:rolling-desktop-noble; \
+    	docker tag \
+			osrf/ros:rolling-desktop-noble \
+			osrf/ros:rolling-desktop; \
+		docker push \
+			osrf/ros:rolling-desktop; \
+	fi
+	@docker buildx build --pull --push \
+		--cache-from=type=registry,ref=osrf/ros:rolling-simulation-noble \
+		--cache-to=type=inline \
+		--tag=osrf/ros:rolling-simulation-noble \
+		simulation/.
+	@if [ "ubuntu" = "ubuntu" ]; then \
+		docker pull \
+			osrf/ros:rolling-simulation-noble; \
+		docker tag \
+			osrf/ros:rolling-simulation-noble \
+			osrf/ros:rolling-simulation; \
+		docker push \
+			osrf/ros:rolling-simulation; \
+	fi
+	@docker buildx build --pull --push \
+		--cache-from=type=registry,ref=osrf/ros:rolling-desktop-full-noble \
+		--cache-to=type=inline \
+		--tag=osrf/ros:rolling-desktop-full-noble \
+		desktop-full/.
+	@if [ "ubuntu" = "ubuntu" ]; then \
+		docker pull \
+			osrf/ros:rolling-desktop-full-noble; \
+		docker tag \
+			osrf/ros:rolling-desktop-full-noble \
+			osrf/ros:rolling-desktop-full; \
+		docker push \
+			osrf/ros:rolling-desktop-full; \
+	fi

--- a/ros/rolling/ubuntu/noble/Makefile
+++ b/ros/rolling/ubuntu/noble/Makefile
@@ -48,31 +48,31 @@ ci_buildx:
 		docker push \
 			osrf/ros:rolling-desktop; \
 	fi
-	@docker buildx build --pull --push \
-		--cache-from=type=registry,ref=osrf/ros:rolling-simulation-noble \
-		--cache-to=type=inline \
-		--tag=osrf/ros:rolling-simulation-noble \
-		simulation/.
-	@if [ "ubuntu" = "ubuntu" ]; then \
-		docker pull \
-			osrf/ros:rolling-simulation-noble; \
-		docker tag \
-			osrf/ros:rolling-simulation-noble \
-			osrf/ros:rolling-simulation; \
-		docker push \
-			osrf/ros:rolling-simulation; \
-	fi
-	@docker buildx build --pull --push \
-		--cache-from=type=registry,ref=osrf/ros:rolling-desktop-full-noble \
-		--cache-to=type=inline \
-		--tag=osrf/ros:rolling-desktop-full-noble \
-		desktop-full/.
-	@if [ "ubuntu" = "ubuntu" ]; then \
-		docker pull \
-			osrf/ros:rolling-desktop-full-noble; \
-		docker tag \
-			osrf/ros:rolling-desktop-full-noble \
-			osrf/ros:rolling-desktop-full; \
-		docker push \
-			osrf/ros:rolling-desktop-full; \
-	fi
+	# @docker buildx build --pull --push \
+	# 	--cache-from=type=registry,ref=osrf/ros:rolling-simulation-noble \
+	# 	--cache-to=type=inline \
+	# 	--tag=osrf/ros:rolling-simulation-noble \
+	# 	simulation/.
+	# @if [ "ubuntu" = "ubuntu" ]; then \
+	# 	docker pull \
+	# 		osrf/ros:rolling-simulation-noble; \
+	# 	docker tag \
+	# 		osrf/ros:rolling-simulation-noble \
+	# 		osrf/ros:rolling-simulation; \
+	# 	docker push \
+	# 		osrf/ros:rolling-simulation; \
+	# fi
+	# @docker buildx build --pull --push \
+	# 	--cache-from=type=registry,ref=osrf/ros:rolling-desktop-full-noble \
+	# 	--cache-to=type=inline \
+	# 	--tag=osrf/ros:rolling-desktop-full-noble \
+	# 	desktop-full/.
+	# @if [ "ubuntu" = "ubuntu" ]; then \
+	# 	docker pull \
+	# 		osrf/ros:rolling-desktop-full-noble; \
+	# 	docker tag \
+	# 		osrf/ros:rolling-desktop-full-noble \
+	# 		osrf/ros:rolling-desktop-full; \
+	# 	docker push \
+	# 		osrf/ros:rolling-desktop-full; \
+	# fi

--- a/ros/rolling/ubuntu/noble/desktop/Dockerfile
+++ b/ros/rolling/ubuntu/noble/desktop/Dockerfile
@@ -1,0 +1,9 @@
+# This is an auto generated Dockerfile for ros:desktop
+# generated from docker_images_ros2/create_ros_image.Dockerfile.em
+FROM ros:rolling-ros-base-noble
+
+# install ros2 packages
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ros-rolling-desktop=0.10.0-3* \
+    && rm -rf /var/lib/apt/lists/*
+

--- a/ros/rolling/ubuntu/noble/images.yaml.em
+++ b/ros/rolling/ubuntu/noble/images.yaml.em
@@ -1,0 +1,54 @@
+%YAML 1.1
+# ROS2 Dockerfile database
+---
+images:
+    ros-core:
+        base_image: @(os_name):@(os_code_name)
+        maintainer_name: @(maintainer_name)
+        template_name: docker_images_ros2/create_ros_core_image.Dockerfile.em
+        entrypoint_name: docker_images_ros2/ros_entrypoint.sh
+        template_packages:
+            - docker_templates
+        ros2_packages:
+            - ros-core
+    ros-base:
+        base_image: @(user_name):@(ros2distro_name)-ros-core-@(os_code_name)
+        maintainer_name: @(maintainer_name)
+        template_name: docker_images_ros2/create_ros_image.Dockerfile.em
+        template_packages:
+            - docker_templates
+        ros2_packages:
+            - ros-base
+        bootstrap_ros_tools:
+    perception:
+        base_image: @(user_name):@(ros2distro_name)-ros-base-@(os_code_name)
+        maintainer_name: @(maintainer_name)
+        template_name: docker_images_ros2/create_ros_image.Dockerfile.em
+        template_packages:
+            - docker_templates
+        ros2_packages:
+            - perception
+    simulation:
+        base_image: @(user_name):@(ros2distro_name)-ros-base-@(os_code_name)
+        maintainer_name: @(maintainer_name)
+        template_name: docker_images_ros2/create_ros_image.Dockerfile.em
+        template_packages:
+            - docker_templates
+        ros2_packages:
+            - simulation
+    desktop:
+        base_image: @(user_name):@(ros2distro_name)-ros-base-@(os_code_name)
+        maintainer_name: @(maintainer_name)
+        template_name: docker_images_ros2/create_ros_image.Dockerfile.em
+        template_packages:
+            - docker_templates
+        ros2_packages:
+            - desktop
+    desktop-full:
+        base_image: osrf/@(user_name):@(ros2distro_name)-desktop-@(os_code_name)
+        maintainer_name: @(maintainer_name)
+        template_name: docker_images_ros2/create_ros_image.Dockerfile.em
+        template_packages:
+            - docker_templates
+        ros2_packages:
+            - desktop-full

--- a/ros/rolling/ubuntu/noble/images.yaml.em
+++ b/ros/rolling/ubuntu/noble/images.yaml.em
@@ -28,14 +28,14 @@ images:
             - docker_templates
         ros2_packages:
             - perception
-    simulation:
-        base_image: @(user_name):@(ros2distro_name)-ros-base-@(os_code_name)
-        maintainer_name: @(maintainer_name)
-        template_name: docker_images_ros2/create_ros_image.Dockerfile.em
-        template_packages:
-            - docker_templates
-        ros2_packages:
-            - simulation
+    # simulation:
+    #     base_image: @(user_name):@(ros2distro_name)-ros-base-@(os_code_name)
+    #     maintainer_name: @(maintainer_name)
+    #     template_name: docker_images_ros2/create_ros_image.Dockerfile.em
+    #     template_packages:
+    #         - docker_templates
+    #     ros2_packages:
+    #         - simulation
     desktop:
         base_image: @(user_name):@(ros2distro_name)-ros-base-@(os_code_name)
         maintainer_name: @(maintainer_name)
@@ -44,11 +44,11 @@ images:
             - docker_templates
         ros2_packages:
             - desktop
-    desktop-full:
-        base_image: osrf/@(user_name):@(ros2distro_name)-desktop-@(os_code_name)
-        maintainer_name: @(maintainer_name)
-        template_name: docker_images_ros2/create_ros_image.Dockerfile.em
-        template_packages:
-            - docker_templates
-        ros2_packages:
-            - desktop-full
+    # desktop-full:
+    #     base_image: osrf/@(user_name):@(ros2distro_name)-desktop-@(os_code_name)
+    #     maintainer_name: @(maintainer_name)
+    #     template_name: docker_images_ros2/create_ros_image.Dockerfile.em
+    #     template_packages:
+    #         - docker_templates
+    #     ros2_packages:
+    #         - desktop-full

--- a/ros/rolling/ubuntu/noble/perception/Dockerfile
+++ b/ros/rolling/ubuntu/noble/perception/Dockerfile
@@ -1,0 +1,9 @@
+# This is an auto generated Dockerfile for ros:perception
+# generated from docker_images_ros2/create_ros_image.Dockerfile.em
+FROM ros:rolling-ros-base-noble
+
+# install ros2 packages
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ros-rolling-perception=0.10.0-3* \
+    && rm -rf /var/lib/apt/lists/*
+

--- a/ros/rolling/ubuntu/noble/platform.yaml
+++ b/ros/rolling/ubuntu/noble/platform.yaml
@@ -1,0 +1,12 @@
+%YAML 1.1
+# ROS2 Dockerfile database
+---
+platform:
+    os_name: ubuntu
+    os_code_name: noble
+    ros2distro_name: rolling
+    user_name: ros
+    maintainer_name:
+    arch: amd64
+    type: distribution
+    version:

--- a/ros/rolling/ubuntu/noble/ros-base/Dockerfile
+++ b/ros/rolling/ubuntu/noble/ros-base/Dockerfile
@@ -1,0 +1,31 @@
+# This is an auto generated Dockerfile for ros:ros-base
+# generated from docker_images_ros2/create_ros_image.Dockerfile.em
+FROM ros:rolling-ros-core-noble
+
+# install bootstrap tools
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    build-essential \
+    git \
+    python3-colcon-common-extensions \
+    python3-colcon-mixin \
+    python3-rosdep \
+    python3-vcstool \
+    && rm -rf /var/lib/apt/lists/*
+
+# bootstrap rosdep
+RUN rosdep init && \
+  rosdep update --rosdistro $ROS_DISTRO
+
+# setup colcon mixin and metadata
+RUN colcon mixin add default \
+      https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml && \
+    colcon mixin update && \
+    colcon metadata add default \
+      https://raw.githubusercontent.com/colcon/colcon-metadata-repository/master/index.yaml && \
+    colcon metadata update
+
+# install ros2 packages
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ros-rolling-ros-base=0.10.0-3* \
+    && rm -rf /var/lib/apt/lists/*
+

--- a/ros/rolling/ubuntu/noble/ros-core/Dockerfile
+++ b/ros/rolling/ubuntu/noble/ros-core/Dockerfile
@@ -1,0 +1,46 @@
+# This is an auto generated Dockerfile for ros:ros-core
+# generated from docker_images_ros2/create_ros_core_image.Dockerfile.em
+FROM ubuntu:noble
+
+# setup timezone
+RUN echo 'Etc/UTC' > /etc/timezone && \
+    ln -s /usr/share/zoneinfo/Etc/UTC /etc/localtime && \
+    apt-get update && \
+    apt-get install -q -y --no-install-recommends tzdata && \
+    rm -rf /var/lib/apt/lists/*
+
+# install packages
+RUN apt-get update && apt-get install -q -y --no-install-recommends \
+    dirmngr \
+    gnupg2 \
+    && rm -rf /var/lib/apt/lists/*
+
+# setup keys
+RUN set -eux; \
+       key='C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654'; \
+       export GNUPGHOME="$(mktemp -d)"; \
+       gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key"; \
+       mkdir -p /usr/share/keyrings; \
+       gpg --batch --export "$key" > /usr/share/keyrings/ros2-latest-archive-keyring.gpg; \
+       gpgconf --kill all; \
+       rm -rf "$GNUPGHOME"
+
+# setup sources.list
+RUN echo "deb [ signed-by=/usr/share/keyrings/ros2-latest-archive-keyring.gpg ] http://packages.ros.org/ros2/ubuntu noble main" > /etc/apt/sources.list.d/ros2-latest.list
+
+# setup environment
+ENV LANG C.UTF-8
+ENV LC_ALL C.UTF-8
+
+ENV ROS_DISTRO rolling
+
+# install ros2 packages
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ros-rolling-ros-core=0.10.0-3* \
+    && rm -rf /var/lib/apt/lists/*
+
+# setup entrypoint
+COPY ./ros_entrypoint.sh /
+
+ENTRYPOINT ["/ros_entrypoint.sh"]
+CMD ["bash"]

--- a/ros/rolling/ubuntu/noble/ros-core/ros_entrypoint.sh
+++ b/ros/rolling/ubuntu/noble/ros-core/ros_entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+# setup ros2 environment
+source "/opt/ros/$ROS_DISTRO/setup.bash" --
+exec "$@"

--- a/ros/ros
+++ b/ros/ros
@@ -76,20 +76,20 @@ Directory: ros/iron/ubuntu/jammy/perception
 # Release: rolling
 
 ########################################
-# Distro: ubuntu:jammy
+# Distro: ubuntu:noble
 
-Tags: rolling-ros-core, rolling-ros-core-jammy
+Tags: rolling-ros-core, rolling-ros-core-noble
 Architectures: amd64, arm64v8
-GitCommit: 27cc0b68263bbbb10bb58dd814efc0a6b0a01ec7
-Directory: ros/rolling/ubuntu/jammy/ros-core
+GitCommit: 026069e4a10a7e6d390db2bb0ce9d3f704e93919
+Directory: ros/rolling/ubuntu/noble/ros-core
 
-Tags: rolling-ros-base, rolling-ros-base-jammy, rolling
+Tags: rolling-ros-base, rolling-ros-base-noble, rolling
 Architectures: amd64, arm64v8
-GitCommit: 73c1bf4c30e97d5d3d7c2aaddc8137cae2411409
-Directory: ros/rolling/ubuntu/jammy/ros-base
+GitCommit: 026069e4a10a7e6d390db2bb0ce9d3f704e93919
+Directory: ros/rolling/ubuntu/noble/ros-base
 
-Tags: rolling-perception, rolling-perception-jammy
+Tags: rolling-perception, rolling-perception-noble
 Architectures: amd64, arm64v8
-GitCommit: 73c1bf4c30e97d5d3d7c2aaddc8137cae2411409
-Directory: ros/rolling/ubuntu/jammy/perception
+GitCommit: 026069e4a10a7e6d390db2bb0ce9d3f704e93919
+Directory: ros/rolling/ubuntu/noble/perception
 


### PR DESCRIPTION
related to https://github.com/osrf/docker_images/issues/728

Currently this disables the simulation and desktop_full images as these packages are not available on noble yet
(As s side effect it also disables the rolling CI so this can be merged to be released upstream)