### PR TITLE
Snapshots noetic and update ROS 2 distros building noetic bridge

### DIFF
--- a/.github/workflows/ros_ci.yaml
+++ b/.github/workflows/ros_ci.yaml
@@ -10,7 +10,7 @@ on:
     - 'ros/jazzy/**'
     - 'ros/kilted/**'
     - 'ros/humble/**'
-    # - 'ros/noetic/**'
+    - 'ros/noetic/**'
   push:
     paths:
     - '.ci/**'
@@ -19,7 +19,7 @@ on:
     - 'ros/jazzy/**'
     - 'ros/kilted/**'
     - 'ros/humble/**'
-    # - 'ros/noetic/**'
+    - 'ros/noetic/**'
   schedule:
     # Trigger daily to check for upstream changes
     - cron: '0 0 * * *'
@@ -33,7 +33,7 @@ jobs:
           - {HUB_REPO: ros, HUB_RELEASE: jazzy, HUB_OS_NAME: ubuntu, HUB_OS_CODE_NAME: noble}
           - {HUB_REPO: ros, HUB_RELEASE: kilted, HUB_OS_NAME: ubuntu, HUB_OS_CODE_NAME: noble}
           - {HUB_REPO: ros, HUB_RELEASE: humble, HUB_OS_NAME: ubuntu, HUB_OS_CODE_NAME: jammy}
-          # - {HUB_REPO: ros, HUB_RELEASE: noetic, HUB_OS_NAME: ubuntu, HUB_OS_CODE_NAME: focal}
+          - {HUB_REPO: ros, HUB_RELEASE: noetic, HUB_OS_NAME: ubuntu, HUB_OS_CODE_NAME: focal}
     runs-on: ubuntu-latest
     env:
       GITHUBEMAIL: ${{ secrets.GITHUBEMAIL }}

--- a/.github/workflows/ros_ci.yaml
+++ b/.github/workflows/ros_ci.yaml
@@ -30,8 +30,8 @@ jobs:
       matrix:
         env:
           - {HUB_REPO: ros, HUB_RELEASE: rolling, HUB_OS_NAME: ubuntu, HUB_OS_CODE_NAME: noble}
-          - {HUB_REPO: ros, HUB_RELEASE: jazzy, HUB_OS_NAME: ubuntu, HUB_OS_CODE_NAME: noble}
           - {HUB_REPO: ros, HUB_RELEASE: kilted, HUB_OS_NAME: ubuntu, HUB_OS_CODE_NAME: noble}
+          - {HUB_REPO: ros, HUB_RELEASE: jazzy, HUB_OS_NAME: ubuntu, HUB_OS_CODE_NAME: noble}
           - {HUB_REPO: ros, HUB_RELEASE: humble, HUB_OS_NAME: ubuntu, HUB_OS_CODE_NAME: jammy}
           - {HUB_REPO: ros, HUB_RELEASE: noetic, HUB_OS_NAME: ubuntu, HUB_OS_CODE_NAME: focal}
     runs-on: ubuntu-latest

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -9,7 +9,7 @@ ros_buildfarm
 
 ###### Requirements with Repo Specifiers ######
 #   See https://pip.readthedocs.io/en/stable/reference/pip_install/#git
-git+https://github.com/osrf/docker_templates.git@follow-up-templates-114#egg=docker_templates
+git+https://github.com/osrf/docker_templates.git@master#egg=docker_templates
 
 ###### Requirements with Version Specifiers ######
 #   See https://www.python.org/dev/peps/pep-0440/#version-specifiers

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -9,7 +9,7 @@ ros_buildfarm
 
 ###### Requirements with Repo Specifiers ######
 #   See https://pip.readthedocs.io/en/stable/reference/pip_install/#git
-git+https://github.com/osrf/docker_templates.git@master#egg=docker_templates
+git+https://github.com/osrf/docker_templates.git@follow-up-templates-114#egg=docker_templates
 
 ###### Requirements with Version Specifiers ######
 #   See https://www.python.org/dev/peps/pep-0440/#version-specifiers

--- a/ros/foxy/ubuntu/focal/ros-core/Dockerfile
+++ b/ros/foxy/ubuntu/focal/ros-core/Dockerfile
@@ -11,21 +11,31 @@ RUN echo 'Etc/UTC' > /etc/timezone && \
 
 # install packages
 RUN apt-get update && apt-get install -q -y --no-install-recommends \
+    ca-certificates \
+    curl \
     dirmngr \
     gnupg2 \
     && rm -rf /var/lib/apt/lists/*
 
+
 # setup keys
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 4B63CF8FDE49746E98FA01DDAD19BAB3CBF125EA
+RUN set -eux; \
+       key='4B63CF8FDE49746E98FA01DDAD19BAB3CBF125EA'; \
+       export GNUPGHOME="$(mktemp -d)"; \
+       gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key"; \
+       mkdir -p /usr/share/keyrings; \
+       gpg --batch --export "$key" > /usr/share/keyrings/ros2-snapshots-archive-keyring.gpg; \
+       gpgconf --kill all; \
+       rm -rf "$GNUPGHOME"
 
 # setup sources.list
-RUN echo "deb http://snapshots.ros.org/foxy/final/ubuntu focal main" > /etc/apt/sources.list.d/ros2-snapshots.list
+RUN echo "deb [ signed-by=/usr/share/keyrings/ros2-snapshots-archive-keyring.gpg ] http://snapshots.ros.org/foxy/final/ubuntu focal main" > /etc/apt/sources.list.d/ros2-snapshots.list
 
 # setup environment
-ENV LANG C.UTF-8
-ENV LC_ALL C.UTF-8
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
 
-ENV ROS_DISTRO foxy
+ENV ROS_DISTRO=foxy
 
 # install ros2 packages
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/ros/foxy/ubuntu/focal/ros1-bridge/Dockerfile
+++ b/ros/foxy/ubuntu/focal/ros1-bridge/Dockerfile
@@ -27,9 +27,9 @@ ENV ROS2_DISTRO=foxy
 
 # install ros packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    ros-noetic-ros-comm=1.16.0-1* \
-    ros-noetic-roscpp-tutorials=0.10.2-1* \
-    ros-noetic-rospy-tutorials=0.10.2-1* \
+    ros-noetic-ros-comm=1.17.4-1* \
+    ros-noetic-roscpp-tutorials=0.10.3-1* \
+    ros-noetic-rospy-tutorials=0.10.3-1* \
     && rm -rf /var/lib/apt/lists/*
 
 # install ros2 packages

--- a/ros/foxy/ubuntu/focal/ros1-bridge/Dockerfile
+++ b/ros/foxy/ubuntu/focal/ros1-bridge/Dockerfile
@@ -2,14 +2,28 @@
 # generated from docker_images_ros2/ros1_bridge/create_ros_ros1_bridge_image.Dockerfile.em
 FROM ros:foxy-ros-base-focal
 
+# install packages
+RUN apt-get update && apt-get install -q -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+
 # setup keys
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
+RUN set -eux; \
+       key='4B63CF8FDE49746E98FA01DDAD19BAB3CBF125EA'; \
+       export GNUPGHOME="$(mktemp -d)"; \
+       gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key"; \
+       mkdir -p /usr/share/keyrings; \
+       gpg --batch --export "$key" > /usr/share/keyrings/ros1-snapshots-archive-keyring.gpg; \
+       gpgconf --kill all; \
+       rm -rf "$GNUPGHOME"
 
 # setup sources.list
-RUN echo "deb http://packages.ros.org/ros/ubuntu focal main" > /etc/apt/sources.list.d/ros1-latest.list
+RUN echo "deb [ signed-by=/usr/share/keyrings/ros1-snapshots-archive-keyring.gpg ] http://snapshots.ros.org/noetic/final/ubuntu focal main" > /etc/apt/sources.list.d/ros1-snapshots.list
 
-ENV ROS1_DISTRO noetic
-ENV ROS2_DISTRO foxy
+ENV ROS1_DISTRO=noetic
+ENV ROS2_DISTRO=foxy
 
 # install ros packages
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/ros/galactic/ubuntu/focal/platform.yaml
+++ b/ros/galactic/ubuntu/focal/platform.yaml
@@ -11,4 +11,3 @@ platform:
     arch: amd64
     type: distribution
     version:
-    ros_version: 2

--- a/ros/galactic/ubuntu/focal/ros-core/Dockerfile
+++ b/ros/galactic/ubuntu/focal/ros-core/Dockerfile
@@ -11,21 +11,31 @@ RUN echo 'Etc/UTC' > /etc/timezone && \
 
 # install packages
 RUN apt-get update && apt-get install -q -y --no-install-recommends \
+    ca-certificates \
+    curl \
     dirmngr \
     gnupg2 \
     && rm -rf /var/lib/apt/lists/*
 
+
 # setup keys
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 4B63CF8FDE49746E98FA01DDAD19BAB3CBF125EA
+RUN set -eux; \
+       key='4B63CF8FDE49746E98FA01DDAD19BAB3CBF125EA'; \
+       export GNUPGHOME="$(mktemp -d)"; \
+       gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key"; \
+       mkdir -p /usr/share/keyrings; \
+       gpg --batch --export "$key" > /usr/share/keyrings/ros2-snapshots-archive-keyring.gpg; \
+       gpgconf --kill all; \
+       rm -rf "$GNUPGHOME"
 
 # setup sources.list
-RUN echo "deb http://snapshots.ros.org/galactic/final/ubuntu focal main" > /etc/apt/sources.list.d/ros2-snapshots.list
+RUN echo "deb [ signed-by=/usr/share/keyrings/ros2-snapshots-archive-keyring.gpg ] http://snapshots.ros.org/galactic/final/ubuntu focal main" > /etc/apt/sources.list.d/ros2-snapshots.list
 
 # setup environment
-ENV LANG C.UTF-8
-ENV LC_ALL C.UTF-8
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
 
-ENV ROS_DISTRO galactic
+ENV ROS_DISTRO=galactic
 
 # install ros2 packages
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/ros/galactic/ubuntu/focal/ros1-bridge/Dockerfile
+++ b/ros/galactic/ubuntu/focal/ros1-bridge/Dockerfile
@@ -27,9 +27,9 @@ ENV ROS2_DISTRO=galactic
 
 # install ros packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    ros-noetic-ros-comm=1.16.0-1* \
-    ros-noetic-roscpp-tutorials=0.10.2-1* \
-    ros-noetic-rospy-tutorials=0.10.2-1* \
+    ros-noetic-ros-comm=1.17.4-1* \
+    ros-noetic-roscpp-tutorials=0.10.3-1* \
+    ros-noetic-rospy-tutorials=0.10.3-1* \
     && rm -rf /var/lib/apt/lists/*
 
 # install ros2 packages

--- a/ros/galactic/ubuntu/focal/ros1-bridge/Dockerfile
+++ b/ros/galactic/ubuntu/focal/ros1-bridge/Dockerfile
@@ -2,14 +2,28 @@
 # generated from docker_images_ros2/ros1_bridge/create_ros_ros1_bridge_image.Dockerfile.em
 FROM ros:galactic-ros-base-focal
 
+# install packages
+RUN apt-get update && apt-get install -q -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+
 # setup keys
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
+RUN set -eux; \
+       key='4B63CF8FDE49746E98FA01DDAD19BAB3CBF125EA'; \
+       export GNUPGHOME="$(mktemp -d)"; \
+       gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key"; \
+       mkdir -p /usr/share/keyrings; \
+       gpg --batch --export "$key" > /usr/share/keyrings/ros1-snapshots-archive-keyring.gpg; \
+       gpgconf --kill all; \
+       rm -rf "$GNUPGHOME"
 
 # setup sources.list
-RUN echo "deb http://packages.ros.org/ros/ubuntu focal main" > /etc/apt/sources.list.d/ros1-latest.list
+RUN echo "deb [ signed-by=/usr/share/keyrings/ros1-snapshots-archive-keyring.gpg ] http://snapshots.ros.org/noetic/final/ubuntu focal main" > /etc/apt/sources.list.d/ros1-snapshots.list
 
-ENV ROS1_DISTRO noetic
-ENV ROS2_DISTRO galactic
+ENV ROS1_DISTRO=noetic
+ENV ROS2_DISTRO=galactic
 
 # install ros packages
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/ros/manifest.yaml
+++ b/ros/manifest.yaml
@@ -340,23 +340,23 @@ release_names:
                             - arm64v8
                         tag_names:
                             # TEMPORARY until snapshots.ros.org issues are resolved
-                            # ros-core:
-                            #       aliases:
-                            #           - "$release_name-ros-core"
-                            #           - "$release_name-ros-core-$os_code_name"
-                            #   ros-base:
-                            #       aliases:
-                            #           - "$release_name-ros-base"
-                            #           - "$release_name-ros-base-$os_code_name"
-                            #           - "$release_name"
-                            #   robot:
-                            #       aliases:
-                            #           - "$release_name-robot"
-                            #           - "$release_name-robot-$os_code_name"
-                            #   perception:
-                            #       aliases:
-                            #           - "$release_name-perception"
-                            #           - "$release_name-perception-$os_code_name"
+                            ros-core:
+                                aliases:
+                                    - "$release_name-ros-core"
+                                    - "$release_name-ros-core-$os_code_name"
+                            ros-base:
+                                aliases:
+                                    - "$release_name-ros-base"
+                                    - "$release_name-ros-base-$os_code_name"
+                                    - "$release_name"
+                            robot:
+                                aliases:
+                                    - "$release_name-robot"
+                                    - "$release_name-robot-$os_code_name"
+                            perception:
+                                aliases:
+                                    - "$release_name-perception"
+                                    - "$release_name-perception-$os_code_name"
             debian:
                 os_code_names:
                     buster:
@@ -511,19 +511,19 @@ release_names:
                             - arm64v8
                         tag_names:
                             # EOL
-                            # ros-core:
-                            #     aliases:
-                            #         - "$release_name-ros-core"
-                            #         - "$release_name-ros-core-$os_code_name"
-                            # ros-base:
-                            #     aliases:
-                            #         - "$release_name-ros-base"
-                            #         - "$release_name-ros-base-$os_code_name"
-                            #         - "$release_name"
-                            # ros1-bridge:
-                            #     aliases:
-                            #         - "$release_name-ros1-bridge"
-                            #         - "$release_name-ros1-bridge-$os_code_name"
+                            ros-core:
+                                aliases:
+                                    - "$release_name-ros-core"
+                                    - "$release_name-ros-core-$os_code_name"
+                            ros-base:
+                                aliases:
+                                    - "$release_name-ros-base"
+                                    - "$release_name-ros-base-$os_code_name"
+                                    - "$release_name"
+                            ros1-bridge:
+                                aliases:
+                                    - "$release_name-ros1-bridge"
+                                    - "$release_name-ros1-bridge-$os_code_name"
     galactic:
         eol: 2022-11
         os_names:
@@ -537,19 +537,19 @@ release_names:
                             - arm64v8
                         tag_names:
                             # EOL
-                            # ros-core:
-                            #     aliases:
-                            #         - "$release_name-ros-core"
-                            #         - "$release_name-ros-core-$os_code_name"
-                            # ros-base:
-                            #     aliases:
-                            #         - "$release_name-ros-base"
-                            #         - "$release_name-ros-base-$os_code_name"
-                            #         - "$release_name"
-                            # ros1-bridge:
-                            #     aliases:
-                            #         - "$release_name-ros1-bridge"
-                            #         - "$release_name-ros1-bridge-$os_code_name"
+                            ros-core:
+                                aliases:
+                                    - "$release_name-ros-core"
+                                    - "$release_name-ros-core-$os_code_name"
+                            ros-base:
+                                aliases:
+                                    - "$release_name-ros-base"
+                                    - "$release_name-ros-base-$os_code_name"
+                                    - "$release_name"
+                            ros1-bridge:
+                                aliases:
+                                    - "$release_name-ros1-bridge"
+                                    - "$release_name-ros1-bridge-$os_code_name"
     humble:
         eol: 2025-05
         os_names:

--- a/ros/noetic/ubuntu/focal/ros-core/Dockerfile
+++ b/ros/noetic/ubuntu/focal/ros-core/Dockerfile
@@ -18,13 +18,18 @@ RUN apt-get update && apt-get install -q -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 
-# NOTE: this doesnt deal with snapshots repo as not clear what to install for those..
-# NOTE: How do we break cache and ensure rebuild if that version changes ?
-RUN export ROS_APT_SOURCE_VERSION=$(curl -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | grep -F "tag_name" | awk -F\" '{print $4}') ;\
-    curl -L -s -o /tmp/ros-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros-apt-source_${ROS_APT_SOURCE_VERSION}.$(. /etc/os-release && echo $VERSION_CODENAME)_all.deb" \
-    && apt-get update \
-    && apt-get install /tmp/ros-apt-source.deb \
-    && rm -f /tmp/ros-apt-source.deb
+# setup keys
+RUN set -eux; \
+       key='4B63CF8FDE49746E98FA01DDAD19BAB3CBF125EA'; \
+       export GNUPGHOME="$(mktemp -d)"; \
+       gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key"; \
+       mkdir -p /usr/share/keyrings; \
+       gpg --batch --export "$key" > /usr/share/keyrings/ros1-snapshots-archive-keyring.gpg; \
+       gpgconf --kill all; \
+       rm -rf "$GNUPGHOME"
+
+# setup sources.list
+RUN echo "deb [ signed-by=/usr/share/keyrings/ros1-snapshots-archive-keyring.gpg ] http://snapshots.ros.org/noetic/final/ubuntu focal main" > /etc/apt/sources.list.d/ros1-snapshots.list
 
 # setup environment
 ENV LANG=C.UTF-8

--- a/ros/ros
+++ b/ros/ros
@@ -2,6 +2,77 @@ Maintainers: Tully Foote <tfoote+buildfarm@osrfoundation.org> (@tfoote)
 GitRepo: https://github.com/osrf/docker_images.git
 
 ################################################################################
+# Release: noetic
+
+########################################
+# Distro: ubuntu:focal
+
+Tags: noetic-ros-core, noetic-ros-core-focal
+Architectures: amd64, arm32v7, arm64v8
+GitCommit: f1d91dccd2aa75a52d7beffd93196455043e695c
+Directory: ros/noetic/ubuntu/focal/ros-core
+
+Tags: noetic-ros-base, noetic-ros-base-focal, noetic
+Architectures: amd64, arm32v7, arm64v8
+GitCommit: df19ab7d5993d3b78a908362cdcd1479a8e78b35
+Directory: ros/noetic/ubuntu/focal/ros-base
+
+Tags: noetic-robot, noetic-robot-focal
+Architectures: amd64, arm32v7, arm64v8
+GitCommit: df19ab7d5993d3b78a908362cdcd1479a8e78b35
+Directory: ros/noetic/ubuntu/focal/robot
+
+Tags: noetic-perception, noetic-perception-focal
+Architectures: amd64, arm32v7, arm64v8
+GitCommit: df19ab7d5993d3b78a908362cdcd1479a8e78b35
+Directory: ros/noetic/ubuntu/focal/perception
+
+
+################################################################################
+# Release: foxy
+
+########################################
+# Distro: ubuntu:focal
+
+Tags: foxy-ros-core, foxy-ros-core-focal
+Architectures: amd64, arm64v8
+GitCommit: f1d91dccd2aa75a52d7beffd93196455043e695c
+Directory: ros/foxy/ubuntu/focal/ros-core
+
+Tags: foxy-ros-base, foxy-ros-base-focal, foxy
+Architectures: amd64, arm64v8
+GitCommit: df19ab7d5993d3b78a908362cdcd1479a8e78b35
+Directory: ros/foxy/ubuntu/focal/ros-base
+
+Tags: foxy-ros1-bridge, foxy-ros1-bridge-focal
+Architectures: amd64, arm64v8
+GitCommit: 40cfb45357e267ea9aeb714e9b556ae77c859e76
+Directory: ros/foxy/ubuntu/focal/ros1-bridge
+
+
+################################################################################
+# Release: galactic
+
+########################################
+# Distro: ubuntu:focal
+
+Tags: galactic-ros-core, galactic-ros-core-focal
+Architectures: amd64, arm64v8
+GitCommit: f1d91dccd2aa75a52d7beffd93196455043e695c
+Directory: ros/galactic/ubuntu/focal/ros-core
+
+Tags: galactic-ros-base, galactic-ros-base-focal, galactic
+Architectures: amd64, arm64v8
+GitCommit: 6511d8fc0754616550b7f5ea31a40084c2462938
+Directory: ros/galactic/ubuntu/focal/ros-base
+
+Tags: galactic-ros1-bridge, galactic-ros1-bridge-focal
+Architectures: amd64, arm64v8
+GitCommit: 40cfb45357e267ea9aeb714e9b556ae77c859e76
+Directory: ros/galactic/ubuntu/focal/ros1-bridge
+
+
+################################################################################
 # Release: humble
 
 ########################################


### PR DESCRIPTION
This is generated from https://github.com/osrf/docker_templates/pull/116

Now that the noetic final snapshot is available we can move ros noetic images to target the snapshot repository: https://github.com/osrf/docker_images/issues/814

This will fix currently broken ROS Noetic docker images