### PR TITLE
Lyrical testing docker images

### DIFF
--- a/ros/lyrical/ubuntu/resolute/Makefile
+++ b/ros/lyrical/ubuntu/resolute/Makefile
@@ -1,0 +1,78 @@
+all: help
+
+help:
+	@echo ""
+	@echo "-- Help Menu"
+	@echo ""
+	@echo "   1. make build            - build all images"
+	@echo "   2. make pull             - pull all images"
+	@echo "   3. make clean            - remove all images"
+	@echo ""
+
+build:
+	@docker build --tag=ros:lyrical-ros-core-resolute			ros-core/.
+	@docker build --tag=ros:lyrical-ros-base-resolute			ros-base/.
+	@docker build --tag=ros:lyrical-perception-resolute			perception/.
+	# @docker build --tag=osrf/ros:lyrical-simulation-resolute			simulation/.
+	# @docker build --tag=osrf/ros:lyrical-desktop-resolute			desktop/.
+	# @docker build --tag=osrf/ros:lyrical-desktop-full-resolute			desktop-full/.
+
+pull:
+	@docker pull ros:lyrical-ros-core-resolute
+	@docker pull ros:lyrical-ros-base-resolute
+	@docker pull ros:lyrical-perception-resolute
+	# @docker pull osrf/ros:lyrical-simulation-resolute
+	# @docker pull osrf/ros:lyrical-desktop-resolute
+	# @docker pull osrf/ros:lyrical-desktop-full-resolute
+
+clean:
+	@docker rmi -f ros:lyrical-ros-core-resolute
+	@docker rmi -f ros:lyrical-ros-base-resolute
+	@docker rmi -f ros:lyrical-perception-resolute
+	# @docker rmi -f osrf/ros:lyrical-simulation-resolute
+	# @docker rmi -f osrf/ros:lyrical-desktop-resolute
+	# @docker rmi -f osrf/ros:lyrical-desktop-full-resolute
+
+ci_buildx:
+	@docker buildx build --pull --push \
+		--cache-from=type=registry,ref=osrf/ros:lyrical-desktop-resolute \
+		--cache-to=type=inline \
+		--tag=osrf/ros:lyrical-desktop-resolute \
+		desktop/.
+	@if [ "ubuntu" = "ubuntu" ]; then \
+		docker pull \
+			osrf/ros:lyrical-desktop-resolute; \
+    	docker tag \
+			osrf/ros:lyrical-desktop-resolute \
+			osrf/ros:lyrical-desktop; \
+		docker push \
+			osrf/ros:lyrical-desktop; \
+	fi
+	@docker buildx build --pull --push \
+		--cache-from=type=registry,ref=osrf/ros:lyrical-simulation-resolute \
+		--cache-to=type=inline \
+		--tag=osrf/ros:lyrical-simulation-resolute \
+		simulation/.
+	@if [ "ubuntu" = "ubuntu" ]; then \
+		docker pull \
+			osrf/ros:lyrical-simulation-resolute; \
+		docker tag \
+			osrf/ros:lyrical-simulation-resolute \
+			osrf/ros:lyrical-simulation; \
+		docker push \
+			osrf/ros:lyrical-simulation; \
+	fi
+	@docker buildx build --pull --push \
+		--cache-from=type=registry,ref=osrf/ros:lyrical-desktop-full-resolute \
+		--cache-to=type=inline \
+		--tag=osrf/ros:lyrical-desktop-full-resolute \
+		desktop-full/.
+	@if [ "ubuntu" = "ubuntu" ]; then \
+		docker pull \
+			osrf/ros:lyrical-desktop-full-resolute; \
+		docker tag \
+			osrf/ros:lyrical-desktop-full-resolute \
+			osrf/ros:lyrical-desktop-full; \
+		docker push \
+			osrf/ros:lyrical-desktop-full; \
+	fi

--- a/ros/lyrical/ubuntu/resolute/desktop-full/Dockerfile
+++ b/ros/lyrical/ubuntu/resolute/desktop-full/Dockerfile
@@ -1,0 +1,9 @@
+# This is an auto generated Dockerfile for ros:desktop-full
+# generated from docker_images_ros2/create_ros_image.Dockerfile.em
+FROM osrf/ros:lyrical-desktop-resolute
+
+# install ros2 packages
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ros-lyrical-desktop-full=0.13.0-3* \
+    && rm -rf /var/lib/apt/lists/*
+

--- a/ros/lyrical/ubuntu/resolute/desktop/Dockerfile
+++ b/ros/lyrical/ubuntu/resolute/desktop/Dockerfile
@@ -1,0 +1,9 @@
+# This is an auto generated Dockerfile for ros:desktop
+# generated from docker_images_ros2/create_ros_image.Dockerfile.em
+FROM ros:lyrical-ros-base-resolute
+
+# install ros2 packages
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ros-lyrical-desktop=0.13.0-3* \
+    && rm -rf /var/lib/apt/lists/*
+

--- a/ros/lyrical/ubuntu/resolute/images.yaml.em
+++ b/ros/lyrical/ubuntu/resolute/images.yaml.em
@@ -1,0 +1,54 @@
+%YAML 1.1
+# ROS2 Dockerfile database
+---
+images:
+    ros-core:
+        base_image: @(os_name):@(os_code_name)
+        maintainer_name: @(maintainer_name)
+        template_name: docker_images_ros2/create_ros_core_image.Dockerfile.em
+        entrypoint_name: docker_images_ros2/ros_entrypoint.sh
+        template_packages:
+            - docker_templates
+        ros2_packages:
+            - ros-core
+    ros-base:
+        base_image: @(user_name):@(ros2distro_name)-ros-core-@(os_code_name)
+        maintainer_name: @(maintainer_name)
+        template_name: docker_images_ros2/create_ros_image.Dockerfile.em
+        template_packages:
+            - docker_templates
+        ros2_packages:
+            - ros-base
+        bootstrap_ros_tools:
+    perception:
+        base_image: @(user_name):@(ros2distro_name)-ros-base-@(os_code_name)
+        maintainer_name: @(maintainer_name)
+        template_name: docker_images_ros2/create_ros_image.Dockerfile.em
+        template_packages:
+            - docker_templates
+        ros2_packages:
+            - perception
+    simulation:
+        base_image: @(user_name):@(ros2distro_name)-ros-base-@(os_code_name)
+        maintainer_name: @(maintainer_name)
+        template_name: docker_images_ros2/create_ros_image.Dockerfile.em
+        template_packages:
+            - docker_templates
+        ros2_packages:
+            - simulation
+    desktop:
+        base_image: @(user_name):@(ros2distro_name)-ros-base-@(os_code_name)
+        maintainer_name: @(maintainer_name)
+        template_name: docker_images_ros2/create_ros_image.Dockerfile.em
+        template_packages:
+            - docker_templates
+        ros2_packages:
+            - desktop
+    desktop-full:
+        base_image: osrf/@(user_name):@(ros2distro_name)-desktop-@(os_code_name)
+        maintainer_name: @(maintainer_name)
+        template_name: docker_images_ros2/create_ros_image.Dockerfile.em
+        template_packages:
+            - docker_templates
+        ros2_packages:
+            - desktop-full

--- a/ros/lyrical/ubuntu/resolute/perception/Dockerfile
+++ b/ros/lyrical/ubuntu/resolute/perception/Dockerfile
@@ -1,0 +1,9 @@
+# This is an auto generated Dockerfile for ros:perception
+# generated from docker_images_ros2/create_ros_image.Dockerfile.em
+FROM ros:lyrical-ros-base-resolute
+
+# install ros2 packages
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ros-lyrical-perception=0.13.0-3* \
+    && rm -rf /var/lib/apt/lists/*
+

--- a/ros/lyrical/ubuntu/resolute/platform.yaml
+++ b/ros/lyrical/ubuntu/resolute/platform.yaml
@@ -1,0 +1,13 @@
+%YAML 1.1
+# ROS2 Dockerfile database
+---
+platform:
+    os_name: ubuntu
+    os_code_name: resolute
+    ros2distro_name: lyrical
+    user_name: ros
+    maintainer_name:
+    testing_repo: true
+    arch: amd64
+    type: distribution
+    version:

--- a/ros/lyrical/ubuntu/resolute/ros-base/Dockerfile
+++ b/ros/lyrical/ubuntu/resolute/ros-base/Dockerfile
@@ -1,0 +1,31 @@
+# This is an auto generated Dockerfile for ros:ros-base
+# generated from docker_images_ros2/create_ros_image.Dockerfile.em
+FROM ros:lyrical-ros-core-resolute
+
+# install bootstrap tools
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    build-essential \
+    git \
+    python3-colcon-common-extensions \
+    python3-colcon-mixin \
+    python3-rosdep \
+    python3-vcstool \
+    && rm -rf /var/lib/apt/lists/*
+
+# bootstrap rosdep
+RUN rosdep init && \
+  rosdep update --rosdistro $ROS_DISTRO
+
+# setup colcon mixin and metadata
+RUN colcon mixin add default \
+      https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml && \
+    colcon mixin update && \
+    colcon metadata add default \
+      https://raw.githubusercontent.com/colcon/colcon-metadata-repository/master/index.yaml && \
+    colcon metadata update
+
+# install ros2 packages
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ros-lyrical-ros-base=0.13.0-3* \
+    && rm -rf /var/lib/apt/lists/*
+

--- a/ros/lyrical/ubuntu/resolute/ros-core/Dockerfile
+++ b/ros/lyrical/ubuntu/resolute/ros-core/Dockerfile
@@ -1,0 +1,44 @@
+# This is an auto generated Dockerfile for ros:ros-core
+# generated from docker_images_ros2/create_ros_core_image.Dockerfile.em
+FROM ubuntu:resolute
+
+# setup timezone
+RUN echo 'Etc/UTC' > /etc/timezone && \
+    ln -s /usr/share/zoneinfo/Etc/UTC /etc/localtime && \
+    apt-get update && \
+    apt-get install -q -y --no-install-recommends tzdata && \
+    rm -rf /var/lib/apt/lists/*
+
+# install packages
+RUN apt-get update && apt-get install -q -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    dirmngr \
+    gnupg2 \
+    && rm -rf /var/lib/apt/lists/*
+
+
+# Setup ROS Apt sources
+RUN curl -L -s -o /tmp/ros2-testing-apt-source.deb https://github.com/ros-infrastructure/ros-apt-source/releases/download/1.2.0/ros2-testing-apt-source_1.2.0.resolute_all.deb \
+    && echo "da9261ca7c06244da1528e0ede44018f7bb2e24a8a077eb0202f70706b578546 /tmp/ros2-testing-apt-source.deb" | sha256sum --strict --check \
+    && apt-get update \
+    && apt-get install /tmp/ros2-testing-apt-source.deb \
+    && rm -f /tmp/ros2-testing-apt-source.deb \
+    && rm -rf /var/lib/apt/lists/*
+
+# setup environment
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
+
+ENV ROS_DISTRO=lyrical
+
+# install ros2 packages
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ros-lyrical-ros-core=0.13.0-3* \
+    && rm -rf /var/lib/apt/lists/*
+
+# setup entrypoint
+COPY ./ros_entrypoint.sh /
+
+ENTRYPOINT ["/ros_entrypoint.sh"]
+CMD ["bash"]

--- a/ros/lyrical/ubuntu/resolute/ros-core/ros_entrypoint.sh
+++ b/ros/lyrical/ubuntu/resolute/ros-core/ros_entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+# setup ros2 environment
+source "/opt/ros/$ROS_DISTRO/setup.bash" --
+exec "$@"

--- a/ros/lyrical/ubuntu/resolute/simulation/Dockerfile
+++ b/ros/lyrical/ubuntu/resolute/simulation/Dockerfile
@@ -1,0 +1,9 @@
+# This is an auto generated Dockerfile for ros:simulation
+# generated from docker_images_ros2/create_ros_image.Dockerfile.em
+FROM ros:lyrical-ros-base-resolute
+
+# install ros2 packages
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ros-lyrical-simulation=0.13.0-3* \
+    && rm -rf /var/lib/apt/lists/*
+

--- a/ros/manifest.yaml
+++ b/ros/manifest.yaml
@@ -648,6 +648,30 @@ release_names:
                                 aliases:
                                     - "$release_name-perception"
                                     - "$release_name-perception-$os_code_name"
+    lyrical:
+        eol: 2031-05
+        os_names:
+            ubuntu:
+                os_code_names:
+                    resolute:
+                        <<: *DEFAULT_ROS2
+                        archs:
+                            - amd64
+                            - arm64v8
+                        tag_names:
+                            ros-core:
+                                aliases:
+                                    - "$release_name-ros-core"
+                                    - "$release_name-ros-core-$os_code_name"
+                            ros-base:
+                                aliases:
+                                    - "$release_name-ros-base"
+                                    - "$release_name-ros-base-$os_code_name"
+                                    - "$release_name"
+                            perception:
+                                aliases:
+                                    - "$release_name-perception"
+                                    - "$release_name-perception-$os_code_name"
     rolling:
         eol: 2022-05
         os_names:

--- a/ros/ros
+++ b/ros/ros
@@ -68,6 +68,28 @@ Directory: ros/kilted/ubuntu/noble/perception
 
 
 ################################################################################
+# Release: lyrical
+
+########################################
+# Distro: ubuntu:resolute
+
+Tags: lyrical-ros-core, lyrical-ros-core-resolute
+Architectures: amd64, arm64v8
+GitCommit: 0d65786f3d9bb10d55dc28ccd5b87da204240d1a
+Directory: ros/lyrical/ubuntu/resolute/ros-core
+
+Tags: lyrical-ros-base, lyrical-ros-base-resolute, lyrical
+Architectures: amd64, arm64v8
+GitCommit: 0d65786f3d9bb10d55dc28ccd5b87da204240d1a
+Directory: ros/lyrical/ubuntu/resolute/ros-base
+
+Tags: lyrical-perception, lyrical-perception-resolute
+Architectures: amd64, arm64v8
+GitCommit: 0d65786f3d9bb10d55dc28ccd5b87da204240d1a
+Directory: ros/lyrical/ubuntu/resolute/perception
+
+
+################################################################################
 # Release: rolling
 
 ########################################


### PR DESCRIPTION
Using templates from https://github.com/osrf/docker_templates/pull/119

Same strategy as for Jazzy (https://github.com/osrf/docker_images/pull/741) :
- Provide Lyrical docker images for the testing phase before official release
- Publish these images (based on the testing apt repo) to dockerhub
- not add them to CI
- not move the latest tag

At official Lyrical releaste time:
- regenerate the images pointing to the right repo
- move the latest tag
- submit to dockerhub for rebuild
- enable CI

Alternative to https://github.com/osrf/docker_images/pull/876

Main differences:
- Do not mix rolling and lyrical changes
- Do not enable CI
- Do not move the latest tag
