### PR TITLE
Make Lyrical target main apt repo and promote to latest

### DIFF
--- a/.github/workflows/ros_ci.yaml
+++ b/.github/workflows/ros_ci.yaml
@@ -7,6 +7,7 @@ on:
     - '.ci/**'
     - '.github/workflows/ros_ci.yaml'
     # - 'ros/rolling/**'
+    - 'ros/lyrical/**'
     - 'ros/kilted/**'
     - 'ros/jazzy/**'
     - 'ros/humble/**'
@@ -15,6 +16,7 @@ on:
     - '.ci/**'
     - '.github/workflows/ros_ci.yaml'
     # - 'ros/rolling/**'
+    - 'ros/lyrical/**'
     - 'ros/kilted/**'
     - 'ros/jazzy/**'
     - 'ros/humble/**'
@@ -28,6 +30,7 @@ jobs:
       matrix:
         env:
           # - {HUB_REPO: ros, HUB_RELEASE: rolling, HUB_OS_NAME: ubuntu, HUB_OS_CODE_NAME: noble}
+          - {HUB_REPO: ros, HUB_RELEASE: lyrical, HUB_OS_NAME: ubuntu, HUB_OS_CODE_NAME: resolute}
           - {HUB_REPO: ros, HUB_RELEASE: kilted, HUB_OS_NAME: ubuntu, HUB_OS_CODE_NAME: noble}
           - {HUB_REPO: ros, HUB_RELEASE: jazzy, HUB_OS_NAME: ubuntu, HUB_OS_CODE_NAME: noble}
           - {HUB_REPO: ros, HUB_RELEASE: humble, HUB_OS_NAME: ubuntu, HUB_OS_CODE_NAME: jammy}

--- a/ros/lyrical/ubuntu/resolute/platform.yaml
+++ b/ros/lyrical/ubuntu/resolute/platform.yaml
@@ -7,7 +7,6 @@ platform:
     ros2distro_name: lyrical
     user_name: ros
     maintainer_name:
-    testing_repo: true
     arch: amd64
     type: distribution
     version:

--- a/ros/lyrical/ubuntu/resolute/ros-core/Dockerfile
+++ b/ros/lyrical/ubuntu/resolute/ros-core/Dockerfile
@@ -19,11 +19,11 @@ RUN apt-get update && apt-get install -q -y --no-install-recommends \
 
 
 # Setup ROS Apt sources
-RUN curl -L -s -o /tmp/ros2-testing-apt-source.deb https://github.com/ros-infrastructure/ros-apt-source/releases/download/1.2.0/ros2-testing-apt-source_1.2.0.resolute_all.deb \
-    && echo "da9261ca7c06244da1528e0ede44018f7bb2e24a8a077eb0202f70706b578546 /tmp/ros2-testing-apt-source.deb" | sha256sum --strict --check \
+RUN curl -L -s -f -o /tmp/ros2-apt-source.deb https://github.com/ros-infrastructure/ros-apt-source/releases/download/1.2.0/ros2-apt-source_1.2.0.resolute_all.deb \
+    && echo "a275b9b819874e745a928e83e39c429fa4d607159285c4ef3ebcf75afa732ee3 */tmp/ros2-apt-source.deb" | sha256sum --strict --check \
     && apt-get update \
-    && apt-get install /tmp/ros2-testing-apt-source.deb \
-    && rm -f /tmp/ros2-testing-apt-source.deb \
+    && apt-get install /tmp/ros2-apt-source.deb \
+    && rm -f /tmp/ros2-apt-source.deb \
     && rm -rf /var/lib/apt/lists/*
 
 # setup environment

--- a/ros/manifest.yaml
+++ b/ros/manifest.yaml
@@ -619,7 +619,6 @@ release_names:
                                     - "$release_name-ros-base"
                                     - "$release_name-ros-base-$os_code_name"
                                     - "$release_name"
-                                    - latest
                             perception:
                                 aliases:
                                     - "$release_name-perception"
@@ -668,6 +667,7 @@ release_names:
                                     - "$release_name-ros-base"
                                     - "$release_name-ros-base-$os_code_name"
                                     - "$release_name"
+                                    - latest
                             perception:
                                 aliases:
                                     - "$release_name-perception"

--- a/ros/ros
+++ b/ros/ros
@@ -34,7 +34,7 @@ Architectures: amd64, arm64v8
 GitCommit: 58af41813ba67f611943c35c551387d652fcdbde
 Directory: ros/jazzy/ubuntu/noble/ros-core
 
-Tags: jazzy-ros-base, jazzy-ros-base-noble, jazzy, latest
+Tags: jazzy-ros-base, jazzy-ros-base-noble, jazzy
 Architectures: amd64, arm64v8
 GitCommit: 0038f1c3a11aa0fc573d698b39ab5c204aad5a40
 Directory: ros/jazzy/ubuntu/noble/ros-base
@@ -75,10 +75,10 @@ Directory: ros/kilted/ubuntu/noble/perception
 
 Tags: lyrical-ros-core, lyrical-ros-core-resolute
 Architectures: amd64, arm64v8
-GitCommit: 0d65786f3d9bb10d55dc28ccd5b87da204240d1a
+GitCommit: 54c9478ffafa47e2e65a90a20ebd5412009a35b0
 Directory: ros/lyrical/ubuntu/resolute/ros-core
 
-Tags: lyrical-ros-base, lyrical-ros-base-resolute, lyrical
+Tags: lyrical-ros-base, lyrical-ros-base-resolute, lyrical, latest
 Architectures: amd64, arm64v8
 GitCommit: 0d65786f3d9bb10d55dc28ccd5b87da204240d1a
 Directory: ros/lyrical/ubuntu/resolute/ros-base


### PR DESCRIPTION
ROS Lyrical is officially released: https://discourse.openrobotics.org/t/ros-2-lyrical-luth-released/55021

This PR migrates the latest tag of ROS Docker images to Lyrical