### PR TITLE
[ros2][devel/nightly] add some missing pytest dependencies

### DIFF
--- a/ros2/nightly/nightly/Dockerfile
+++ b/ros2/nightly/nightly/Dockerfile
@@ -28,8 +28,12 @@ RUN apt-get update && apt-get install -q -y --no-install-recommends \
     python3-flake8-import-order \
     python3-flake8-quotes \
     python3-pip \
+    python3-pytest-cov \
+    python3-pytest-mock \
     python3-pytest-repeat \
     python3-pytest-rerunfailures \
+    python3-pytest-runner \
+    python3-pytest-timeout \
     wget \
     && rm -rf /var/lib/apt/lists/*
 

--- a/ros2/source/devel/Dockerfile
+++ b/ros2/source/devel/Dockerfile
@@ -23,8 +23,12 @@ RUN apt-get update && apt-get install -q -y --no-install-recommends \
     python3-flake8-import-order \
     python3-flake8-quotes \
     python3-pip \
+    python3-pytest-cov \
+    python3-pytest-mock \
     python3-pytest-repeat \
     python3-pytest-rerunfailures \
+    python3-pytest-runner \
+    python3-pytest-timeout \
     && rm -rf /var/lib/apt/lists/*
 
 # setup keys

--- a/ros2/source/images.yaml.em
+++ b/ros2/source/images.yaml.em
@@ -21,12 +21,12 @@ images:
             - python3-flake8-docstrings
             - python3-flake8-import-order
             - python3-flake8-quotes
-            - python3-pytest-cov \
-            - python3-pytest-mock \
-            - python3-pytest-repeat \
-            - python3-pytest-rerunfailures \
-            - python3-pytest-runner \
-            - python3-pytest-timeout \
+            - python3-pytest-cov
+            - python3-pytest-mock
+            - python3-pytest-repeat
+            - python3-pytest-rerunfailures
+            - python3-pytest-runner
+            - python3-pytest-timeout
         pip3_install:
         ws: /opt/ros2_ws
     source:

--- a/ros2/source/images.yaml.em
+++ b/ros2/source/images.yaml.em
@@ -21,8 +21,12 @@ images:
             - python3-flake8-docstrings
             - python3-flake8-import-order
             - python3-flake8-quotes
-            - python3-pytest-repeat
-            - python3-pytest-rerunfailures
+            - python3-pytest-cov \
+            - python3-pytest-mock \
+            - python3-pytest-repeat \
+            - python3-pytest-rerunfailures \
+            - python3-pytest-runner \
+            - python3-pytest-timeout \
         pip3_install:
         ws: /opt/ros2_ws
     source:


### PR DESCRIPTION
Otherwise some jobs based on ros2:devel fail, e.g. if you try to generate coverage for a python package

I took the set of pytest package from the ROS 2 CI:
https://github.com/ros2/ci/blob/3435d04acf17872b07861e81265bc34d7ef40c72/linux_docker_resources/Dockerfile#L120-L125