### PR TITLE
Add images for Jazzy testing

### DIFF
--- a/ros/jazzy/ubuntu/noble/Makefile
+++ b/ros/jazzy/ubuntu/noble/Makefile
@@ -1,0 +1,78 @@
+all: help
+
+help:
+	@echo ""
+	@echo "-- Help Menu"
+	@echo ""
+	@echo "   1. make build            - build all images"
+	@echo "   2. make pull             - pull all images"
+	@echo "   3. make clean            - remove all images"
+	@echo ""
+
+build:
+	@docker build --tag=ros:jazzy-ros-core-noble			ros-core/.
+	@docker build --tag=ros:jazzy-ros-base-noble			ros-base/.
+	@docker build --tag=ros:jazzy-perception-noble			perception/.
+	@docker build --tag=osrf/ros:jazzy-simulation-noble			simulation/.
+	@docker build --tag=osrf/ros:jazzy-desktop-noble			desktop/.
+	@docker build --tag=osrf/ros:jazzy-desktop-full-noble			desktop-full/.
+
+pull:
+	@docker pull ros:jazzy-ros-core-noble
+	@docker pull ros:jazzy-ros-base-noble
+	@docker pull ros:jazzy-perception-noble
+	# @docker pull osrf/ros:jazzy-simulation-noble
+	# @docker pull osrf/ros:jazzy-desktop-noble
+	# @docker pull osrf/ros:jazzy-desktop-full-noble
+
+clean:
+	@docker rmi -f ros:jazzy-ros-core-noble
+	@docker rmi -f ros:jazzy-ros-base-noble
+	@docker rmi -f ros:jazzy-perception-noble
+	# @docker rmi -f osrf/ros:jazzy-simulation-noble
+	# @docker rmi -f osrf/ros:jazzy-desktop-noble
+	# @docker rmi -f osrf/ros:jazzy-desktop-full-noble
+
+ci_buildx:
+	@docker buildx build --pull --push \
+		--cache-from=type=registry,ref=osrf/ros:jazzy-desktop-noble \
+		--cache-to=type=inline \
+		--tag=osrf/ros:jazzy-desktop-noble \
+		desktop/.
+	@if [ "ubuntu" = "ubuntu" ]; then \
+		docker pull \
+			osrf/ros:jazzy-desktop-noble; \
+    	docker tag \
+			osrf/ros:jazzy-desktop-noble \
+			osrf/ros:jazzy-desktop; \
+		docker push \
+			osrf/ros:jazzy-desktop; \
+	fi
+	@docker buildx build --pull --push \
+		--cache-from=type=registry,ref=osrf/ros:jazzy-simulation-noble \
+		--cache-to=type=inline \
+		--tag=osrf/ros:jazzy-simulation-noble \
+		simulation/.
+	@if [ "ubuntu" = "ubuntu" ]; then \
+		docker pull \
+			osrf/ros:jazzy-simulation-noble; \
+		docker tag \
+			osrf/ros:jazzy-simulation-noble \
+			osrf/ros:jazzy-simulation; \
+		docker push \
+			osrf/ros:jazzy-simulation; \
+	fi
+	@docker buildx build --pull --push \
+		--cache-from=type=registry,ref=osrf/ros:jazzy-desktop-full-noble \
+		--cache-to=type=inline \
+		--tag=osrf/ros:jazzy-desktop-full-noble \
+		desktop-full/.
+	@if [ "ubuntu" = "ubuntu" ]; then \
+		docker pull \
+			osrf/ros:jazzy-desktop-full-noble; \
+		docker tag \
+			osrf/ros:jazzy-desktop-full-noble \
+			osrf/ros:jazzy-desktop-full; \
+		docker push \
+			osrf/ros:jazzy-desktop-full; \
+	fi

--- a/ros/jazzy/ubuntu/noble/desktop-full/Dockerfile
+++ b/ros/jazzy/ubuntu/noble/desktop-full/Dockerfile
@@ -1,0 +1,9 @@
+# This is an auto generated Dockerfile for ros:desktop-full
+# generated from docker_images_ros2/create_ros_image.Dockerfile.em
+FROM osrf/ros:jazzy-desktop-noble
+
+# install ros2 packages
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ros-jazzy-desktop-full=0.10.0-4* \
+    && rm -rf /var/lib/apt/lists/*
+

--- a/ros/jazzy/ubuntu/noble/desktop/Dockerfile
+++ b/ros/jazzy/ubuntu/noble/desktop/Dockerfile
@@ -1,0 +1,9 @@
+# This is an auto generated Dockerfile for ros:desktop
+# generated from docker_images_ros2/create_ros_image.Dockerfile.em
+FROM ros:jazzy-ros-base-noble
+
+# install ros2 packages
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ros-jazzy-desktop=0.10.0-4* \
+    && rm -rf /var/lib/apt/lists/*
+

--- a/ros/jazzy/ubuntu/noble/images.yaml.em
+++ b/ros/jazzy/ubuntu/noble/images.yaml.em
@@ -1,0 +1,54 @@
+%YAML 1.1
+# ROS2 Dockerfile database
+---
+images:
+    ros-core:
+        base_image: @(os_name):@(os_code_name)
+        maintainer_name: @(maintainer_name)
+        template_name: docker_images_ros2/create_ros_core_image.Dockerfile.em
+        entrypoint_name: docker_images_ros2/ros_entrypoint.sh
+        template_packages:
+            - docker_templates
+        ros2_packages:
+            - ros-core
+    ros-base:
+        base_image: @(user_name):@(ros2distro_name)-ros-core-@(os_code_name)
+        maintainer_name: @(maintainer_name)
+        template_name: docker_images_ros2/create_ros_image.Dockerfile.em
+        template_packages:
+            - docker_templates
+        ros2_packages:
+            - ros-base
+        bootstrap_ros_tools:
+    perception:
+        base_image: @(user_name):@(ros2distro_name)-ros-base-@(os_code_name)
+        maintainer_name: @(maintainer_name)
+        template_name: docker_images_ros2/create_ros_image.Dockerfile.em
+        template_packages:
+            - docker_templates
+        ros2_packages:
+            - perception
+    simulation:
+        base_image: @(user_name):@(ros2distro_name)-ros-base-@(os_code_name)
+        maintainer_name: @(maintainer_name)
+        template_name: docker_images_ros2/create_ros_image.Dockerfile.em
+        template_packages:
+            - docker_templates
+        ros2_packages:
+            - simulation
+    desktop:
+        base_image: @(user_name):@(ros2distro_name)-ros-base-@(os_code_name)
+        maintainer_name: @(maintainer_name)
+        template_name: docker_images_ros2/create_ros_image.Dockerfile.em
+        template_packages:
+            - docker_templates
+        ros2_packages:
+            - desktop
+    desktop-full:
+        base_image: osrf/@(user_name):@(ros2distro_name)-desktop-@(os_code_name)
+        maintainer_name: @(maintainer_name)
+        template_name: docker_images_ros2/create_ros_image.Dockerfile.em
+        template_packages:
+            - docker_templates
+        ros2_packages:
+            - desktop-full

--- a/ros/jazzy/ubuntu/noble/perception/Dockerfile
+++ b/ros/jazzy/ubuntu/noble/perception/Dockerfile
@@ -1,0 +1,9 @@
+# This is an auto generated Dockerfile for ros:perception
+# generated from docker_images_ros2/create_ros_image.Dockerfile.em
+FROM ros:jazzy-ros-base-noble
+
+# install ros2 packages
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ros-jazzy-perception=0.10.0-4* \
+    && rm -rf /var/lib/apt/lists/*
+

--- a/ros/jazzy/ubuntu/noble/platform.yaml
+++ b/ros/jazzy/ubuntu/noble/platform.yaml
@@ -1,0 +1,12 @@
+%YAML 1.1
+# ROS2 Dockerfile database
+---
+platform:
+    os_name: ubuntu
+    os_code_name: noble
+    ros2distro_name: jazzy
+    user_name: ros
+    maintainer_name:
+    arch: amd64
+    type: distribution
+    version:

--- a/ros/jazzy/ubuntu/noble/ros-base/Dockerfile
+++ b/ros/jazzy/ubuntu/noble/ros-base/Dockerfile
@@ -1,0 +1,31 @@
+# This is an auto generated Dockerfile for ros:ros-base
+# generated from docker_images_ros2/create_ros_image.Dockerfile.em
+FROM ros:jazzy-ros-core-noble
+
+# install bootstrap tools
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    build-essential \
+    git \
+    python3-colcon-common-extensions \
+    python3-colcon-mixin \
+    python3-rosdep \
+    python3-vcstool \
+    && rm -rf /var/lib/apt/lists/*
+
+# bootstrap rosdep
+RUN rosdep init && \
+  rosdep update --rosdistro $ROS_DISTRO
+
+# setup colcon mixin and metadata
+RUN colcon mixin add default \
+      https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml && \
+    colcon mixin update && \
+    colcon metadata add default \
+      https://raw.githubusercontent.com/colcon/colcon-metadata-repository/master/index.yaml && \
+    colcon metadata update
+
+# install ros2 packages
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ros-jazzy-ros-base=0.10.0-4* \
+    && rm -rf /var/lib/apt/lists/*
+

--- a/ros/jazzy/ubuntu/noble/ros-core/Dockerfile
+++ b/ros/jazzy/ubuntu/noble/ros-core/Dockerfile
@@ -1,0 +1,46 @@
+# This is an auto generated Dockerfile for ros:ros-core
+# generated from docker_images_ros2/create_ros_core_image.Dockerfile.em
+FROM ubuntu:noble
+
+# setup timezone
+RUN echo 'Etc/UTC' > /etc/timezone && \
+    ln -s /usr/share/zoneinfo/Etc/UTC /etc/localtime && \
+    apt-get update && \
+    apt-get install -q -y --no-install-recommends tzdata && \
+    rm -rf /var/lib/apt/lists/*
+
+# install packages
+RUN apt-get update && apt-get install -q -y --no-install-recommends \
+    dirmngr \
+    gnupg2 \
+    && rm -rf /var/lib/apt/lists/*
+
+# setup keys
+RUN set -eux; \
+       key='C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654'; \
+       export GNUPGHOME="$(mktemp -d)"; \
+       gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key"; \
+       mkdir -p /usr/share/keyrings; \
+       gpg --batch --export "$key" > /usr/share/keyrings/ros2-testing-archive-keyring.gpg; \
+       gpgconf --kill all; \
+       rm -rf "$GNUPGHOME"
+
+# setup sources.list
+RUN echo "deb [ signed-by=/usr/share/keyrings/ros2-testing-archive-keyring.gpg ] http://packages.ros.org/ros2-testing/ubuntu noble main" > /etc/apt/sources.list.d/ros2-testing.list
+
+# setup environment
+ENV LANG C.UTF-8
+ENV LC_ALL C.UTF-8
+
+ENV ROS_DISTRO jazzy
+
+# install ros2 packages
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ros-jazzy-ros-core=0.10.0-4* \
+    && rm -rf /var/lib/apt/lists/*
+
+# setup entrypoint
+COPY ./ros_entrypoint.sh /
+
+ENTRYPOINT ["/ros_entrypoint.sh"]
+CMD ["bash"]

--- a/ros/jazzy/ubuntu/noble/ros-core/ros_entrypoint.sh
+++ b/ros/jazzy/ubuntu/noble/ros-core/ros_entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+# setup ros2 environment
+source "/opt/ros/$ROS_DISTRO/setup.bash" --
+exec "$@"

--- a/ros/jazzy/ubuntu/noble/simulation/Dockerfile
+++ b/ros/jazzy/ubuntu/noble/simulation/Dockerfile
@@ -1,0 +1,9 @@
+# This is an auto generated Dockerfile for ros:simulation
+# generated from docker_images_ros2/create_ros_image.Dockerfile.em
+FROM ros:jazzy-ros-base-noble
+
+# install ros2 packages
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ros-jazzy-simulation=0.10.0-4* \
+    && rm -rf /var/lib/apt/lists/*
+

--- a/ros/manifest.yaml
+++ b/ros/manifest.yaml
@@ -598,6 +598,30 @@ release_names:
                                 aliases:
                                     - "$release_name-perception"
                                     - "$release_name-perception-$os_code_name"
+    jazzy:
+        eol: 2029-05
+        os_names:
+            ubuntu:
+                os_code_names:
+                    noble:
+                        <<: *DEFAULT_ROS2
+                        archs:
+                            - amd64
+                            - arm64v8
+                        tag_names:
+                            ros-core:
+                                aliases:
+                                    - "$release_name-ros-core"
+                                    - "$release_name-ros-core-$os_code_name"
+                            ros-base:
+                                aliases:
+                                    - "$release_name-ros-base"
+                                    - "$release_name-ros-base-$os_code_name"
+                                    - "$release_name"
+                            perception:
+                                aliases:
+                                    - "$release_name-perception"
+                                    - "$release_name-perception-$os_code_name"
     rolling:
         eol: 2022-05
         os_names:

--- a/ros/ros
+++ b/ros/ros
@@ -73,6 +73,28 @@ Directory: ros/iron/ubuntu/jammy/perception
 
 
 ################################################################################
+# Release: jazzy
+
+########################################
+# Distro: ubuntu:noble
+
+Tags: jazzy-ros-core, jazzy-ros-core-noble
+Architectures: amd64, arm64v8
+GitCommit: 543aabeed37ee905ac3737fd38ffbc9894e997db
+Directory: ros/jazzy/ubuntu/noble/ros-core
+
+Tags: jazzy-ros-base, jazzy-ros-base-noble, jazzy
+Architectures: amd64, arm64v8
+GitCommit: 543aabeed37ee905ac3737fd38ffbc9894e997db
+Directory: ros/jazzy/ubuntu/noble/ros-base
+
+Tags: jazzy-perception, jazzy-perception-noble
+Architectures: amd64, arm64v8
+GitCommit: 543aabeed37ee905ac3737fd38ffbc9894e997db
+Directory: ros/jazzy/ubuntu/noble/perception
+
+
+################################################################################
 # Release: rolling
 
 ########################################


### PR DESCRIPTION
@ruffsl curious to know how you feel about this.

Jazzy will be released in a month and is not fully ready yet
Having images available for pre-release would be likely useful

I was thinking of:
- publishing these images (based on the testing apt repo) to dockerhub
  - not add them to CI
  - not move the latest tag
- A jazzy release time:
  - regenerate the images pointing to the right repo
  - move the latest tag
  - submit to dockerhub for rebuild
 
What do you think?