### PR TITLE
Explicitly encode apt keys 1.1.0 and their checksums in the Dockerfile at generation time

### DIFF
--- a/ros/humble/ubuntu/jammy/ros-core/Dockerfile
+++ b/ros/humble/ubuntu/jammy/ros-core/Dockerfile
@@ -18,13 +18,13 @@ RUN apt-get update && apt-get install -q -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 
-# NOTE: this doesnt deal with snapshots repo as not clear what to install for those..
-# NOTE: How do we break cache and ensure rebuild if that version changes ?
-RUN export ROS_APT_SOURCE_VERSION=$(curl -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | grep -F "tag_name" | awk -F\" '{print $4}') ;\
-    curl -L -s -o /tmp/ros2-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros2-apt-source_${ROS_APT_SOURCE_VERSION}.$(. /etc/os-release && echo $VERSION_CODENAME)_all.deb" \
+# Setup ROS Apt sources
+RUN curl -L -s -o /tmp/ros2-apt-source.deb https://github.com/ros-infrastructure/ros-apt-source/releases/download/1.1.0/ros2-apt-source_1.1.0.jammy_all.deb \
+    && echo "1600cb8cc28258a39bffc1736a75bcbf52d1f2db371a4d020c1b187d2a5a083b /tmp/ros2-apt-source.deb" | sha256sum --strict --check \
     && apt-get update \
     && apt-get install /tmp/ros2-apt-source.deb \
-    && rm -f /tmp/ros2-apt-source.deb
+    && rm -f /tmp/ros2-apt-source.deb \
+    && rm -rf /var/lib/apt/lists/*
 
 # setup environment
 ENV LANG=C.UTF-8

--- a/ros/jazzy/ubuntu/noble/ros-core/Dockerfile
+++ b/ros/jazzy/ubuntu/noble/ros-core/Dockerfile
@@ -18,13 +18,13 @@ RUN apt-get update && apt-get install -q -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 
-# NOTE: this doesnt deal with snapshots repo as not clear what to install for those..
-# NOTE: How do we break cache and ensure rebuild if that version changes ?
-RUN export ROS_APT_SOURCE_VERSION=$(curl -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | grep -F "tag_name" | awk -F\" '{print $4}') ;\
-    curl -L -s -o /tmp/ros2-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros2-apt-source_${ROS_APT_SOURCE_VERSION}.$(. /etc/os-release && echo $VERSION_CODENAME)_all.deb" \
+# Setup ROS Apt sources
+RUN curl -L -s -o /tmp/ros2-apt-source.deb https://github.com/ros-infrastructure/ros-apt-source/releases/download/1.1.0/ros2-apt-source_1.1.0.noble_all.deb \
+    && echo "35441f3092fd05773a3c397fab38661bec466584c7a1f1c05366579997cb5fe7 /tmp/ros2-apt-source.deb" | sha256sum --strict --check \
     && apt-get update \
     && apt-get install /tmp/ros2-apt-source.deb \
-    && rm -f /tmp/ros2-apt-source.deb
+    && rm -f /tmp/ros2-apt-source.deb \
+    && rm -rf /var/lib/apt/lists/*
 
 # setup environment
 ENV LANG=C.UTF-8

--- a/ros/kilted/ubuntu/noble/ros-core/Dockerfile
+++ b/ros/kilted/ubuntu/noble/ros-core/Dockerfile
@@ -18,13 +18,13 @@ RUN apt-get update && apt-get install -q -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 
-# NOTE: this doesnt deal with snapshots repo as not clear what to install for those..
-# NOTE: How do we break cache and ensure rebuild if that version changes ?
-RUN export ROS_APT_SOURCE_VERSION=$(curl -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | grep -F "tag_name" | awk -F\" '{print $4}') ;\
-    curl -L -s -o /tmp/ros2-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros2-apt-source_${ROS_APT_SOURCE_VERSION}.$(. /etc/os-release && echo $VERSION_CODENAME)_all.deb" \
+# Setup ROS Apt sources
+RUN curl -L -s -o /tmp/ros2-apt-source.deb https://github.com/ros-infrastructure/ros-apt-source/releases/download/1.1.0/ros2-apt-source_1.1.0.noble_all.deb \
+    && echo "35441f3092fd05773a3c397fab38661bec466584c7a1f1c05366579997cb5fe7 /tmp/ros2-apt-source.deb" | sha256sum --strict --check \
     && apt-get update \
     && apt-get install /tmp/ros2-apt-source.deb \
-    && rm -f /tmp/ros2-apt-source.deb
+    && rm -f /tmp/ros2-apt-source.deb \
+    && rm -rf /var/lib/apt/lists/*
 
 # setup environment
 ENV LANG=C.UTF-8

--- a/ros/rolling/ubuntu/noble/ros-core/Dockerfile
+++ b/ros/rolling/ubuntu/noble/ros-core/Dockerfile
@@ -18,13 +18,13 @@ RUN apt-get update && apt-get install -q -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 
-# NOTE: this doesnt deal with snapshots repo as not clear what to install for those..
-# NOTE: How do we break cache and ensure rebuild if that version changes ?
-RUN export ROS_APT_SOURCE_VERSION=$(curl -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | grep -F "tag_name" | awk -F\" '{print $4}') ;\
-    curl -L -s -o /tmp/ros2-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros2-apt-source_${ROS_APT_SOURCE_VERSION}.$(. /etc/os-release && echo $VERSION_CODENAME)_all.deb" \
+# Setup ROS Apt sources
+RUN curl -L -s -o /tmp/ros2-apt-source.deb https://github.com/ros-infrastructure/ros-apt-source/releases/download/1.1.0/ros2-apt-source_1.1.0.noble_all.deb \
+    && echo "35441f3092fd05773a3c397fab38661bec466584c7a1f1c05366579997cb5fe7 /tmp/ros2-apt-source.deb" | sha256sum --strict --check \
     && apt-get update \
     && apt-get install /tmp/ros2-apt-source.deb \
-    && rm -f /tmp/ros2-apt-source.deb
+    && rm -f /tmp/ros2-apt-source.deb \
+    && rm -rf /var/lib/apt/lists/*
 
 # setup environment
 ENV LANG=C.UTF-8

--- a/ros/ros
+++ b/ros/ros
@@ -36,7 +36,7 @@ Directory: ros/noetic/ubuntu/focal/perception
 
 Tags: humble-ros-core, humble-ros-core-jammy
 Architectures: amd64, arm64v8
-GitCommit: 6610eeddd6026e93db33578f6967bac23fa21ac0
+GitCommit: eb5634cf92ba079897e44fb7541d3b78aa6cf717
 Directory: ros/humble/ubuntu/jammy/ros-core
 
 Tags: humble-ros-base, humble-ros-base-jammy, humble
@@ -58,7 +58,7 @@ Directory: ros/humble/ubuntu/jammy/perception
 
 Tags: jazzy-ros-core, jazzy-ros-core-noble
 Architectures: amd64, arm64v8
-GitCommit: 6610eeddd6026e93db33578f6967bac23fa21ac0
+GitCommit: eb5634cf92ba079897e44fb7541d3b78aa6cf717
 Directory: ros/jazzy/ubuntu/noble/ros-core
 
 Tags: jazzy-ros-base, jazzy-ros-base-noble, jazzy, latest
@@ -80,7 +80,7 @@ Directory: ros/jazzy/ubuntu/noble/perception
 
 Tags: kilted-ros-core, kilted-ros-core-noble
 Architectures: amd64, arm64v8
-GitCommit: 6610eeddd6026e93db33578f6967bac23fa21ac0
+GitCommit: eb5634cf92ba079897e44fb7541d3b78aa6cf717
 Directory: ros/kilted/ubuntu/noble/ros-core
 
 Tags: kilted-ros-base, kilted-ros-base-noble, kilted
@@ -102,7 +102,7 @@ Directory: ros/kilted/ubuntu/noble/perception
 
 Tags: rolling-ros-core, rolling-ros-core-noble
 Architectures: amd64, arm64v8
-GitCommit: 6610eeddd6026e93db33578f6967bac23fa21ac0
+GitCommit: eb5634cf92ba079897e44fb7541d3b78aa6cf717
 Directory: ros/rolling/ubuntu/noble/ros-core
 
 Tags: rolling-ros-base, rolling-ros-base-noble, rolling

--- a/ros/ros
+++ b/ros/ros
@@ -9,7 +9,7 @@ GitRepo: https://github.com/osrf/docker_images.git
 
 Tags: noetic-ros-core, noetic-ros-core-focal
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 6610eeddd6026e93db33578f6967bac23fa21ac0
+GitCommit: b525e9ef659ce448db6150fd5407ef62b2c5b265
 Directory: ros/noetic/ubuntu/focal/ros-core
 
 Tags: noetic-ros-base, noetic-ros-base-focal, noetic


### PR DESCRIPTION
Using results of https://github.com/osrf/docker_templates/pull/117

Supersedes #809 used for testing the branch