### PR TITLE
Fail early on deb download failure and use binary mode for sha check

### DIFF
--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -9,7 +9,7 @@ ros_buildfarm
 
 ###### Requirements with Repo Specifiers ######
 #   See https://pip.readthedocs.io/en/stable/reference/pip_install/#git
-git+https://github.com/osrf/docker_templates.git@master#egg=docker_templates
+git+https://github.com/osrf/docker_templates.git@tianons_feedback#egg=docker_templates
 
 ###### Requirements with Version Specifiers ######
 #   See https://www.python.org/dev/peps/pep-0440/#version-specifiers

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -9,7 +9,7 @@ ros_buildfarm
 
 ###### Requirements with Repo Specifiers ######
 #   See https://pip.readthedocs.io/en/stable/reference/pip_install/#git
-git+https://github.com/osrf/docker_templates.git@tianons_feedback#egg=docker_templates
+git+https://github.com/osrf/docker_templates.git@master#egg=docker_templates
 
 ###### Requirements with Version Specifiers ######
 #   See https://www.python.org/dev/peps/pep-0440/#version-specifiers

--- a/ros/humble/ubuntu/jammy/ros-core/Dockerfile
+++ b/ros/humble/ubuntu/jammy/ros-core/Dockerfile
@@ -19,8 +19,8 @@ RUN apt-get update && apt-get install -q -y --no-install-recommends \
 
 
 # Setup ROS Apt sources
-RUN curl -L -s -o /tmp/ros2-apt-source.deb https://github.com/ros-infrastructure/ros-apt-source/releases/download/1.2.0/ros2-apt-source_1.2.0.jammy_all.deb \
-    && echo "767884cf4ed03116b9d64438930a832ed854147ae435279a7924dfdf60f94433 /tmp/ros2-apt-source.deb" | sha256sum --strict --check \
+RUN curl -L -s -f -o /tmp/ros2-apt-source.deb https://github.com/ros-infrastructure/ros-apt-source/releases/download/1.2.0/ros2-apt-source_1.2.0.jammy_all.deb \
+    && echo "767884cf4ed03116b9d64438930a832ed854147ae435279a7924dfdf60f94433 */tmp/ros2-apt-source.deb" | sha256sum --strict --check \
     && apt-get update \
     && apt-get install /tmp/ros2-apt-source.deb \
     && rm -f /tmp/ros2-apt-source.deb \

--- a/ros/jazzy/ubuntu/noble/ros-core/Dockerfile
+++ b/ros/jazzy/ubuntu/noble/ros-core/Dockerfile
@@ -19,8 +19,8 @@ RUN apt-get update && apt-get install -q -y --no-install-recommends \
 
 
 # Setup ROS Apt sources
-RUN curl -L -s -o /tmp/ros2-apt-source.deb https://github.com/ros-infrastructure/ros-apt-source/releases/download/1.2.0/ros2-apt-source_1.2.0.noble_all.deb \
-    && echo "0804d9b13db770eb87019be414cd78378835228ad5fa801fc88758596dd8f7e5 /tmp/ros2-apt-source.deb" | sha256sum --strict --check \
+RUN curl -L -s -f -o /tmp/ros2-apt-source.deb https://github.com/ros-infrastructure/ros-apt-source/releases/download/1.2.0/ros2-apt-source_1.2.0.noble_all.deb \
+    && echo "0804d9b13db770eb87019be414cd78378835228ad5fa801fc88758596dd8f7e5 */tmp/ros2-apt-source.deb" | sha256sum --strict --check \
     && apt-get update \
     && apt-get install /tmp/ros2-apt-source.deb \
     && rm -f /tmp/ros2-apt-source.deb \

--- a/ros/kilted/ubuntu/noble/ros-core/Dockerfile
+++ b/ros/kilted/ubuntu/noble/ros-core/Dockerfile
@@ -19,8 +19,8 @@ RUN apt-get update && apt-get install -q -y --no-install-recommends \
 
 
 # Setup ROS Apt sources
-RUN curl -L -s -o /tmp/ros2-apt-source.deb https://github.com/ros-infrastructure/ros-apt-source/releases/download/1.2.0/ros2-apt-source_1.2.0.noble_all.deb \
-    && echo "0804d9b13db770eb87019be414cd78378835228ad5fa801fc88758596dd8f7e5 /tmp/ros2-apt-source.deb" | sha256sum --strict --check \
+RUN curl -L -s -f -o /tmp/ros2-apt-source.deb https://github.com/ros-infrastructure/ros-apt-source/releases/download/1.2.0/ros2-apt-source_1.2.0.noble_all.deb \
+    && echo "0804d9b13db770eb87019be414cd78378835228ad5fa801fc88758596dd8f7e5 */tmp/ros2-apt-source.deb" | sha256sum --strict --check \
     && apt-get update \
     && apt-get install /tmp/ros2-apt-source.deb \
     && rm -f /tmp/ros2-apt-source.deb \

--- a/ros/ros
+++ b/ros/ros
@@ -9,7 +9,7 @@ GitRepo: https://github.com/osrf/docker_images.git
 
 Tags: humble-ros-core, humble-ros-core-jammy
 Architectures: amd64, arm64v8
-GitCommit: 6baec8a7ddecbfeb424ab8e9f8f81a5bce82ba4d
+GitCommit: 58af41813ba67f611943c35c551387d652fcdbde
 Directory: ros/humble/ubuntu/jammy/ros-core
 
 Tags: humble-ros-base, humble-ros-base-jammy, humble
@@ -31,7 +31,7 @@ Directory: ros/humble/ubuntu/jammy/perception
 
 Tags: jazzy-ros-core, jazzy-ros-core-noble
 Architectures: amd64, arm64v8
-GitCommit: fd0c0c943e25f48fe199593597ea21d3f3f5935d
+GitCommit: 58af41813ba67f611943c35c551387d652fcdbde
 Directory: ros/jazzy/ubuntu/noble/ros-core
 
 Tags: jazzy-ros-base, jazzy-ros-base-noble, jazzy, latest
@@ -53,7 +53,7 @@ Directory: ros/jazzy/ubuntu/noble/perception
 
 Tags: kilted-ros-core, kilted-ros-core-noble
 Architectures: amd64, arm64v8
-GitCommit: fd0c0c943e25f48fe199593597ea21d3f3f5935d
+GitCommit: 58af41813ba67f611943c35c551387d652fcdbde
 Directory: ros/kilted/ubuntu/noble/ros-core
 
 Tags: kilted-ros-base, kilted-ros-base-noble, kilted


### PR DESCRIPTION
Based on @tianon feedback from https://github.com/docker-library/official-images/pull/21417#pullrequestreview-4255672560

Note to self: revert https://github.com/osrf/docker_images/commit/0b9b30eedc03500533502d178697bf6889ef2e3e once approved and matching template branch approved