### PR TITLE
Fix ros2/nightly images

### DIFF
--- a/ros2/nightly/nightly-rmw-nonfree/Dockerfile
+++ b/ros2/nightly/nightly-rmw-nonfree/Dockerfile
@@ -12,6 +12,6 @@ RUN apt-get update && rosdep install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # set up environment
-ENV NDDSHOME /opt/rti.com/rti_connext_dds-7.3.0
-ENV PATH "$NDDSHOME/bin":$PATH
-ENV LD_LIBRARY_PATH "$NDDSHOME/lib/x64Linux4gcc7.3.0":$LD_LIBRARY_PATH
+ENV NDDSHOME=/opt/rti.com/rti_connext_dds-7.3.0
+ENV PATH="$NDDSHOME/bin":$PATH
+ENV LD_LIBRARY_PATH="$NDDSHOME/lib/x64Linux4gcc7.3.0":$LD_LIBRARY_PATH

--- a/ros2/nightly/nightly-rmw-nonfree/Dockerfile
+++ b/ros2/nightly/nightly-rmw-nonfree/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update && rosdep install -y \
     --from-paths /opt/ros/$ROS_DISTRO/share \
     --ignore-src \
     --skip-keys " \
+      fastdds \
       " \
     && rm -rf /var/lib/apt/lists/*
 

--- a/ros2/nightly/nightly-rmw-nonfree/Dockerfile
+++ b/ros2/nightly/nightly-rmw-nonfree/Dockerfile
@@ -12,6 +12,6 @@ RUN apt-get update && rosdep install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # set up environment
-ENV NDDSHOME /opt/rti.com/rti_connext_dds-6.0.1
+ENV NDDSHOME /opt/rti.com/rti_connext_dds-7.3.0
 ENV PATH "$NDDSHOME/bin":$PATH
 ENV LD_LIBRARY_PATH "$NDDSHOME/lib/x64Linux4gcc7.3.0":$LD_LIBRARY_PATH

--- a/ros2/nightly/nightly-rmw/Dockerfile
+++ b/ros2/nightly/nightly-rmw/Dockerfile
@@ -6,5 +6,7 @@ RUN apt-get update && rosdep install -y \
     --from-paths /opt/ros/$ROS_DISTRO/share \
     --ignore-src \
     --skip-keys " \
-      rti-connext-dds-6.0.1" \
+      fastdds \
+      rti-connext-dds-7.3.0 \
+      " \
     && rm -rf /var/lib/apt/lists/*

--- a/ros2/nightly/nightly/Dockerfile
+++ b/ros2/nightly/nightly/Dockerfile
@@ -122,7 +122,9 @@ RUN apt-get update && rosdep update && rosdep install -y \
     --ignore-src \
     --skip-keys " \
       cyclonedds \
-      rti-connext-dds-6.0.1" \
+      fastdds \
+      rti-connext-dds-7.3.0 \
+      " \
     && rm -rf /var/lib/apt/lists/*
 
 # install nightly

--- a/ros2/nightly/nightly/Dockerfile
+++ b/ros2/nightly/nightly/Dockerfile
@@ -1,5 +1,5 @@
 # multi-stage for setup
-FROM ubuntu:noble-20241015 AS setuper
+FROM ubuntu:noble-20250714 AS setuper
 ARG DEBIAN_FRONTEND=noninteractive
 
 # setup timezone

--- a/ros2/nightly/nightly/Dockerfile
+++ b/ros2/nightly/nightly/Dockerfile
@@ -1,5 +1,5 @@
 # multi-stage for setup
-FROM ubuntu:noble-20241015 as setuper
+FROM ubuntu:noble-20241015 AS setuper
 ARG DEBIAN_FRONTEND=noninteractive
 
 # setup timezone
@@ -61,10 +61,10 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     && rm -rf /var/lib/apt/lists/*
 
 # setup environment
-ENV ROS_DISTRO rolling
-ENV LANG C.UTF-8
-ENV LC_ALL C.UTF-8
-ENV ROSDISTRO_INDEX_URL https://raw.githubusercontent.com/osrf/docker_images/master/ros2/nightly/nightly/index-v4.yaml
+ENV ROS_DISTRO=rolling
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
+ENV ROSDISTRO_INDEX_URL=https://raw.githubusercontent.com/osrf/docker_images/master/ros2/nightly/nightly/index-v4.yaml
 
 # This is a workaround for pytest not found causing builds to fail
 # Following RUN statements tests for regression of https://github.com/ros2/ros2/issues/722


### PR DESCRIPTION
Since 24 January 2025 (https://github.com/osrf/docker_images/actions/runs/12944907207) the ROS 2 nightly image doesnt build because the nightly archive doesnt provide a package.xml for fastdds.


This PR does the following:
- ignore fastdds for rosdep install calls in all nightly images
- update the RTI Connext version for rosdep keys and env var paths
- fix docker linter violations regarding casing and ENV/ARG usage