### PR TITLE
Rolling update

### DIFF
--- a/.github/workflows/ros_ci.yaml
+++ b/.github/workflows/ros_ci.yaml
@@ -6,7 +6,7 @@ on:
     paths:
     - '.ci/**'
     - '.github/workflows/ros_ci.yaml'
-    # - 'ros/rolling/**'
+    - 'ros/rolling/**'
     - 'ros/jazzy/**'
     - 'ros/iron/**'
     - 'ros/humble/**'
@@ -15,7 +15,7 @@ on:
     paths:
     - '.ci/**'
     - '.github/workflows/ros_ci.yaml'
-    # - 'ros/rolling/**'
+    - 'ros/rolling/**'
     - 'ros/jazzy/**'
     - 'ros/iron/**'
     - 'ros/humble/**'
@@ -29,7 +29,7 @@ jobs:
       fail-fast: false
       matrix:
         env:
-          # - {HUB_REPO: ros, HUB_RELEASE: rolling, HUB_OS_NAME: ubuntu, HUB_OS_CODE_NAME: jammy}
+          - {HUB_REPO: ros, HUB_RELEASE: rolling, HUB_OS_NAME: ubuntu, HUB_OS_CODE_NAME: noble}
           - {HUB_REPO: ros, HUB_RELEASE: jazzy, HUB_OS_NAME: ubuntu, HUB_OS_CODE_NAME: noble}
           - {HUB_REPO: ros, HUB_RELEASE: iron, HUB_OS_NAME: ubuntu, HUB_OS_CODE_NAME: jammy}
           - {HUB_REPO: ros, HUB_RELEASE: humble, HUB_OS_NAME: ubuntu, HUB_OS_CODE_NAME: jammy}

--- a/ros/rolling/ubuntu/noble/Makefile
+++ b/ros/rolling/ubuntu/noble/Makefile
@@ -48,31 +48,31 @@ ci_buildx:
 		docker push \
 			osrf/ros:rolling-desktop; \
 	fi
-	# @docker buildx build --pull --push \
-	# 	--cache-from=type=registry,ref=osrf/ros:rolling-simulation-noble \
-	# 	--cache-to=type=inline \
-	# 	--tag=osrf/ros:rolling-simulation-noble \
-	# 	simulation/.
-	# @if [ "ubuntu" = "ubuntu" ]; then \
-	# 	docker pull \
-	# 		osrf/ros:rolling-simulation-noble; \
-	# 	docker tag \
-	# 		osrf/ros:rolling-simulation-noble \
-	# 		osrf/ros:rolling-simulation; \
-	# 	docker push \
-	# 		osrf/ros:rolling-simulation; \
-	# fi
-	# @docker buildx build --pull --push \
-	# 	--cache-from=type=registry,ref=osrf/ros:rolling-desktop-full-noble \
-	# 	--cache-to=type=inline \
-	# 	--tag=osrf/ros:rolling-desktop-full-noble \
-	# 	desktop-full/.
-	# @if [ "ubuntu" = "ubuntu" ]; then \
-	# 	docker pull \
-	# 		osrf/ros:rolling-desktop-full-noble; \
-	# 	docker tag \
-	# 		osrf/ros:rolling-desktop-full-noble \
-	# 		osrf/ros:rolling-desktop-full; \
-	# 	docker push \
-	# 		osrf/ros:rolling-desktop-full; \
-	# fi
+	@docker buildx build --pull --push \
+		--cache-from=type=registry,ref=osrf/ros:rolling-simulation-noble \
+		--cache-to=type=inline \
+		--tag=osrf/ros:rolling-simulation-noble \
+		simulation/.
+	@if [ "ubuntu" = "ubuntu" ]; then \
+		docker pull \
+			osrf/ros:rolling-simulation-noble; \
+		docker tag \
+			osrf/ros:rolling-simulation-noble \
+			osrf/ros:rolling-simulation; \
+		docker push \
+			osrf/ros:rolling-simulation; \
+	fi
+	@docker buildx build --pull --push \
+		--cache-from=type=registry,ref=osrf/ros:rolling-desktop-full-noble \
+		--cache-to=type=inline \
+		--tag=osrf/ros:rolling-desktop-full-noble \
+		desktop-full/.
+	@if [ "ubuntu" = "ubuntu" ]; then \
+		docker pull \
+			osrf/ros:rolling-desktop-full-noble; \
+		docker tag \
+			osrf/ros:rolling-desktop-full-noble \
+			osrf/ros:rolling-desktop-full; \
+		docker push \
+			osrf/ros:rolling-desktop-full; \
+	fi

--- a/ros/rolling/ubuntu/noble/desktop/Dockerfile
+++ b/ros/rolling/ubuntu/noble/desktop/Dockerfile
@@ -4,6 +4,6 @@ FROM ros:rolling-ros-base-noble
 
 # install ros2 packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    ros-rolling-desktop=0.10.0-3* \
+    ros-rolling-desktop=0.11.0-1* \
     && rm -rf /var/lib/apt/lists/*
 

--- a/ros/rolling/ubuntu/noble/images.yaml.em
+++ b/ros/rolling/ubuntu/noble/images.yaml.em
@@ -28,14 +28,14 @@ images:
             - docker_templates
         ros2_packages:
             - perception
-    # simulation:
-    #     base_image: @(user_name):@(ros2distro_name)-ros-base-@(os_code_name)
-    #     maintainer_name: @(maintainer_name)
-    #     template_name: docker_images_ros2/create_ros_image.Dockerfile.em
-    #     template_packages:
-    #         - docker_templates
-    #     ros2_packages:
-    #         - simulation
+    simulation:
+        base_image: @(user_name):@(ros2distro_name)-ros-base-@(os_code_name)
+        maintainer_name: @(maintainer_name)
+        template_name: docker_images_ros2/create_ros_image.Dockerfile.em
+        template_packages:
+            - docker_templates
+        ros2_packages:
+            - simulation
     desktop:
         base_image: @(user_name):@(ros2distro_name)-ros-base-@(os_code_name)
         maintainer_name: @(maintainer_name)
@@ -44,11 +44,11 @@ images:
             - docker_templates
         ros2_packages:
             - desktop
-    # desktop-full:
-    #     base_image: osrf/@(user_name):@(ros2distro_name)-desktop-@(os_code_name)
-    #     maintainer_name: @(maintainer_name)
-    #     template_name: docker_images_ros2/create_ros_image.Dockerfile.em
-    #     template_packages:
-    #         - docker_templates
-    #     ros2_packages:
-    #         - desktop-full
+    desktop-full:
+        base_image: osrf/@(user_name):@(ros2distro_name)-desktop-@(os_code_name)
+        maintainer_name: @(maintainer_name)
+        template_name: docker_images_ros2/create_ros_image.Dockerfile.em
+        template_packages:
+            - docker_templates
+        ros2_packages:
+            - desktop-full

--- a/ros/rolling/ubuntu/noble/perception/Dockerfile
+++ b/ros/rolling/ubuntu/noble/perception/Dockerfile
@@ -4,6 +4,6 @@ FROM ros:rolling-ros-base-noble
 
 # install ros2 packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    ros-rolling-perception=0.10.0-3* \
+    ros-rolling-perception=0.11.0-1* \
     && rm -rf /var/lib/apt/lists/*
 

--- a/ros/rolling/ubuntu/noble/ros-base/Dockerfile
+++ b/ros/rolling/ubuntu/noble/ros-base/Dockerfile
@@ -26,6 +26,6 @@ RUN colcon mixin add default \
 
 # install ros2 packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    ros-rolling-ros-base=0.10.0-3* \
+    ros-rolling-ros-base=0.11.0-1* \
     && rm -rf /var/lib/apt/lists/*
 

--- a/ros/rolling/ubuntu/noble/ros-core/Dockerfile
+++ b/ros/rolling/ubuntu/noble/ros-core/Dockerfile
@@ -36,7 +36,7 @@ ENV ROS_DISTRO rolling
 
 # install ros2 packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    ros-rolling-ros-core=0.10.0-3* \
+    ros-rolling-ros-core=0.11.0-1* \
     && rm -rf /var/lib/apt/lists/*
 
 # setup entrypoint

--- a/ros/ros
+++ b/ros/ros
@@ -102,16 +102,16 @@ Directory: ros/jazzy/ubuntu/noble/perception
 
 Tags: rolling-ros-core, rolling-ros-core-noble
 Architectures: amd64, arm64v8
-GitCommit: 026069e4a10a7e6d390db2bb0ce9d3f704e93919
+GitCommit: 7f98ddd88d872299c45b60c8bcd70d4eb6665222
 Directory: ros/rolling/ubuntu/noble/ros-core
 
 Tags: rolling-ros-base, rolling-ros-base-noble, rolling
 Architectures: amd64, arm64v8
-GitCommit: 026069e4a10a7e6d390db2bb0ce9d3f704e93919
+GitCommit: 7f98ddd88d872299c45b60c8bcd70d4eb6665222
 Directory: ros/rolling/ubuntu/noble/ros-base
 
 Tags: rolling-perception, rolling-perception-noble
 Architectures: amd64, arm64v8
-GitCommit: 026069e4a10a7e6d390db2bb0ce9d3f704e93919
+GitCommit: 7f98ddd88d872299c45b60c8bcd70d4eb6665222
 Directory: ros/rolling/ubuntu/noble/perception
 


### PR DESCRIPTION
Closes https://github.com/osrf/docker_images/issues/728

Now that the rolling sync with desktop_full is out we can update all images and revert temporary hacks