### PR TITLE
migrate all osrf/ros2 images to ubuntu noble

### DIFF
--- a/ros2/nightly/nightly/Dockerfile
+++ b/ros2/nightly/nightly/Dockerfile
@@ -1,5 +1,5 @@
 # multi-stage for setup
-FROM ubuntu:jammy-20240416 as setuper
+FROM ubuntu:noble-20240423 as setuper
 ARG DEBIAN_FRONTEND=noninteractive
 
 # setup timezone
@@ -17,6 +17,7 @@ RUN apt-get update && apt-get install -q -y --no-install-recommends \
     git \
     gnupg2 \
     libssl-dev \
+    python3-argcomplete \
     python3-flake8 \
     python3-flake8-blind-except \
     python3-flake8-builtins \
@@ -43,7 +44,7 @@ RUN set -eux; \
        rm -rf "$GNUPGHOME"
 
 # setup sources.list
-RUN echo "deb [ signed-by=/usr/share/keyrings/ros2-testing-archive-keyring.gpg ] http://packages.ros.org/ros2-testing/ubuntu jammy main" > /etc/apt/sources.list.d/ros2-testing.list
+RUN echo "deb [ signed-by=/usr/share/keyrings/ros2-testing-archive-keyring.gpg ] http://packages.ros.org/ros2-testing/ubuntu noble main" > /etc/apt/sources.list.d/ros2-testing.list
 
 # install bootstrap tools
 RUN apt-get update && apt-get install --no-install-recommends -y \
@@ -61,9 +62,6 @@ ENV LANG C.UTF-8
 ENV LC_ALL C.UTF-8
 ENV ROSDISTRO_INDEX_URL https://raw.githubusercontent.com/osrf/docker_images/master/ros2/nightly/nightly/index-v4.yaml
 
-# install python packages
-RUN pip3 install -U \
-    argcomplete
 # This is a workaround for pytest not found causing builds to fail
 # Following RUN statements tests for regression of https://github.com/ros2/ros2/issues/722
 RUN pip3 freeze | grep pytest \

--- a/ros2/source/devel/Dockerfile
+++ b/ros2/source/devel/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:jammy-20240416
+FROM ubuntu:noble-20240423
 
 # setup timezone
 RUN echo 'Etc/UTC' > /etc/timezone && \
@@ -12,6 +12,7 @@ RUN apt-get update && apt-get install -q -y --no-install-recommends \
     bash-completion \
     dirmngr \
     gnupg2 \
+    python3-argcomplete \
     python3-flake8 \
     python3-flake8-blind-except \
     python3-flake8-builtins \
@@ -37,7 +38,7 @@ RUN set -eux; \
        rm -rf "$GNUPGHOME"
 
 # setup sources.list
-RUN echo "deb [ signed-by=/usr/share/keyrings/ros2-latest-archive-keyring.gpg ] http://packages.ros.org/ros2/ubuntu jammy main" > /etc/apt/sources.list.d/ros2-latest.list
+RUN echo "deb [ signed-by=/usr/share/keyrings/ros2-latest-archive-keyring.gpg ] http://packages.ros.org/ros2/ubuntu noble main" > /etc/apt/sources.list.d/ros2-latest.list
 
 # setup environment
 ENV LANG C.UTF-8
@@ -54,9 +55,6 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     python3-vcstool \
     && rm -rf /var/lib/apt/lists/*
 
-# install python packages
-RUN pip3 install -U \
-    argcomplete
 # This is a workaround for pytest not found causing builds to fail
 # Following RUN statements tests for regression of https://github.com/ros2/ros2/issues/722
 RUN pip3 freeze | grep pytest \

--- a/ros2/source/images.yaml.em
+++ b/ros2/source/images.yaml.em
@@ -11,6 +11,7 @@ images:
             - docker_templates
         upstream_packages:
             - bash-completion
+            - python3-argcomplete
             - python3-flake8
             - python3-flake8-blind-except
             - python3-flake8-builtins
@@ -23,7 +24,6 @@ images:
             - python3-pytest-repeat
             - python3-pytest-rerunfailures
         pip3_install:
-            - argcomplete
         ws: /opt/ros2_ws
     source:
         maintainer_name: @(maintainer_name)

--- a/ros2/source/platform.yaml
+++ b/ros2/source/platform.yaml
@@ -3,7 +3,7 @@
 ---
 platform:
     os_name: ubuntu
-    os_code_name: jammy
+    os_code_name: noble
     user_name: ros2
     maintainer_name:
     arch: amd64

--- a/ros2/testing/platform.yaml
+++ b/ros2/testing/platform.yaml
@@ -3,7 +3,7 @@
 ---
 platform:
     os_name: ubuntu
-    os_code_name: jammy
+    os_code_name: noble
     ros2distro_name: rolling
     user_name: ros
     maintainer_name:


### PR DESCRIPTION
Related to https://github.com/osrf/docker_images/pull/735#issuecomment-2079466268



This has been tested locally by launching the talker_listener example on source and nightly images with all rmw implementations