### PR TITLE
Disable rolling until migration to resolute complete

### DIFF
--- a/.github/workflows/ros_ci.yaml
+++ b/.github/workflows/ros_ci.yaml
@@ -6,7 +6,7 @@ on:
     paths:
     - '.ci/**'
     - '.github/workflows/ros_ci.yaml'
-    - 'ros/rolling/**'
+    # - 'ros/rolling/**'
     - 'ros/kilted/**'
     - 'ros/jazzy/**'
     - 'ros/humble/**'
@@ -14,7 +14,7 @@ on:
     paths:
     - '.ci/**'
     - '.github/workflows/ros_ci.yaml'
-    - 'ros/rolling/**'
+    # - 'ros/rolling/**'
     - 'ros/kilted/**'
     - 'ros/jazzy/**'
     - 'ros/humble/**'
@@ -27,7 +27,7 @@ jobs:
       fail-fast: false
       matrix:
         env:
-          - {HUB_REPO: ros, HUB_RELEASE: rolling, HUB_OS_NAME: ubuntu, HUB_OS_CODE_NAME: noble}
+          # - {HUB_REPO: ros, HUB_RELEASE: rolling, HUB_OS_NAME: ubuntu, HUB_OS_CODE_NAME: noble}
           - {HUB_REPO: ros, HUB_RELEASE: kilted, HUB_OS_NAME: ubuntu, HUB_OS_CODE_NAME: noble}
           - {HUB_REPO: ros, HUB_RELEASE: jazzy, HUB_OS_NAME: ubuntu, HUB_OS_CODE_NAME: noble}
           - {HUB_REPO: ros, HUB_RELEASE: humble, HUB_OS_NAME: ubuntu, HUB_OS_CODE_NAME: jammy}

--- a/ros/manifest.yaml
+++ b/ros/manifest.yaml
@@ -672,30 +672,31 @@ release_names:
                                 aliases:
                                     - "$release_name-perception"
                                     - "$release_name-perception-$os_code_name"
-    rolling:
-        eol: 2022-05
-        os_names:
-            ubuntu:
-                os_code_names:
-                    noble:
-                        <<: *DEFAULT_ROS2
-                        archs:
-                            - amd64
-                            - arm64v8
-                        tag_names:
-                            ros-core:
-                                aliases:
-                                    - "$release_name-ros-core"
-                                    - "$release_name-ros-core-$os_code_name"
-                            ros-base:
-                                aliases:
-                                    - "$release_name-ros-base"
-                                    - "$release_name-ros-base-$os_code_name"
-                                    - "$release_name"
-                            perception:
-                                aliases:
-                                    - "$release_name-perception"
-                                    - "$release_name-perception-$os_code_name"
+    # FIXME Disable rolling currently broken
+    # rolling:
+    #     eol: 2022-05
+    #     os_names:
+    #         ubuntu:
+    #             os_code_names:
+    #                 noble:
+    #                     <<: *DEFAULT_ROS2
+    #                     archs:
+    #                         - amd64
+    #                         - arm64v8
+    #                     tag_names:
+    #                         ros-core:
+    #                             aliases:
+    #                                 - "$release_name-ros-core"
+    #                                 - "$release_name-ros-core-$os_code_name"
+    #                         ros-base:
+    #                             aliases:
+    #                                 - "$release_name-ros-base"
+    #                                 - "$release_name-ros-base-$os_code_name"
+    #                                 - "$release_name"
+    #                         perception:
+    #                             aliases:
+    #                                 - "$release_name-perception"
+    #                                 - "$release_name-perception-$os_code_name"
 meta:
     maintainers:
         - Tully Foote <tfoote+buildfarm@osrfoundation.org> (@tfoote)

--- a/ros/ros
+++ b/ros/ros
@@ -97,7 +97,7 @@ Directory: ros/lyrical/ubuntu/resolute/perception
 
 Tags: rolling-ros-core, rolling-ros-core-noble
 Architectures: amd64, arm64v8
-GitCommit: fd0c0c943e25f48fe199593597ea21d3f3f5935d
+GitCommit: 8cf2903c0f8813aacd3042c71d4d2d56d5068ad5
 Directory: ros/rolling/ubuntu/noble/ros-core
 
 Tags: rolling-ros-base, rolling-ros-base-noble, rolling

--- a/ros/ros
+++ b/ros/ros
@@ -9,7 +9,7 @@ GitRepo: https://github.com/osrf/docker_images.git
 
 Tags: humble-ros-core, humble-ros-core-jammy
 Architectures: amd64, arm64v8
-GitCommit: eb5634cf92ba079897e44fb7541d3b78aa6cf717
+GitCommit: 6baec8a7ddecbfeb424ab8e9f8f81a5bce82ba4d
 Directory: ros/humble/ubuntu/jammy/ros-core
 
 Tags: humble-ros-base, humble-ros-base-jammy, humble
@@ -31,7 +31,7 @@ Directory: ros/humble/ubuntu/jammy/perception
 
 Tags: jazzy-ros-core, jazzy-ros-core-noble
 Architectures: amd64, arm64v8
-GitCommit: eb5634cf92ba079897e44fb7541d3b78aa6cf717
+GitCommit: fd0c0c943e25f48fe199593597ea21d3f3f5935d
 Directory: ros/jazzy/ubuntu/noble/ros-core
 
 Tags: jazzy-ros-base, jazzy-ros-base-noble, jazzy, latest
@@ -53,7 +53,7 @@ Directory: ros/jazzy/ubuntu/noble/perception
 
 Tags: kilted-ros-core, kilted-ros-core-noble
 Architectures: amd64, arm64v8
-GitCommit: eb5634cf92ba079897e44fb7541d3b78aa6cf717
+GitCommit: fd0c0c943e25f48fe199593597ea21d3f3f5935d
 Directory: ros/kilted/ubuntu/noble/ros-core
 
 Tags: kilted-ros-base, kilted-ros-base-noble, kilted
@@ -97,7 +97,7 @@ Directory: ros/lyrical/ubuntu/resolute/perception
 
 Tags: rolling-ros-core, rolling-ros-core-noble
 Architectures: amd64, arm64v8
-GitCommit: 8cf2903c0f8813aacd3042c71d4d2d56d5068ad5
+GitCommit: fd0c0c943e25f48fe199593597ea21d3f3f5935d
 Directory: ros/rolling/ubuntu/noble/ros-core
 
 Tags: rolling-ros-base, rolling-ros-base-noble, rolling


### PR DESCRIPTION
Rolling images currently fail to build. Rolling is now targetting resolute but all packages are not available on main yet.

This PR disables rolling image generation and CI for now.

Follow-up is tracked here: https://github.com/osrf/docker_images/issues/878

This also regenerates the docker library to update commit hashes