### PR TITLE
jazzy 0.10.0-4 -> 0.11.0-1

### DIFF
--- a/ros/jazzy/ubuntu/noble/desktop-full/Dockerfile
+++ b/ros/jazzy/ubuntu/noble/desktop-full/Dockerfile
@@ -4,6 +4,6 @@ FROM osrf/ros:jazzy-desktop-noble
 
 # install ros2 packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    ros-jazzy-desktop-full=0.10.0-4* \
+    ros-jazzy-desktop-full=0.11.0-1* \
     && rm -rf /var/lib/apt/lists/*
 

--- a/ros/jazzy/ubuntu/noble/desktop/Dockerfile
+++ b/ros/jazzy/ubuntu/noble/desktop/Dockerfile
@@ -4,6 +4,6 @@ FROM ros:jazzy-ros-base-noble
 
 # install ros2 packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    ros-jazzy-desktop=0.10.0-4* \
+    ros-jazzy-desktop=0.11.0-1* \
     && rm -rf /var/lib/apt/lists/*
 

--- a/ros/jazzy/ubuntu/noble/perception/Dockerfile
+++ b/ros/jazzy/ubuntu/noble/perception/Dockerfile
@@ -4,6 +4,6 @@ FROM ros:jazzy-ros-base-noble
 
 # install ros2 packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    ros-jazzy-perception=0.10.0-4* \
+    ros-jazzy-perception=0.11.0-1* \
     && rm -rf /var/lib/apt/lists/*
 

--- a/ros/jazzy/ubuntu/noble/ros-base/Dockerfile
+++ b/ros/jazzy/ubuntu/noble/ros-base/Dockerfile
@@ -26,6 +26,6 @@ RUN colcon mixin add default \
 
 # install ros2 packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    ros-jazzy-ros-base=0.10.0-4* \
+    ros-jazzy-ros-base=0.11.0-1* \
     && rm -rf /var/lib/apt/lists/*
 

--- a/ros/jazzy/ubuntu/noble/ros-core/Dockerfile
+++ b/ros/jazzy/ubuntu/noble/ros-core/Dockerfile
@@ -36,7 +36,7 @@ ENV ROS_DISTRO jazzy
 
 # install ros2 packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    ros-jazzy-ros-core=0.10.0-4* \
+    ros-jazzy-ros-core=0.11.0-1* \
     && rm -rf /var/lib/apt/lists/*
 
 # setup entrypoint

--- a/ros/jazzy/ubuntu/noble/simulation/Dockerfile
+++ b/ros/jazzy/ubuntu/noble/simulation/Dockerfile
@@ -4,6 +4,6 @@ FROM ros:jazzy-ros-base-noble
 
 # install ros2 packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    ros-jazzy-simulation=0.10.0-4* \
+    ros-jazzy-simulation=0.11.0-1* \
     && rm -rf /var/lib/apt/lists/*
 

--- a/ros/ros
+++ b/ros/ros
@@ -80,17 +80,17 @@ Directory: ros/iron/ubuntu/jammy/perception
 
 Tags: jazzy-ros-core, jazzy-ros-core-noble
 Architectures: amd64, arm64v8
-GitCommit: 543aabeed37ee905ac3737fd38ffbc9894e997db
+GitCommit: 0038f1c3a11aa0fc573d698b39ab5c204aad5a40
 Directory: ros/jazzy/ubuntu/noble/ros-core
 
 Tags: jazzy-ros-base, jazzy-ros-base-noble, jazzy
 Architectures: amd64, arm64v8
-GitCommit: 543aabeed37ee905ac3737fd38ffbc9894e997db
+GitCommit: 0038f1c3a11aa0fc573d698b39ab5c204aad5a40
 Directory: ros/jazzy/ubuntu/noble/ros-base
 
 Tags: jazzy-perception, jazzy-perception-noble
 Architectures: amd64, arm64v8
-GitCommit: 543aabeed37ee905ac3737fd38ffbc9894e997db
+GitCommit: 0038f1c3a11aa0fc573d698b39ab5c204aad5a40
 Directory: ros/jazzy/ubuntu/noble/perception
 
 


### PR DESCRIPTION
Looks like docker images build fail due to a bump in variants https://doi-janky.infosiftr.net/job/multiarch/job/amd64/job/ros/

https://github.com/osrf/docker_images/pull/741#discussion_r1585267598
