### PR TITLE
Remove noetic from automated build to allow rebuilding all non EOL ROS 2 images

### DIFF
--- a/.github/workflows/ros_ci.yaml
+++ b/.github/workflows/ros_ci.yaml
@@ -10,7 +10,7 @@ on:
     - 'ros/jazzy/**'
     - 'ros/kilted/**'
     - 'ros/humble/**'
-    - 'ros/noetic/**'
+    # - 'ros/noetic/**'
   push:
     paths:
     - '.ci/**'
@@ -19,7 +19,7 @@ on:
     - 'ros/jazzy/**'
     - 'ros/kilted/**'
     - 'ros/humble/**'
-    - 'ros/noetic/**'
+    # - 'ros/noetic/**'
   schedule:
     # Trigger daily to check for upstream changes
     - cron: '0 0 * * *'
@@ -33,7 +33,7 @@ jobs:
           - {HUB_REPO: ros, HUB_RELEASE: jazzy, HUB_OS_NAME: ubuntu, HUB_OS_CODE_NAME: noble}
           - {HUB_REPO: ros, HUB_RELEASE: kilted, HUB_OS_NAME: ubuntu, HUB_OS_CODE_NAME: noble}
           - {HUB_REPO: ros, HUB_RELEASE: humble, HUB_OS_NAME: ubuntu, HUB_OS_CODE_NAME: jammy}
-          - {HUB_REPO: ros, HUB_RELEASE: noetic, HUB_OS_NAME: ubuntu, HUB_OS_CODE_NAME: focal}
+          # - {HUB_REPO: ros, HUB_RELEASE: noetic, HUB_OS_NAME: ubuntu, HUB_OS_CODE_NAME: focal}
     runs-on: ubuntu-latest
     env:
       GITHUBEMAIL: ${{ secrets.GITHUBEMAIL }}

--- a/ros/manifest.yaml
+++ b/ros/manifest.yaml
@@ -339,23 +339,24 @@ release_names:
                             - arm32v7
                             - arm64v8
                         tag_names:
-                            ros-core:
-                                aliases:
-                                    - "$release_name-ros-core"
-                                    - "$release_name-ros-core-$os_code_name"
-                            ros-base:
-                                aliases:
-                                    - "$release_name-ros-base"
-                                    - "$release_name-ros-base-$os_code_name"
-                                    - "$release_name"
-                            robot:
-                                aliases:
-                                    - "$release_name-robot"
-                                    - "$release_name-robot-$os_code_name"
-                            perception:
-                                aliases:
-                                    - "$release_name-perception"
-                                    - "$release_name-perception-$os_code_name"
+                            # TEMPORARY until snapshots.ros.org issues are resolved
+                            # ros-core:
+                            #       aliases:
+                            #           - "$release_name-ros-core"
+                            #           - "$release_name-ros-core-$os_code_name"
+                            #   ros-base:
+                            #       aliases:
+                            #           - "$release_name-ros-base"
+                            #           - "$release_name-ros-base-$os_code_name"
+                            #           - "$release_name"
+                            #   robot:
+                            #       aliases:
+                            #           - "$release_name-robot"
+                            #           - "$release_name-robot-$os_code_name"
+                            #   perception:
+                            #       aliases:
+                            #           - "$release_name-perception"
+                            #           - "$release_name-perception-$os_code_name"
             debian:
                 os_code_names:
                     buster:

--- a/ros/ros
+++ b/ros/ros
@@ -2,33 +2,6 @@ Maintainers: Tully Foote <tfoote+buildfarm@osrfoundation.org> (@tfoote)
 GitRepo: https://github.com/osrf/docker_images.git
 
 ################################################################################
-# Release: noetic
-
-########################################
-# Distro: ubuntu:focal
-
-Tags: noetic-ros-core, noetic-ros-core-focal
-Architectures: amd64, arm32v7, arm64v8
-GitCommit: b525e9ef659ce448db6150fd5407ef62b2c5b265
-Directory: ros/noetic/ubuntu/focal/ros-core
-
-Tags: noetic-ros-base, noetic-ros-base-focal, noetic
-Architectures: amd64, arm32v7, arm64v8
-GitCommit: df19ab7d5993d3b78a908362cdcd1479a8e78b35
-Directory: ros/noetic/ubuntu/focal/ros-base
-
-Tags: noetic-robot, noetic-robot-focal
-Architectures: amd64, arm32v7, arm64v8
-GitCommit: df19ab7d5993d3b78a908362cdcd1479a8e78b35
-Directory: ros/noetic/ubuntu/focal/robot
-
-Tags: noetic-perception, noetic-perception-focal
-Architectures: amd64, arm32v7, arm64v8
-GitCommit: df19ab7d5993d3b78a908362cdcd1479a8e78b35
-Directory: ros/noetic/ubuntu/focal/perception
-
-
-################################################################################
 # Release: humble
 
 ########################################


### PR DESCRIPTION
Related to https://github.com/osrf/docker_images/issues/807

Now that https://github.com/docker-library/official-images/pull/19162 has merged. The "ros" images are being rebuilt.
For the osrf/ros children images to be rebuilt and pushed we need passing CI and updated docker library.

This PR temporarily rules out noetic (that became EOL in the middle of the gpg key expiration event).

It needs to be reverted as soon as there is a working path forward to build a set of ROS Noetic images based on the snapshots repositories before disabling the build definitively